### PR TITLE
Point interpolation via `Iteration` blocks

### DIFF
--- a/devito/__init__.py
+++ b/devito/__init__.py
@@ -2,3 +2,4 @@ from __future__ import absolute_import
 from devito.interfaces import *  # noqa
 from devito.operator import *  # noqa
 from devito.finite_difference import *  # noqa
+from devito.iteration import *  # noqa

--- a/devito/codeprinter.py
+++ b/devito/codeprinter.py
@@ -10,6 +10,11 @@ class CodePrinter(CCodePrinter):
     """
     def __init__(self, settings={}):
         CCodePrinter.__init__(self, settings)
+        custom_functions = {
+            'INT': 'int',
+            'FLOAT': 'float'
+        }
+        self.known_functions.update(custom_functions)
 
     def _print_Indexed(self, expr):
         """Print field as C style multidimensional array

--- a/devito/interfaces.py
+++ b/devito/interfaces.py
@@ -373,7 +373,8 @@ class PointData(DenseData):
     """Data object for sparse point data that acts as a Function symbol
 
     :param name: Name of the resulting :class:`sympy.Function` symbol
-    :param point: Number of points to sample
+    :param npoint: Number of points to sample
+    :param coordinates: Coordinates data for the sparse points
     :param nt: Size of the time dimension for point data
     :param dtype: Data type of the buffered data
 
@@ -391,7 +392,8 @@ class PointData(DenseData):
             self.nt = kwargs.get('nt')
             self.npoint = kwargs.get('npoint')
             kwargs['shape'] = (self.nt, self.npoint)
-            DenseData.__init__(self, *args, **kwargs)
+            super(PointData, self).__init__(self, *args, **kwargs)
+            self.coordinates = kwargs.get('coordinates')
             # Store final instance in symbol cache
             self._cache_put(self)
 

--- a/devito/interfaces.py
+++ b/devito/interfaces.py
@@ -406,6 +406,11 @@ class CoordinateData(SymbolicData):
         _indices = [p]
         return _indices
 
+    @property
+    def indexed(self):
+        """:return: Base symbol as sympy.IndexedBase"""
+        return IndexedBase(self.name, shape=self.shape)
+
 
 class PointData(DenseData):
     """Data object for sparse point data that acts as a Function symbol

--- a/devito/interfaces.py
+++ b/devito/interfaces.py
@@ -6,7 +6,7 @@ from tempfile import gettempdir
 
 import numpy as np
 from sympy import Function, IndexedBase, as_finite_diff
-from sympy.abc import h, s, t, x, y, z
+from sympy.abc import h, p, s, t, x, y, z
 
 from devito.finite_difference import cross_derivative
 from tools import aligned
@@ -369,6 +369,44 @@ class TimeData(DenseData):
         return as_finite_diff(self.diff(t, t), indt)
 
 
