### PR TITLE
Cache blocking Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,20 @@ op = Operator(..., compiler=IntelCompiler)
 
 Thread parallel execution via OpenMP can also be enabled by setting
 `DEVITO_OPENMP=1`.
+
+## Cache Blocking
+
+Devito supports loop cache blocking, which increases the effectiveness
+of memory by reusing the data in the cache. To enable this feature
+set `cache_blocking` flag to `True` in `Operator`. Furthermore you can
+specify the block sizes using `block_size` parameter. It can be a single
+number which will be used for all dimensions or a list explicitly stating
+block sizes for each dim(x,y,z).
+
+Note, by default inner most dimension is not blocked, if you want to
+disable this set `cb_inner_dim` flag to `True`
+Example usage:
+```
+op = Operator(..., cache_blocking=True, block_size=[5, 10, 5], cb_inner_dim=False)
+```
+ 

--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ number which will be used for all dimensions or a list explicitly stating
 block sizes for each dim(x,y,z).
 
 Note, by default inner most dimension is not blocked, if you want to
-disable this set `cb_inner_dim` flag to `True`
+disable this set `cb_inner_dim` flag to `True`.
 Example usage:
 ```
-op = Operator(..., cache_blocking=True, block_size=[5, 10, 5], cb_inner_dim=False)
+op = Operator(..., cache_blocking=True, block_size=[5, 10, 5], cb_inner_dim=True)
 ```
  

--- a/README.md
+++ b/README.md
@@ -64,12 +64,15 @@ of memory by reusing the data in the cache. To enable this feature
 set `cache_blocking` flag to `True` in `Operator`. Furthermore you can
 specify the block sizes using `block_size` parameter. It can be a single
 number which will be used for all dimensions or a list explicitly stating
-block sizes for each dim(x,y,z).
+block sizes for each dim(x,y,z). If you do not want to block some dimensions, 
+set `block_size` to `None` respectively.
 
-Note, by default inner most dimension is not blocked, if you want to
-disable this set `cb_inner_dim` flag to `True`.
+Note
+ If `block_size` is set to `None` or list of `None`'s
+ cache blocking will be turned off.
+ 
 Example usage:
 ```
-op = Operator(..., cache_blocking=True, block_size=[5, 10, 5], cb_inner_dim=True)
+op = Operator(..., cache_blocking=True, block_size=[5, 10, None])
 ```
  

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -84,7 +84,8 @@ class Operator(object):
                      environment variable DEVITO_ARCH, or default to GNUCompiler.
     :param profile: Flag to enable performance profiling
     :param cache_blocking: Flag to enable cache blocking
-    :param block_size: Block size used for cache clocking
+    :param block_size: Block size used for cache clocking. Can be either a single number used for all dimensions or
+                      a list stating block sizes for each dimension. Set block size to None to skip blocking on that dim
     :param input_params: List of symbols that are expected as input.
     :param output_params: List of symbols that define operator output.
     :param factorized: A map given by {string_name:sympy_object} for including factorized terms

--- a/devito/propagator.py
+++ b/devito/propagator.py
@@ -357,8 +357,8 @@ class Propagator(object):
         orig_loop_body = loop_body
 
         for spc_var, block_size in reversed(zip(list(self.space_dims), self.block_sizes)):
-            dim_var = str(self._var_map[spc_var])
-            block_var = dim_var + "b"
+            orig_var = str(self._var_map[spc_var])
+            block_var = orig_var + "b"
             loop_limits = self._space_loop_limits[spc_var]
 
             if block_size is not None:
@@ -368,43 +368,55 @@ class Propagator(object):
                 lower_limit_str = str(loop_limits[0])
                 upper_limit_str = str(loop_limits[1])
 
-            loop_body = cgen.For(cgen.InlineInitializer(cgen.Value("int", dim_var), lower_limit_str),
-                                 dim_var + "<" + upper_limit_str, dim_var + "++", loop_body)
+            loop_body = cgen.For(cgen.InlineInitializer(cgen.Value("int", orig_var), lower_limit_str),
+                                 orig_var + "<" + upper_limit_str, orig_var + "++", loop_body)
 
             if inner_most_dim and len(self.space_dims) > 1:
                 loop_body = cgen.Block([self.compiler.pragma_ivdep] + [loop_body])
             inner_most_dim = False
 
