### PR TITLE
Fixed and tested Interfaces.TimeData save parameter

### DIFF
--- a/devito/interfaces.py
+++ b/devito/interfaces.py
@@ -304,14 +304,16 @@ class TimeData(DenseData):
     def init_data(self, timestep, data):
         """Function to initialize the initial time steps
 
-        :param timestep: Time step to initialize. Must be negative since calculated timesteps start from 0.
+        :param timestep: Time step to initialize.
+                         Must be negative since calculated timesteps start from 0.
         :param data: :class:`numpy.ndarray` containing the initial spatial data
         """
         if self._full_data is None:
             self._allocate_memory()
 
         assert timestep < 0, "Timestep must be negative"
-        assert data.shape == self._full_data[0].shape, "Data must have the same shape as the spatial data"
+        assert data.shape == self._full_data[0].shape, \
+            "Data must have the same shape as the spatial data"
 
         # Adds the time_order to the index to access padded indexes
         timestep += self.time_order

--- a/tests/test_save.py
+++ b/tests/test_save.py
@@ -21,7 +21,10 @@ def run_simulation(save=False, dx=0.01, dy=0.01, a=0.5, timesteps=100):
     dx2, dy2 = dx**2, dy**2
     dt = dx2 * dy2 / (2 * a * (dx2 + dy2))
 
-    u = TimeData(name='u', shape=(nx, ny), time_dim=timesteps, time_order=1, space_order=2, save=save, pad_time=save)
+    u = TimeData(
+        name='u', shape=(nx, ny), time_dim=timesteps,
+        time_order=1, space_order=2, save=save, pad_time=save
+    )
     u.init_data(-1, initial())
 
     a, h, s = symbols('a h s')

--- a/tests/test_save.py
+++ b/tests/test_save.py
@@ -1,0 +1,41 @@
+import numpy as np
+from sympy import Eq, solve, symbols
+
+from devito.interfaces import TimeData
+from devito.operator import Operator
+
+
+def initial(dx=0.01, dy=0.01):
+    nx, ny = int(1 / dx), int(1 / dy)
+    xx, yy = np.meshgrid(np.linspace(0., 1., nx, dtype=np.float32),
+                         np.linspace(0., 1., ny, dtype=np.float32))
+    ui = np.zeros((nx, ny), dtype=np.float32)
+    r = (xx - .5)**2. + (yy - .5)**2.
+    ui[np.logical_and(.05 <= r, r <= .1)] = 1.
+
+    return ui
+
+
+def run_simulation(save=False, dx=0.01, dy=0.01, a=0.5, timesteps=100):
+    nx, ny = int(1 / dx), int(1 / dy)
+    dx2, dy2 = dx**2, dy**2
+    dt = dx2 * dy2 / (2 * a * (dx2 + dy2))
+
+    u = TimeData(name='u', shape=(nx, ny), time_dim=timesteps, time_order=1, space_order=2, save=save, pad_time=save)
+    u.init_data(-1, initial())
+
+    a, h, s = symbols('a h s')
+    eqn = Eq(u.dt, a * (u.dx2 + u.dy2))
+    stencil = solve(eqn, u.forward)[0]
+    op = Operator(stencils=Eq(u.forward, stencil), substitutions={a: 0.5, h: dx, s: dt},
+                  nt=timesteps, shape=(nx, ny), spc_border=1, time_order=1)
+    op.apply()
+
+    if save:
+        return u.get_data(timesteps - 2)
+    else:
+        return u.get_data()
+
+
+def test_save():
+    assert(np.array_equal(run_simulation(True), run_simulation()))


### PR DESCRIPTION
- Added methods to initialize spatial data and retrieve results from TimeData objects. 
- Added a test for the save parameter.

A little issue: The final result is at `timesteps - 2` while one would expect it to be at `timesteps - 1` since the Devito calculated values start from 0.

My guess is that the result when `save=False` is not the 100th timestep, but the 99th. I can't see why that would happen though.

EDIT: Added issue https://github.com/opesci/devito/issues/69 regarding this problem