+class CoordinateData(SymbolicData):
+    """Data object for sparse coordinate data that acts as a Function symbol
+
+    """
+
+    def __init__(self, *args, **kwargs):
+        if self._cached():
+            # Initialise instance from symbol cache
+            SymbolicData.__init__(self)
+            return
+        else:
+            self.name = kwargs.get('name')
+            self.ndim = kwargs.get('ndim')
+            self.npoint = kwargs.get('npoint')
+            self.shape = (self.npoint, self.ndim)
+            self.dtype = kwargs.get('dtype', np.float32)
+            self.data = aligned(np.zeros(self.shape, self.dtype,
+                                         order='C'), alignment=64)
+            # Store final instance in symbol cache
+            self._cache_put(self)
+
+    def __new__(cls, *args, **kwargs):
+        ndim = kwargs.get('ndim')
+        npoint = kwargs.get('npoint')
+        kwargs['shape'] = (npoint, ndim)
+        return SymbolicData.__new__(cls, *args, **kwargs)
+
+    @classmethod
+    def indices(cls, shape):
+        """Return the default dimension indices for a given data shape
+
+        :param shape: Shape of the spatial data
+        :return: indices used for axis.
+        """
+        _indices = [p]
+        return _indices
+
+
 class PointData(DenseData):
     """Data object for sparse point data that acts as a Function symbol
 
@@ -391,9 +429,14 @@ class PointData(DenseData):
         else:
             self.nt = kwargs.get('nt')
             self.npoint = kwargs.get('npoint')
+            ndim = kwargs.get('ndim')
             kwargs['shape'] = (self.nt, self.npoint)
             super(PointData, self).__init__(self, *args, **kwargs)
-            self.coordinates = kwargs.get('coordinates')
+            coordinates = kwargs.get('coordinates')
+            self.coordinates = CoordinateData(name='%s_coords' % self.name,
+                                              data=coordinates, ndim=ndim,
+                                              nt=self.nt, npoint=self.npoint)
+            self.coordinates.data[:] = kwargs.get('coordinates')[:]
             # Store final instance in symbol cache
             self._cache_put(self)
 

--- a/devito/iteration.py
+++ b/devito/iteration.py
@@ -1,0 +1,53 @@
+from collections import Iterable
+
+import cgen
+
+from devito.codeprinter import ccode
+
+__all__ = ['Iteration']
+
+
+class Iteration(object):
+    """Iteration object that encapsualtes a single loop over sympy expressions.
+
+    :param stencils: SymPy equation or list of equations that define the
+                     stencil used to create the loop body.
+    :param variable: Symbol that defines the name of the variable over which
+                     to iterate.
+    :param limits: Limits for the iteration space, either the loop size or a
+                   tuple of the form (start, finish, stepping).
+    """
+
+    def __init__(self, stencils, variable, limits):
+        self.stencils = stencils if isinstance(stencils, list) else [stencils]
+        self.variable = str(variable)
+        if isinstance(limits, Iterable):
+            assert(len(limits) == 3)
+            self.limits = limits
+        else:
+            self.limits = (0, limits, 1)
+
+    def substitute(self, substitutions):
+        """Apply substitutions to loop stencils via sympy.subs()
+
+        :param substitutions: Dict containing the substitutions to apply to
+                              the stored loop stencils.
+        """
+        self.stencils = [eq.subs(substitutions) for eq in self.stencils]
+
+    @property
+    def ccode(self):
+        """Generate C code for the represented stencil loop
+
+        :returns: :class:`cgen.For` object representing the loop
+        """
+        forward = self.limits[1] >= self.limits[0]
+        loop_body = cgen.Block([ccode(cgen.Assign(ccode(eq.lhs), ccode(eq.rhs)))
+                                for eq in self.stencils])
+        loop_init = cgen.InlineInitializer(cgen.Value("int", self.variable), self.limits[0])
+        loop_cond = '%s %s %s' % (self.variable, '<' if forward else '>', self.limits[1])
+        if self.limits[2] == 1:
+            loop_inc = '%s%s' % (self.variable, '++' if forward else '--')
+        else:
+            loop_inc = '%s %s %s' % (self.variable, '+=' if forward else '-=', self.limits[2])
+        return cgen.For(loop_init, loop_cond, loop_inc, loop_body)

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -195,8 +195,8 @@ class Operator(object):
         f = self.propagator.cfunction
 
         for param in self.input_params:
-            param.initialize()
-
+            if hasattr(param, 'initialize'):
+                param.initialize()
         args = [param.data for param in self.input_params + self.output_params]
 
         if isinstance(self.compiler, IntelMICCompiler):

--- a/devito/propagator.py
+++ b/devito/propagator.py
@@ -296,9 +296,11 @@ class Propagator(object):
             time_stepping = []
         loop_body = [cgen.Block(omp_for + loop_body)]
         # Statements to be inserted into the time loop before the spatial loop
+        time_loop_stencils_b = [self.time_substitutions(x) for x in self.time_loop_stencils_b]
         time_loop_stencils_b = [self.convert_equality_to_cgen(x) for x in self.time_loop_stencils_b]
 
         # Statements to be inserted into the time loop after the spatial loop
+        time_loop_stencils_a = [self.time_substitutions(x) for x in self.time_loop_stencils_a]
         time_loop_stencils_a = [self.convert_equality_to_cgen(x) for x in self.time_loop_stencils_a]
 
         if self.profile:
@@ -566,6 +568,12 @@ class Propagator(object):
         :returns: The expression after the substitutions
         """
         subs_dict = {}
+
+        # For Iteration objects we apply time subs to the stencil list
+        if isinstance(sympy_expr, Iteration):
+            sympy_expr.stencils = [self.time_substitutions(s)
+                                   for s in sympy_expr.stencils]
+            return sympy_expr
 
         for arg in postorder_traversal(sympy_expr):
             if isinstance(arg, Indexed):