-        remainder_list = []  # List indicating how many remainder loops we need.
+        remainder_counter = 0  # indicates how many remainder loops we need
         for spc_var, block_size in reversed(zip(list(self.space_dims), self.block_sizes)):
             # if block size set to None do not block this dimension
             if block_size is not None:
                 orig_var = str(self._var_map[spc_var])
-                dim_var = orig_var + "b"
+                block_var = orig_var + "b"
                 loop_limits = self._space_loop_limits[spc_var]
                 old_upper_limit = loop_limits[1]                  # sets new upper limit
                 loop_limits = (loop_limits[0], loop_limits[1] - (loop_limits[1] - loop_limits[0]) % block_size)
 
-                if old_upper_limit - loop_limits[1] > 0:  # check old vs new upper limit
-                    remainder_list.append(orig_var)
+                if old_upper_limit - loop_limits[1] > 0:  # check old vs new upper
+                    remainder_counter += 1
 
-                loop_body = cgen.For(cgen.InlineInitializer(cgen.Value("int", dim_var), str(loop_limits[0])),
-                                     str(dim_var) + "<" + str(loop_limits[1]), str(dim_var) + "+=" + str(block_size), loop_body)
+                loop_body = cgen.For(cgen.InlineInitializer(cgen.Value("int", block_var), str(loop_limits[0])),
+                                     str(block_var) + "<" + str(loop_limits[1]), str(block_var) + "+=" + str(block_size), loop_body)
 
         full_remainder = []
-        for blocked_dimension in remainder_list:
+        weights = self._decide_weights(self.block_sizes, remainder_counter)  # weights for deciding remainder loop limit
+        for i in range(0, remainder_counter):
             remainder_loop = orig_loop_body
             inner_most_dim = True
 
             for spc_var, block_size in reversed(zip(list(self.space_dims), self.block_sizes)):
-                dim_var = str(self._var_map[spc_var])
-                loop_limits = self._space_loop_limits[spc_var]
+                orig_var = str(self._var_map[spc_var])
+                loop_limits = self._space_loop_limits[spc_var]  # Full loop limits
 
-                if block_size is not None and dim_var == blocked_dimension:
-                    loop_limits = (loop_limits[1] - (loop_limits[1] - loop_limits[0]) % block_size, loop_limits[1])
+                if block_size is not None:
+                    if weights[orig_var] < 0:
+                        # already blocked loop limits
+                        loop_limits = (loop_limits[0], loop_limits[1] - (loop_limits[1] - loop_limits[0]) % block_size)
+                    elif weights[orig_var] == 0:
+                        # remainder loop limits
+                        loop_limits = (loop_limits[1] - (loop_limits[1] - loop_limits[0]) % block_size, loop_limits[1])
 
-                remainder_loop = cgen.For(cgen.InlineInitializer(cgen.Value("int", dim_var), str(loop_limits[0])),
-                                          str(dim_var) + "<" + str(loop_limits[1]), str(dim_var) + "++", remainder_loop)
+                    weights[orig_var] += 1
+
+                    # If loop limits are equal that means no remainder on that dim, thus we want all iteration space
+                    if loop_limits[0] == loop_limits[1]:
+                        loop_limits = self._space_loop_limits[spc_var]
+
+                remainder_loop = cgen.For(cgen.InlineInitializer(cgen.Value("int", orig_var), str(loop_limits[0])),
+                                          str(orig_var) + "<" + str(loop_limits[1]), str(orig_var) + "++", remainder_loop)
 
                 if inner_most_dim and len(self.space_dims) > 1:
                     remainder_loop = cgen.Block([self.compiler.pragma_ivdep] + [remainder_loop])
@@ -413,6 +425,30 @@ class Propagator(object):
             full_remainder.append(remainder_loop)
 
         return [loop_body] + full_remainder if full_remainder else [loop_body]
