### PR TITLE
Refinement over use of memmap

### DIFF
--- a/devito/interfaces.py
+++ b/devito/interfaces.py
@@ -5,8 +5,8 @@ from sympy import Function, IndexedBase, as_finite_diff
 from sympy.abc import h, p, s, t, x, y, z
 
 from devito.finite_difference import cross_derivative, first_derivative
-from tools import aligned
 from devito.memmap_manager import MemmapManager
+from tools import aligned
 
 __all__ = ['DenseData', 'TimeData', 'PointData']
 

--- a/devito/interfaces.py
+++ b/devito/interfaces.py
@@ -478,17 +478,28 @@ class MemmapManager():
     """Class for managing all memmap related settings"""
     # used to enable memmap as default
     _use_memmap = False
+    # determine whether created files are deleted by default
+    _delete_file = True
     # flag for registering exit func
     _registered = False
     _default_disk_path = os.path.join(gettempdir(), "devito_disk")
     # contains str name of all memmap file created
-    _created_data = set()
+    _created_data = {}
+    # unique id
+    _id = 0
     _default_exit_code = 0
 
     @staticmethod
     def set_memmap(memmap):
         """Call this method to set default value of memmap"""
         MemmapManager._use_memmap = memmap
+
+    @staticmethod
+    def set_delete_file(delete):
+        """Call this method to set default flag contolling whether to delete
+        crated files.
+        """
+        MemmapManager._delete_file = delete
 
     @staticmethod
     def set_default_disk_path(default_disk_path):
@@ -499,11 +510,12 @@ class MemmapManager():
     def setup(data_self, *args, **kwargs):
         """This method is used to setup memmap parameters for data classes.
 
-        :param name: Name of data, must be unique
+        :param name: Name of data
         :param memmap: Boolean indicates whether memmap is used. Optional
-        :param disk_path: String indicates path to create memmap file. Optional
+        :param disk_path: String indicates directory to create memmap file. Optional
+        :param delete_file: Boolean indicates whether to delete created file. Optional
 
-        Note: If memmap or disk_path are not provided, the default values
+        Note: If memmap, disk_path or delete_file are not provided, the default values
         are used.
         """
         data_self.memmap = kwargs.get('memmap', MemmapManager._use_memmap)
@@ -514,22 +526,25 @@ class MemmapManager():
             if not os.path.exists(disk_path):
                 os.makedirs(disk_path)
 
-            data_self.f = disk_path + "/data_" + kwargs.get('name')
-            MemmapManager._created_data.add(data_self.f)
+            data_self.f = disk_path + "/data_" + kwargs.get('name') + "_" + str(MemmapManager._id)
+            MemmapManager._id += 1
+            data_self.delete_file = kwargs.get('delete_file', MemmapManager._delete_file)
+            MemmapManager._created_data[data_self.f] = data_self.delete_file
 
             if not MemmapManager._registered:
                 MemmapManager._register_remove_memmap_file_signal()
                 MemmapManager._registered = True
 
     @staticmethod
-    def _reomve_memmap_file():
+    def _remove_memmap_file():
         """This method is used to clean up memmap file"""
         for f in MemmapManager._created_data:
-            try:
-                os.remove(f)
-            except OSError:
-                print("error removing " + f + " it may be already removed, skipping")
-                pass
+            if MemmapManager._created_data[f]:
+                try:
+                    os.remove(f)
+                except OSError:
+                    print("error removing " + f + " it may be already removed, skipping")
+                    pass
 
     @staticmethod
     def _remove_memmap_file_on_signal(*args):
@@ -539,7 +554,7 @@ class MemmapManager():
     @staticmethod
     def _register_remove_memmap_file_signal():
         """This method is used to register clean up method for chosen signals"""
-        atexit.register(MemmapManager._reomve_memmap_file)
+        atexit.register(MemmapManager._remove_memmap_file)
 
         for sig in (SIGABRT, SIGINT, SIGSEGV, SIGTERM):
             signal(sig, MemmapManager._remove_memmap_file_on_signal)

--- a/devito/interfaces.py
+++ b/devito/interfaces.py
@@ -482,11 +482,13 @@ class MemmapManager():
     _delete_file = True
     # flag for registering exit func
     _registered = False
+    # default directory to store memmap file
     _default_disk_path = os.path.join(gettempdir(), "devito_disk")
     # contains str name of all memmap file created
     _created_data = {}
     # unique id
     _id = 0
+    # exit code used for normal exiting
     _default_exit_code = 0
 
     @staticmethod
@@ -545,6 +547,8 @@ class MemmapManager():
                 except OSError:
                     print("error removing " + f + " it may be already removed, skipping")
                     pass
+            else:
+                print("file " + f + " has been left")
 
     @staticmethod
     def _remove_memmap_file_on_signal(*args):

