### PR TITLE
Travis: Test linux and osx builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,26 @@
-language: python
+os:
+  - linux
+  - osx
+
+# language: python
+language: c
+
 python:
     - "2.7"
 
 sudo: false
 
+addons:
+  apt:
+    packages:
+        - python-dev
+        - python-pip
+
 install:
-  - pip install --upgrade pip
-  - pip install -r requirements.txt
+  - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then brew update; brew install python; brew link --overwrite python ; fi
+  - pip install --user -U pip
+  - pip install --user -r requirements.txt
+  - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then export PATH=$PATH:$HOME/Library/Python/2.7/bin; fi
 
 script:
   - export PYTHONPATH=$PYTHONPATH:$PWD


### PR DESCRIPTION
Currently requires explicit setup of the python env via homebrew and apt.