+
+    def _decide_weights(self, block_sizes, remainder_counter):
+        """
+        Decided weights which are used for remainder loop limit calculations
+        :param block_sizes: list of block sizes
+        :param remainder_counter: int stating how many remainder loops are needed
+        :return: dict of weights
+        """
+        weights = {'i3': 0, 'i2': 0, 'i1': 0}
+        if len(block_sizes) == 3 and remainder_counter > 1:
+            if block_sizes[0] and block_sizes[1] and block_sizes[2]:
+                weights.update({'i1': -1})
+                if remainder_counter == 3:
+                    weights.update({'i2': -2})
+            elif (block_sizes[0] and block_sizes[1] and not block_sizes[2]) or\
+                 (not block_sizes[0] and block_sizes[1] and block_sizes[2]):
+                weights.update({'i2': -1})
+            else:
+                weights.update({'i1': -1})
+
+        elif len(block_sizes) == 2 and block_sizes[0] and block_sizes[1] and remainder_counter > 1:
+            weights.update({'i1': -1})
+
+        return weights
 
     def add_loop_step(self, assign, before=False):
         """Add loop step to loop body"""

--- a/devito/propagator.py
+++ b/devito/propagator.py
@@ -98,7 +98,8 @@ class Propagator(object):
             if len(block_size) == len(shape):
                 self.block_sizes = block_size
             else:
-                raise ValueError("Block size should either be a single number or an array of the same size as the spatial domain")
+                raise ValueError("Block size should either be a single number or" +
+                                 " an array of the same size as the spatial domain")
         elif block_size is None:  # Turn off cache blocking if block size set to None
             self.cache_blocking = False
         else:
@@ -389,7 +390,8 @@ class Propagator(object):
                     remainder_counter += 1
 
                 loop_body = cgen.For(cgen.InlineInitializer(cgen.Value("int", block_var), str(loop_limits[0])),
-                                     str(block_var) + "<" + str(loop_limits[1]), str(block_var) + "+=" + str(block_size), loop_body)
+                                     str(block_var) + "<" + str(loop_limits[1]), str(block_var) + "+=" +
+                                     str(block_size), loop_body)
 
         full_remainder = []
         weights = self._decide_weights(self.block_sizes, remainder_counter)  # weights for deciding remainder loop limit
@@ -416,7 +418,8 @@ class Propagator(object):
                         loop_limits = self._space_loop_limits[spc_var]
 
                 remainder_loop = cgen.For(cgen.InlineInitializer(cgen.Value("int", orig_var), str(loop_limits[0])),
-                                          str(orig_var) + "<" + str(loop_limits[1]), str(orig_var) + "++", remainder_loop)
+                                          str(orig_var) + "<" + str(loop_limits[1]), str(orig_var) + "++",
+                                          remainder_loop)
 
                 if inner_most_dim and len(self.space_dims) > 1:
                     remainder_loop = cgen.Block([self.compiler.pragma_ivdep] + [remainder_loop])

--- a/devito/propagator.py
+++ b/devito/propagator.py
@@ -384,7 +384,7 @@ class Propagator(object):
                 dim_var = orig_var + "b"
                 loop_limits = self._space_loop_limits[spc_var]
                 old_upper_limit = loop_limits[1]                  # sets new upper limit
-                loop_limits = (loop_limits[0], loop_limits[1] - loop_limits[1] % block_size)
+                loop_limits = (loop_limits[0], loop_limits[1] - (loop_limits[1]-loop_limits[0]) % block_size)
 
                 if old_upper_limit - loop_limits[1] > 0:  # check old vs new upper limit
                     remainder = True
@@ -402,7 +402,7 @@ class Propagator(object):
                 loop_limits = self._space_loop_limits[spc_var]
 
                 if not ivdep or self.cache_block_inner:  # Does not block inner most dim if cache_block_inne flag is set
-                    loop_limits = (loop_limits[1] - loop_limits[1] % block_size, loop_limits[1])
+                    loop_limits = (loop_limits[1] - (loop_limits[1]-loop_limits[0]) % block_size, loop_limits[1])
 
                 remainder_loop = cgen.For(cgen.InlineInitializer(cgen.Value("int", dim_var), str(loop_limits[0])),
                                           str(dim_var) + "<" + str(loop_limits[1]), str(dim_var) + "++", remainder_loop)

--- a/devito/propagator.py
+++ b/devito/propagator.py
@@ -93,7 +93,6 @@ class Propagator(object):
 
         # Cache blocking and default block sizes
         self.cache_blocking = cache_blocking
-
         if(isinstance(block_size, Iterable)):
             if(len(block_size) == len(shape)):
                 self.block_sizes = block_size

--- a/tests/test_cache_blocking.py
+++ b/tests/test_cache_blocking.py
@@ -1,54 +1,29 @@
 from devito.interfaces import DenseData
 import numpy as np