--- a/devito/interfaces.py
+++ b/devito/interfaces.py
@@ -1,9 +1,4 @@
-import atexit
-import os
-import sys
 import weakref
-from signal import SIGABRT, SIGINT, SIGSEGV, SIGTERM, signal
-from tempfile import gettempdir
 
 import numpy as np
 from sympy import Function, IndexedBase, as_finite_diff
@@ -11,6 +6,7 @@ from sympy.abc import h, p, s, t, x, y, z
 
 from devito.finite_difference import cross_derivative, first_derivative
 from tools import aligned
+from devito.memmap_manager import MemmapManager
 
 __all__ = ['DenseData', 'TimeData', 'PointData']
 
@@ -472,93 +468,3 @@ class PointData(DenseData):
         _indices = [t, x, y, z]
 
         return _indices[:len(shape) + 1]
-
-
-class MemmapManager():
-    """Class for managing all memmap related settings"""
-    # used to enable memmap as default
-    _use_memmap = False
-    # determine whether created files are deleted by default
-    _delete_file = True
-    # flag for registering exit func
-    _registered = False
-    # default directory to store memmap file
-    _default_disk_path = os.path.join(gettempdir(), "devito_disk")
-    # contains str name of all memmap file created
-    _created_data = {}
-    # unique id
-    _id = 0
-    # exit code used for normal exiting
-    _default_exit_code = 0
-
-    @staticmethod
-    def set_memmap(memmap):
-        """Call this method to set default value of memmap"""
-        MemmapManager._use_memmap = memmap
-
-    @staticmethod
-    def set_delete_file(delete):
-        """Call this method to set default flag contolling whether to delete
-        crated files.
-        """
-        MemmapManager._delete_file = delete
-
-    @staticmethod
-    def set_default_disk_path(default_disk_path):
-        """Call this method to change the default disk path for memmap"""
-        MemmapManager._default_disk_path = default_disk_path
-
-    @staticmethod
-    def setup(data_self, *args, **kwargs):
-        """This method is used to setup memmap parameters for data classes.
-
-        :param name: Name of data
-        :param memmap: Boolean indicates whether memmap is used. Optional
-        :param disk_path: String indicates directory to create memmap file. Optional
-        :param delete_file: Boolean indicates whether to delete created file. Optional
-
-        Note: If memmap, disk_path or delete_file are not provided, the default values
-        are used.
-        """
-        data_self.memmap = kwargs.get('memmap', MemmapManager._use_memmap)
-
-        if data_self.memmap:
-            disk_path = kwargs.get('disk_path', MemmapManager._default_disk_path)
-
-            if not os.path.exists(disk_path):
-                os.makedirs(disk_path)
-
-            data_self.f = disk_path + "/data_" + kwargs.get('name') + "_" + str(MemmapManager._id)
-            MemmapManager._id += 1
-            data_self.delete_file = kwargs.get('delete_file', MemmapManager._delete_file)
-            MemmapManager._created_data[data_self.f] = data_self.delete_file
-
-            if not MemmapManager._registered:
-                MemmapManager._register_remove_memmap_file_signal()
-                MemmapManager._registered = True
-
-    @staticmethod
-    def _remove_memmap_file():
-        """This method is used to clean up memmap file"""
-        for f in MemmapManager._created_data:
-            if MemmapManager._created_data[f]:
-                try:
-                    os.remove(f)
-                except OSError:
-                    print("error removing " + f + " it may be already removed, skipping")
-                    pass
-            else:
-                print("file " + f + " has been left")
-
-    @staticmethod
-    def _remove_memmap_file_on_signal(*args):
-        """This method is used to clean memmap file on signal, internal method"""
-        sys.exit(MemmapManager._default_exit_code)
-
-    @staticmethod
-    def _register_remove_memmap_file_signal():
-        """This method is used to register clean up method for chosen signals"""
-        atexit.register(MemmapManager._remove_memmap_file)
-
-        for sig in (SIGABRT, SIGINT, SIGSEGV, SIGTERM):
-            signal(sig, MemmapManager._remove_memmap_file_on_signal)

