### PR TITLE
FIxed _SymbolCache bug

### DIFF
--- a/devito/interfaces.py
+++ b/devito/interfaces.py
@@ -51,7 +51,7 @@ class SymbolicData(Function):
     """
 
     def __new__(cls, *args, **kwargs):
-        if cls not in _SymbolCache:
+        if cls not in _SymbolCache.keys():
             name = kwargs.get('name')
             shape = kwargs.get('shape')
 
@@ -71,13 +71,15 @@ class SymbolicData(Function):
 
     def __init__(self):
         """Initialise from a cached instance by shallow copying __dict__."""
-        original = _SymbolCache[self.__class__]
-        self.__dict__ = original.__dict__.copy()
+        for key in _SymbolCache.keys():
+            if self.__class__ == key:
+                original = _SymbolCache[key]
+                self.__dict__ = original.__dict__.copy()
 
     @classmethod
     def _cached(cls):
         """Test if current class is already in the symbol cache."""
-        return cls in _SymbolCache
+        return cls in _SymbolCache.keys()
 
     @classmethod
     def _cache_put(cls, obj):

--- a/tests/test_symbol_cache.py
+++ b/tests/test_symbol_cache.py
@@ -1,0 +1,16 @@
+import numpy as np
+
+import devito
+from devito.interfaces import DenseData
+
+
+def init(data):
+    data = np.zeros(data.shape)
+
+
+def test_symbol_cache(nx=1000, ny=1000):
+
+    for i in range(10):
+        DenseData(name='u', shape=(nx, ny), dtype=np.float64, space_order=2, initializer=init)
+
+        assert(len(devito.interfaces._SymbolCache) == 1)


### PR DESCRIPTION
- Changed checks for cached classes to `cls in _SymbolCache.keys()`. For reasons unknown, it would return `False` instead of `True` with the old comparison
- Selects key explicitly in `SymbolicData.init()`. With the previous change, calling `init` would result in a KeyError (reason unknown). Looking for the key manually solves the problem.