+import pytest
 from sympy import symbols, Eq
 from devito.operator import SimpleOperator
 
 
 class Test_Cache_Blocking(object):
-    def test_cache_blocking_no_remainder(self):
-        input_grid = DenseData(name="input_grid", shape=(300, 300), dtype=np.float64)
-        input_grid.data[:] = np.arange(90000, dtype=np.float64).reshape((300, 300))
-        output_grid_noblock = DenseData(name="output_grid", shape=(300, 300), dtype=np.float64)
-        x, t = symbols("x t")
-        eq = Eq(output_grid_noblock.indexed[t, x], input_grid.indexed[t, x] + 3)
-        op_noblock = SimpleOperator(input_grid, output_grid_noblock, [eq])
-        op_noblock.apply()
-        output_grid_block = DenseData(name="output_grid", shape=(300, 300), dtype=np.float64)
-        op_block = SimpleOperator(input_grid, output_grid_block, [eq], cache_blocking=True)
-        op_block.apply()
-        assert(np.equal(output_grid_block.data, output_grid_noblock.data).all())
 
-    def test_cache_blocking_remainder(self):
+    # Full range testing
+    @pytest.mark.parametrize("time_order", [2])
+    @pytest.mark.parametrize("spc_border", [0, 1, 2, 3, 4, 5, 6, 7, 8])
+    @pytest.mark.parametrize("block_size", [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
+    @pytest.mark.parametrize("cb_inner_dim", [False, True])
+    def test_cache_blocking_full_range(self, time_order, spc_border, block_size, cb_inner_dim):
         input_grid = DenseData(name="input_grid", shape=(302, 302), dtype=np.float64)
         input_grid.data[:] = np.arange(91204, dtype=np.float64).reshape((302, 302))
+        x, t = symbols("x t")
+
         output_grid_noblock = DenseData(name="output_grid", shape=(302, 302), dtype=np.float64)
-        x, t = symbols("x t")
         eq = Eq(output_grid_noblock.indexed[t, x], input_grid.indexed[t, x] + 3)
-        op_noblock = SimpleOperator(input_grid, output_grid_noblock, [eq])
+        op_noblock = SimpleOperator(input_grid, output_grid_noblock, [eq], time_order=time_order, spc_border=spc_border)
         op_noblock.apply()
+
         output_grid_block = DenseData(name="output_grid", shape=(302, 302), dtype=np.float64)
-        op_block = SimpleOperator(input_grid, output_grid_block, [eq], cache_blocking=True)
+        op_block = SimpleOperator(input_grid, output_grid_block, [eq], cache_blocking=True, cb_inner_dim=cb_inner_dim,
+                                  block_size=block_size, time_order=time_order, spc_border=spc_border)
         op_block.apply()
-        assert(np.equal(output_grid_block.data, output_grid_noblock.data).all())
-
-    def test_cache_blocking_full_range(self):
-        input_grid = DenseData(name="input_grid", shape=(302, 302), dtype=np.float64)
-        input_grid.data[:] = np.arange(91204, dtype=np.float64).reshape((302, 302))
-        x, t = symbols("x t")
-
-        errors = []
-        for spc_border in range(0, 9):
-            for block_size in range(1, 11):
-
-                output_grid_noblock = DenseData(name="output_grid", shape=(302, 302), dtype=np.float64)
-                eq = Eq(output_grid_noblock.indexed[t, x], input_grid.indexed[t, x] + 3)
-                op_noblock = SimpleOperator(input_grid, output_grid_noblock, [eq], time_order=2, spc_border=spc_border)
-                op_noblock.apply()
-
-                output_grid_block = DenseData(name="output_grid", shape=(302, 302), dtype=np.float64)
-                op_block = SimpleOperator(input_grid, output_grid_block, [eq], cache_blocking=True,
-                                          block_size=block_size, time_order=2, spc_border=spc_border)
-                op_block.apply()
-                if not (np.equal(output_grid_block.data, output_grid_noblock.data).all()):
-                    errors.append("Error at spc_order = %d with block_size = %d" % (spc_border * 2, block_size))
-        assert not errors, errors
+        assert np.equal(output_grid_block.data, output_grid_noblock.data).all()

--- a/tests/test_cache_blocking.py
+++ b/tests/test_cache_blocking.py
@@ -31,3 +31,16 @@ class Test_Cache_Blocking(object):
         op_block = SimpleOperator(input_grid, output_grid_block, [eq], cache_blocking=True)
         op_block.apply()
         assert(np.equal(output_grid_block.data, output_grid_noblock.data).all())
+
+    def test_cache_blocking_remainder(self):
+        input_grid = DenseData(name="input_grid", shape=(302, 302), dtype=np.float64)
+        input_grid.data[:] = np.arange(91204, dtype=np.float64).reshape((302, 302))
+        output_grid_noblock = DenseData(name="output_grid", shape=(302, 302), dtype=np.float64)
+        x, t = symbols("x t")
+        eq = Eq(output_grid_noblock.indexed[t, x], input_grid.indexed[t, x] + 3)
+        op_noblock = SimpleOperator(input_grid, output_grid_noblock, [eq])
+        op_noblock.apply()
+        output_grid_block = DenseData(name="output_grid", shape=(302, 302), dtype=np.float64)
+        op_block = SimpleOperator(input_grid, output_grid_block, [eq], cache_blocking=True, cb_inner_dim=True)
+        op_block.apply()
+        assert (np.equal(output_grid_block.data, output_grid_noblock.data).all())

--- a/tests/test_cache_blocking.py
+++ b/tests/test_cache_blocking.py
@@ -32,7 +32,7 @@ class Test_Cache_Blocking(object):
         op_block.apply()
         assert(np.equal(output_grid_block.data, output_grid_noblock.data).all())
 
-    def test_cache_blocking_remainder(self):
+    def test_cache_blocking_cb_inner_dim(self):
         input_grid = DenseData(name="input_grid", shape=(302, 302), dtype=np.float64)
         input_grid.data[:] = np.arange(91204, dtype=np.float64).reshape((302, 302))
         output_grid_noblock = DenseData(name="output_grid", shape=(302, 302), dtype=np.float64)

--- a/tests/test_cache_blocking.py
+++ b/tests/test_cache_blocking.py
@@ -8,26 +8,28 @@ from devito.operator import SimpleOperator
 class Test_Cache_Blocking(object):
 
     # Full range testing.            This syntax tests all possible permutations of parameters
-    @pytest.mark.parametrize("shape", [(31, 45), (45, 30, 45), (31, 31, 31, 31)])
+    @pytest.mark.parametrize("shape", [(10, 45), (10, 31, 45), (10, 45, 31, 45)])
     @pytest.mark.parametrize("time_order", [2])
     @pytest.mark.parametrize("spc_border", [0, 1, 2, 3, 4, 5, 6, 7, 8])
-    @pytest.mark.parametrize("block_size", [2, 3, 4, 5, 6, 7, 8, 9, 10])
+    @pytest.mark.parametrize("block_size", [2, 3, 4, 5, 6, 7, 8])
     def test_cache_blocking_full_range(self, shape, time_order, spc_border, block_size):
         self.cache_blocking_test(shape, time_order, spc_border, block_size)
 
     # Edge cases. Different block sizes, etc
     @pytest.mark.parametrize("shape,time_order,spc_border,block_size", [
-        ((25, 25, 25, 46), 2, 3, [None, None, None]),
-        ((25, 25, 25, 46), 2, 3, [7, None, None]),
-        ((25, 25, 25, 46), 2, 3, [None, None, 7]),
-        ((25, 25, 25, 46), 2, 3, [None, 7, None]),
-        ((25, 25, 25, 46), 2, 3, [5, None, 7]),
-        ((25, 25, 25, 46), 2, 3, [10, 3, None]),
-        ((25, 25, 25, 46), 2, 3, [None, 7, 11]),
-        ((25, 25, 25, 46), 2, 3, [4, 8, 2]),
-        ((25, 25, 25, 46), 2, 3, [1, 1, 1]),
-        ((25, 25, 46), 2, 3, [None, 7]),
-        ((25, 25, 46), 2, 3, [7, None])
+        ((10, 25, 25, 46), 2, 3, [None, None, None]),
+        ((10, 25, 25, 46), 2, 3, [7, None, None]),
+        ((10, 25, 25, 46), 2, 3, [None, None, 7]),
+        ((10, 25, 25, 46), 2, 3, [None, 7, None]),
+        ((10, 25, 25, 46), 2, 3, [5, None, 7]),
+        ((10, 25, 25, 46), 2, 3, [10, 3, None]),
+        ((10, 25, 25, 46), 2, 3, [None, 7, 11]),
+        ((10, 25, 25, 46), 2, 3, [8, 2, 4]),
+        ((10, 25, 25, 46), 2, 3, [2, 4, 8]),
+        ((10, 25, 25, 46), 2, 3, [4, 8, 2]),
+        ((10, 25, 46), 2, 3, [None, 7]),
+        ((10, 25, 46), 2, 3, [7, None]),
+        ((10, 25, 46), 2, 3, None)
     ])
     def test_cache_blocking_edge_cases(self, shape, time_order, spc_border, block_size):
         self.cache_blocking_test(shape, time_order, spc_border, block_size)
@@ -44,12 +46,16 @@ class Test_Cache_Blocking(object):
         input_grid.data[:] = np.arange(size, dtype=np.float64).reshape(shape)
 
         output_grid_noblock = DenseData(name="output_grid", shape=shape, dtype=np.float64)
-        eq = Eq(output_grid_noblock.indexed[indexes], input_grid.indexed[indexes] + 3)
-        op_noblock = SimpleOperator(input_grid, output_grid_noblock, [eq], time_order=time_order, spc_border=spc_border)
+        eq_noblock = Eq(output_grid_noblock.indexed[indexes],
+                        output_grid_noblock.indexed[indexes] + input_grid.indexed[indexes] + 3)
+        op_noblock = SimpleOperator(input_grid, output_grid_noblock, [eq_noblock],
+                                    time_order=time_order, spc_border=spc_border)
         op_noblock.apply()
 
         output_grid_block = DenseData(name="output_grid", shape=shape, dtype=np.float64)
-        op_block = SimpleOperator(input_grid, output_grid_block, [eq], cache_blocking=True,
+        eq_block = Eq(output_grid_block.indexed[indexes],
+                      output_grid_block.indexed[indexes] + input_grid.indexed[indexes] + 3)
+        op_block = SimpleOperator(input_grid, output_grid_block, [eq_block], cache_blocking=True,
                                   block_size=block_size, time_order=time_order, spc_border=spc_border)
         op_block.apply()
         assert np.equal(output_grid_block.data, output_grid_noblock.data).all()

--- a/tests/test_cache_blocking.py
+++ b/tests/test_cache_blocking.py
@@ -10,9 +10,8 @@ class Test_Cache_Blocking(object):
     # Full range testing
     @pytest.mark.parametrize("time_order", [2])
     @pytest.mark.parametrize("spc_border", [0, 1, 2, 3, 4, 5, 6, 7, 8])
-    @pytest.mark.parametrize("block_size", [1, 2, 3, 4, 5, 6, 7, 8, 9, 10])
-    @pytest.mark.parametrize("cb_inner_dim", [False, True])
-    def test_cache_blocking_full_range(self, time_order, spc_border, block_size, cb_inner_dim):
+    @pytest.mark.parametrize("block_size", [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, None, [10], [None]])
+    def test_cache_blocking_full_range(self, time_order, spc_border, block_size):
         input_grid = DenseData(name="input_grid", shape=(302, 302), dtype=np.float64)
         input_grid.data[:] = np.arange(91204, dtype=np.float64).reshape((302, 302))
         x, t = symbols("x t")
@@ -23,7 +22,7 @@ class Test_Cache_Blocking(object):
         op_noblock.apply()
 
         output_grid_block = DenseData(name="output_grid", shape=(302, 302), dtype=np.float64)
-        op_block = SimpleOperator(input_grid, output_grid_block, [eq], cache_blocking=True, cb_inner_dim=cb_inner_dim,
+        op_block = SimpleOperator(input_grid, output_grid_block, [eq], cache_blocking=True,
                                   block_size=block_size, time_order=time_order, spc_border=spc_border)
         op_block.apply()
         assert np.equal(output_grid_block.data, output_grid_noblock.data).all()

--- a/tests/test_cache_blocking.py
+++ b/tests/test_cache_blocking.py
@@ -1,7 +1,8 @@
-from devito.interfaces import DenseData
 import numpy as np
 import pytest
-from sympy import symbols, Eq
+from sympy import Eq, symbols
+
+from devito.interfaces import DenseData
 from devito.operator import SimpleOperator
 
 

--- a/tests/test_cache_blocking.py
+++ b/tests/test_cache_blocking.py
@@ -7,21 +7,48 @@ from devito.operator import SimpleOperator
 
 class Test_Cache_Blocking(object):
 
-    # Full range testing
+    # Full range testing.            This syntax tests all possible permutations of parameters
+    @pytest.mark.parametrize("shape", [(31, 45), (45, 30, 45), (31, 31, 31, 31)])
     @pytest.mark.parametrize("time_order", [2])
     @pytest.mark.parametrize("spc_border", [0, 1, 2, 3, 4, 5, 6, 7, 8])
-    @pytest.mark.parametrize("block_size", [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, None, [10], [None]])
-    def test_cache_blocking_full_range(self, time_order, spc_border, block_size):
-        input_grid = DenseData(name="input_grid", shape=(302, 302), dtype=np.float64)
-        input_grid.data[:] = np.arange(91204, dtype=np.float64).reshape((302, 302))
-        x, t = symbols("x t")
+    @pytest.mark.parametrize("block_size", [2, 3, 4, 5, 6, 7, 8, 9, 10])
+    def test_cache_blocking_full_range(self, shape, time_order, spc_border, block_size):
+        self.cache_blocking_test(shape, time_order, spc_border, block_size)
 
-        output_grid_noblock = DenseData(name="output_grid", shape=(302, 302), dtype=np.float64)
-        eq = Eq(output_grid_noblock.indexed[t, x], input_grid.indexed[t, x] + 3)
+    # Edge cases. Different block sizes, etc
+    @pytest.mark.parametrize("shape,time_order,spc_border,block_size", [
+        ((25, 25, 25, 46), 2, 3, [None, None, None]),
+        ((25, 25, 25, 46), 2, 3, [7, None, None]),
+        ((25, 25, 25, 46), 2, 3, [None, None, 7]),
+        ((25, 25, 25, 46), 2, 3, [None, 7, None]),
+        ((25, 25, 25, 46), 2, 3, [5, None, 7]),
+        ((25, 25, 25, 46), 2, 3, [10, 3, None]),
+        ((25, 25, 25, 46), 2, 3, [None, 7, 11]),
+        ((25, 25, 25, 46), 2, 3, [4, 8, 2]),
+        ((25, 25, 25, 46), 2, 3, [1, 1, 1]),
+        ((25, 25, 46), 2, 3, [None, 7]),
+        ((25, 25, 46), 2, 3, [7, None])
+    ])
+    def test_cache_blocking_edge_cases(self, shape, time_order, spc_border, block_size):
+        self.cache_blocking_test(shape, time_order, spc_border, block_size)
+
+    def cache_blocking_test(self, shape, time_order, spc_border, block_size):
+        symbols_combinations = ['t', 't x', 't x z', 't x y z']
+        indexes = symbols(symbols_combinations[len(shape) - 1])
+
+        size = 1
+        for element in shape:
+            size *= element
+
+        input_grid = DenseData(name="input_grid", shape=shape, dtype=np.float64)
+        input_grid.data[:] = np.arange(size, dtype=np.float64).reshape(shape)
+
+        output_grid_noblock = DenseData(name="output_grid", shape=shape, dtype=np.float64)
+        eq = Eq(output_grid_noblock.indexed[indexes], input_grid.indexed[indexes] + 3)
         op_noblock = SimpleOperator(input_grid, output_grid_noblock, [eq], time_order=time_order, spc_border=spc_border)
         op_noblock.apply()
 
-        output_grid_block = DenseData(name="output_grid", shape=(302, 302), dtype=np.float64)
+        output_grid_block = DenseData(name="output_grid", shape=shape, dtype=np.float64)
         op_block = SimpleOperator(input_grid, output_grid_block, [eq], cache_blocking=True,
                                   block_size=block_size, time_order=time_order, spc_border=spc_border)
         op_block.apply()


### PR DESCRIPTION
Allows user to specify which dimensions he does not want to block by setting block sizes to `None`.
Fixed "#pragma openmn for" bracket bug.
Fixes the cache blocking error that caused segmentation faults.
Fixes remainder loop logic. Now there will be separate remainder loop for each block. To make sure we iterate through each element.
Rewriten test_cache_blocking.py tests to cover full range of models. 