--- a/devito/memmap_manager.py
+++ b/devito/memmap_manager.py
@@ -1,0 +1,94 @@
+import atexit
+import os
+import sys
+from signal import SIGABRT, SIGINT, SIGSEGV, SIGTERM, signal
+from tempfile import gettempdir
+
+
+class MemmapManager():
+    """Class for managing all memmap related settings"""
+    # used to enable memmap as default
+    _use_memmap = False
+    # determine whether created files are deleted by default
+    _delete_file = True
+    # flag for registering exit func
+    _registered = False
+    # default directory to store memmap file
+    _default_disk_path = os.path.join(gettempdir(), "devito_disk")
+    # contains str name of all memmap file created
+    _created_data = {}
+    # unique id
+    _id = 0
+    # exit code used for normal exiting
+    _default_exit_code = 0
+
+    @staticmethod
+    def set_memmap(memmap):
+        """Call this method to set default value of memmap"""
+        MemmapManager._use_memmap = memmap
+
+    @staticmethod
+    def set_delete_file(delete):
+        """Call this method to set default flag contolling whether to delete
+        crated files.
+        """
+        MemmapManager._delete_file = delete
+
+    @staticmethod
+    def set_default_disk_path(default_disk_path):
+        """Call this method to change the default disk path for memmap"""
+        MemmapManager._default_disk_path = default_disk_path
+
+    @staticmethod
+    def setup(data_self, *args, **kwargs):
+        """This method is used to setup memmap parameters for data classes.
+
+        :param name: Name of data
+        :param memmap: Boolean indicates whether memmap is used. Optional
+        :param disk_path: String indicates directory to create memmap file. Optional
+        :param delete_file: Boolean indicates whether to delete created file. Optional
+
+        Note: If memmap, disk_path or delete_file are not provided, the default values
+        are used.
+        """
+        data_self.memmap = kwargs.get('memmap', MemmapManager._use_memmap)
+
+        if data_self.memmap:
+            disk_path = kwargs.get('disk_path', MemmapManager._default_disk_path)
+
+            if not os.path.exists(disk_path):
+                os.makedirs(disk_path)
+
+            data_self.f = disk_path + "/data_" + kwargs.get('name') + "_" + str(MemmapManager._id)
+            MemmapManager._id += 1
+            data_self.delete_file = kwargs.get('delete_file', MemmapManager._delete_file)
+            MemmapManager._created_data[data_self.f] = data_self.delete_file
+
+            if not MemmapManager._registered:
+                MemmapManager._register_remove_memmap_file_signal()
+                MemmapManager._registered = True
+
+    @staticmethod
+    def _remove_memmap_file():
+        """This method is used to clean up memmap file"""
+        for f in MemmapManager._created_data:
+            if MemmapManager._created_data[f]:
+                try:
+                    os.remove(f)
+                except OSError:
+                    print("error removing " + f + " it may be already removed, skipping")
+            else:
+                print("file " + f + " has been left")
+
+    @staticmethod
+    def _remove_memmap_file_on_signal(*args):
+        """This method is used to clean memmap file on signal, internal method"""
+        sys.exit(MemmapManager._default_exit_code)
+
+    @staticmethod
+    def _register_remove_memmap_file_signal():
+        """This method is used to register clean up method for chosen signals"""
+        atexit.register(MemmapManager._remove_memmap_file)
+
+        for sig in (SIGABRT, SIGINT, SIGSEGV, SIGTERM):
+            signal(sig, MemmapManager._remove_memmap_file_on_signal)

--- a/devito/memmap_manager.py
+++ b/devito/memmap_manager.py
@@ -1,9 +1,10 @@
 import atexit
 import os
 import sys
-from devito.logger import warning
 from signal import SIGABRT, SIGINT, SIGSEGV, SIGTERM, signal
 from tempfile import gettempdir
+
+from devito.logger import warning
 
 
 class MemmapManager():
@@ -60,7 +61,8 @@ class MemmapManager():
             if not os.path.exists(disk_path):
                 os.makedirs(disk_path)
 
-            data_self.f = disk_path + "/data_" + kwargs.get('name') + "_" + str(MemmapManager._id)
+            data_self.f = "%s/data_%s_%s" % (disk_path, kwargs.get('name'),
+                                             str(MemmapManager._id))
             MemmapManager._id += 1
             data_self.delete_file = kwargs.get('delete_file', MemmapManager._delete_file)
             MemmapManager._created_data[data_self.f] = data_self.delete_file

--- a/devito/memmap_manager.py
+++ b/devito/memmap_manager.py
@@ -1,6 +1,7 @@
 import atexit
 import os
 import sys
+from devito.logger import warning
 from signal import SIGABRT, SIGINT, SIGSEGV, SIGTERM, signal
 from tempfile import gettempdir
 
@@ -76,9 +77,9 @@ class MemmapManager():
                 try:
                     os.remove(f)
                 except OSError:
-                    print("error removing " + f + " it may be already removed, skipping")
+                    warning("error removing %s it may be already removed, skipping", f)
             else:
-                print("file " + f + " has been left")
+                warning("file %s has been left", f)
 
     @staticmethod
     def _remove_memmap_file_on_signal(*args):


### PR DESCRIPTION
Add some comments.
Add the ability to have files of repeated name, which happened in acoustic_example(though in this case it may not cause an issue, but similar cases can happen in the future).
Add the ability to retain created file, default behaviour is to delete all files created.

Please ignore changes at places other than devito/interface.MemmapManager, those are just merge conflict.