--- a/devito/propagator.py
+++ b/devito/propagator.py
@@ -13,6 +13,7 @@ from codeprinter import ccode
 from devito.compiler import (IntelMICCompiler, get_compiler_from_env,
                              get_tmp_dir, jit_compile_and_load)
 from devito.function_manager import FunctionDescriptor, FunctionManager
+from devito.iteration import Iteration
 
 
 class Propagator(object):
@@ -253,6 +254,9 @@ class Propagator(object):
         """
         if isinstance(equality, cgen.Generable):
             return equality
+        elif isinstance(equality, Iteration):
+            equality.substitute(self._var_map)
+            return equality.ccode
         else:
             s_lhs = ccode(self.time_substitutions(equality.lhs).xreplace(self._var_map))
             s_rhs = ccode(self.time_substitutions(equality.rhs).xreplace(self._var_map))

--- a/examples/Acoustic_codegen.py
+++ b/examples/Acoustic_codegen.py
@@ -73,17 +73,17 @@ class Acoustic_cg:
         damp_boundary(self.damp.data)
 
         self.src = SourceLike(name="src", npoint=1, nt=self.nt, dt=self.dt, h=self.h,
-                              data=np.array(self.data.source_coords, dtype=self.dtype)[np.newaxis, :],
+                              coordinates=np.array(self.data.source_coords, dtype=self.dtype)[np.newaxis, :],
                               ndim=len(dimensions), dtype=self.dtype, nbpml=nbpml)
         self.rec = SourceLike(name="rec", npoint=self.nrec, nt=self.nt, dt=self.dt, h=self.h,
-                              data=self.data.receiver_coords, ndim=len(dimensions), dtype=self.dtype,
+                              coordinates=self.data.receiver_coords, ndim=len(dimensions), dtype=self.dtype,
                               nbpml=nbpml)
         self.src.data[:] = self.data.get_source()[:, np.newaxis]
 
         self.u = TimeData(name="u", shape=self.m.shape, time_dim=self.src.nt, time_order=t_order,
                           save=False, dtype=self.m.dtype)
         self.srca = SourceLike(name="srca", npoint=1, nt=self.nt, dt=self.dt, h=self.h,
-                               data=np.array(self.data.source_coords, dtype=self.dtype)[np.newaxis, :],
+                               coordinates=np.array(self.data.source_coords, dtype=self.dtype)[np.newaxis, :],
                                ndim=len(dimensions), dtype=self.dtype, nbpml=nbpml)
         if dm_initializer is not None:
             self.dm = DenseData(name="dm", shape=self.model.vp.shape, dtype=self.dtype)

--- a/examples/TTI_codegen.py
+++ b/examples/TTI_codegen.py
@@ -77,10 +77,10 @@ class TTI_cg:
         # Initialize damp by calling the function that can precompute damping
         damp_boundary(self.damp.data)
         self.src = SourceLikeTTI(name="src", npoint=1, nt=self.nt, dt=self.dt, h=self.h,
-                                 data=np.array(self.data.source_coords, dtype=self.dtype)[np.newaxis, :],
+                                 coordinates=np.array(self.data.source_coords, dtype=self.dtype)[np.newaxis, :],
                                  ndim=len(dimensions), dtype=self.dtype, nbpml=nbpml)
         self.rec = SourceLikeTTI(name="rec", npoint=self.nrec, nt=self.nt, dt=self.dt, h=self.h,
-                                 data=self.data.receiver_coords, ndim=len(dimensions), dtype=self.dtype,
+                                 coordinates=self.data.receiver_coords, ndim=len(dimensions), dtype=self.dtype,
                                  nbpml=nbpml)
         self.src.data[:] = self.data.get_source()[:, np.newaxis]
         self.u = TimeData(name="u", shape=self.m.shape, time_dim=self.src.nt, time_order=t_order,
@@ -88,7 +88,7 @@ class TTI_cg:
         self.v = TimeData(name="v", shape=self.m.shape, time_dim=self.src.nt, time_order=t_order,
                           save=False, dtype=self.m.dtype)
         self.srca = SourceLikeTTI(name="srca", npoint=1, nt=self.nt, dt=self.dt, h=self.h,
-                                  data=np.array(self.data.source_coords, dtype=self.dtype)[np.newaxis, :],
+                                  coordinates=np.array(self.data.source_coords, dtype=self.dtype)[np.newaxis, :],
                                   ndim=len(dimensions), dtype=self.dtype, nbpml=nbpml)
         if dm_initializer is not None:
             self.dm = DenseData(name="dm", shape=self.model.vp.shape, dtype=self.dtype)

--- a/examples/fwi_operators.py
+++ b/examples/fwi_operators.py
@@ -127,7 +127,7 @@ class SourceLike(PointData):
         eqs = []
 
         for i in range(self.npoint):
-            eqs.append(Eq(self.indexed[t, i], self.grid2point(u, self.coordinates[i, :])))
+            eqs.append(Eq(self.indexed[t, i], self.grid2point(u, self.coordinates.data[i, :])))
         return eqs
 
     def add(self, m, u):
@@ -135,7 +135,7 @@ class SourceLike(PointData):
         dt = self.dt
 
         for j in range(self.npoint):
-            add = self.point2grid(self.coordinates[j, :])
+            add = self.point2grid(self.coordinates.data[j, :])
             coords = add[0]
             s = add[1]
             assignments += [Eq(u.indexed[tuple([t] + [coords[i] + inc[i] for i in range(self.ndim)])],

--- a/examples/fwi_operators.py
+++ b/examples/fwi_operators.py
@@ -67,10 +67,10 @@ class SourceLike(PointData):
         #          (i, k), (i, k+1), (i+1, k), (i+1, k+1)
         if self.ndim == 2:
             rx, rz = self.rs
+            x, z = pt_coords
         else:
             rx, ry, rz = self.rs
-
-        x, y, z = pt_coords
+            x, y, z = pt_coords
         i = int(x/self.h)
         k = int(z/self.h)
         coords = (i + self.nbpml, k + self.nbpml)
@@ -94,10 +94,10 @@ class SourceLike(PointData):
     def grid2point(self, u, pt_coords):
         if self.ndim == 2:
             rx, rz = self.rs
+            x, z = pt_coords
         else:
             rx, ry, rz = self.rs
-
-        x, y, z = pt_coords
+            x, y, z = pt_coords
         i = int(x/self.h)
         k = int(z/self.h)
 

--- a/examples/fwi_operators.py
+++ b/examples/fwi_operators.py
@@ -9,7 +9,6 @@ class SourceLike(PointData):
     """Defines the behaviour of sources and receivers.
     """
     def __init__(self, *args, **kwargs):
-        self.orig_data = kwargs.get('data')
         self.dt = kwargs.get('dt')
         self.h = kwargs.get('h')
         self.ndim = kwargs.get('ndim')
@@ -128,8 +127,7 @@ class SourceLike(PointData):
         eqs = []
 
         for i in range(self.npoint):
-            eqs.append(Eq(self.indexed[t, i], self.grid2point(u, self.orig_data[i, :])))
-
+            eqs.append(Eq(self.indexed[t, i], self.grid2point(u, self.coordinates[i, :])))
         return eqs
 
     def add(self, m, u):
@@ -137,7 +135,7 @@ class SourceLike(PointData):
         dt = self.dt
 
         for j in range(self.npoint):
-            add = self.point2grid(self.orig_data[j, :])
+            add = self.point2grid(self.coordinates[j, :])
             coords = add[0]
             s = add[1]
             assignments += [Eq(u.indexed[tuple([t] + [coords[i] + inc[i] for i in range(self.ndim)])],

--- a/examples/tti_operators.py
+++ b/examples/tti_operators.py
@@ -11,7 +11,6 @@ class SourceLikeTTI(PointData):
     """Defines the behaviour of sources and receivers.
     """
     def __init__(self, *args, **kwargs):
-        self.orig_data = kwargs.get('data')
         self.dt = kwargs.get('dt')
         self.h = kwargs.get('h')
         self.ndim = kwargs.get('ndim')
@@ -129,9 +128,8 @@ class SourceLikeTTI(PointData):
         eqs = []
 
         for i in range(self.npoint):
-            eqs.append(Eq(self.indexed[t, i],
-                          (self.grid2point(v, self.orig_data[i, :]) + self.grid2point(u, self.orig_data[i, :]))))
-
+            eqs.append(Eq(self.indexed[t, i], (self.grid2point(v, self.coordinates[i, :])
+                                               + self.grid2point(u, self.coordinates[i, :]))))
         return eqs
 
     def add(self, m, u):
@@ -139,7 +137,7 @@ class SourceLikeTTI(PointData):
         dt = self.dt
 
         for j in range(self.npoint):
-            add = self.point2grid(self.orig_data[j, :])
+            add = self.point2grid(self.coordinates[j, :])
             coords = add[0]
             s = add[1]
             assignments += [Eq(u.indexed[tuple([t] + [coords[i] + inc[i] for i in range(self.ndim)])],

--- a/examples/tti_operators.py
+++ b/examples/tti_operators.py
@@ -128,8 +128,8 @@ class SourceLikeTTI(PointData):
         eqs = []
 
         for i in range(self.npoint):
-            eqs.append(Eq(self.indexed[t, i], (self.grid2point(v, self.coordinates[i, :])
-                                               + self.grid2point(u, self.coordinates[i, :]))))
+            eqs.append(Eq(self.indexed[t, i], (self.grid2point(v, self.coordinates.data[i, :])
+                                               + self.grid2point(u, self.coordinates.data[i, :]))))
         return eqs
 
     def add(self, m, u):
@@ -137,7 +137,7 @@ class SourceLikeTTI(PointData):
         dt = self.dt
 
         for j in range(self.npoint):
-            add = self.point2grid(self.coordinates[j, :])
+            add = self.point2grid(self.coordinates.data[j, :])
             coords = add[0]
             s = add[1]
             assignments += [Eq(u.indexed[tuple([t] + [coords[i] + inc[i] for i in range(self.ndim)])],

--- a/tests/test_adjointA.py
+++ b/tests/test_adjointA.py
@@ -37,13 +37,15 @@ class Test_AdjointA(object):
             return (1-2.*r**2)*np.exp(-r**2)
 
         time_series = source(np.linspace(t0, tn, nt), f0)
-        location = (origin[0] + dimensions[0] * spacing[0] * 0.5, 0,
+        location = (origin[0] + dimensions[0] * spacing[0] * 0.5,
                     origin[-1] + 2 * spacing[-1])
+        if len(dimensions) == 3:
+            location = (location[0], 0., location[1])
         data.set_source(time_series, dt, location)
-        receiver_coords = np.zeros((30, 3))
+        receiver_coords = np.zeros((30, len(dimensions)))
         receiver_coords[:, 0] = np.linspace(50, origin[0] + dimensions[0]*spacing[0] - 50, num=30)
-        receiver_coords[:, 1] = 0.0
-        receiver_coords[:, 2] = location[2]
+        receiver_coords[:, -1] = location[-1]
+
         data.set_receiver_pos(receiver_coords)
         data.set_shape(nt, 30)
         # Adjoint test


### PR DESCRIPTION
This merge is primarily intended to fix issue #48 by extending the Propagator API to insert user-defined loops over low-level "indexed access" expressions to perform sparse point interpolation. For this purpose a new class `Iteration` is introduced that encapsulates a single loop over a defined dimension. In more detail this PR brings:
* A new symbolic data object `CoordinateData` that gets attached to `PointData` objects and stores the coordinates of the sparse points.
* Fixes to the Operators `input_params` and `output_params` lists, including a more general way of avoiding duplication in the function signature. It also makes the call to `initialize()` on input params optional.
* New `Iteration` class that encapsulates a single loop iteration over a defined iteration space. It auto-generates the loop code around the given stencil(s) and is accepted as input to the Propagator, either as a normal stencil, or a `time_loop_stencil`.
* Small hacks to the `CodePrinter` to enable custom functions `INT` and `FLOAT` for data type conversions. This is required to get around SymPy limitations.
* `SourceLike` objects for FWI now provide symbolic expressions for grid-to-point and point-to-grid interpolation, which in turn now get wrapped by an `Iteration` over the point dimension `p` to insert loop-based interpolation code into all FWI operators. I leave TTI for another PR...

Please note that the new loop-based way of performing interpolation adds flops to the time loop that we previously pre-computed in Python. In turn it brings down the compilation overhead for large data sets though and is more general; and the point interpolation should still be sparse enough to not be a performance bottleneck.