### PR TITLE
Added clean() method to `SymbolicData` and `Operator`

### DIFF
--- a/devito/__init__.py
+++ b/devito/__init__.py
@@ -1,5 +1,19 @@
 from __future__ import absolute_import
+import gc
+
+from sympy.core import cache
+
 from devito.interfaces import *  # noqa
+from devito.interfaces import _SymbolCache
 from devito.operator import *  # noqa
 from devito.finite_difference import *  # noqa
 from devito.iteration import *  # noqa
+
+
+def clear_cache():
+    cache.clear_cache()
+    gc.collect()
+
+    for key, val in _SymbolCache.items():
+        if val() is None:
+            del _SymbolCache[key]

--- a/devito/interfaces.py
+++ b/devito/interfaces.py
@@ -1,6 +1,7 @@
 import atexit
 import os
 import sys
+import weakref
 from signal import SIGABRT, SIGINT, SIGSEGV, SIGTERM, signal
 from tempfile import gettempdir
 
@@ -72,7 +73,7 @@ class SymbolicData(Function):
     def __init__(self):
         """Initialise from a cached instance by shallow copying __dict__."""
         original = _SymbolCache[self.__class__]
-        self.__dict__ = original.__dict__.copy()
+        self.__dict__ = original().__dict__.copy()
 
     @classmethod
     def _cached(cls):
@@ -85,7 +86,7 @@ class SymbolicData(Function):
 
         :param obj: Object to be cached.
         """
-        _SymbolCache[cls] = obj
+        _SymbolCache[cls] = weakref.ref(obj)
 
     @classmethod
     def indices(cls, shape):

--- a/tests/test_symbolic_data.py
+++ b/tests/test_symbolic_data.py
@@ -3,7 +3,8 @@ import pytest
 from sympy import Derivative, as_finite_diff, simplify
 from sympy.abc import h, t, x, y, z
 
-from devito import DenseData, TimeData
+from devito import DenseData, TimeData, clear_cache
+from devito.interfaces import _SymbolCache
 
 
 @pytest.fixture
@@ -60,3 +61,12 @@ def test_second_derivatives_space(derivative, dimension, order):
     s_expr = as_finite_diff(u.diff(dimension, dimension), indices)
     assert(simplify(expr - s_expr) == 0)  # Symbolic equality
     assert(expr == s_expr)  # Exact equailty
+
+
+def test_clear_cache(nx=1000, ny=1000):
+    for i in range(10):
+        clear_cache()
+
+        DenseData(name='u', shape=(nx, ny), dtype=np.float64, space_order=2)
+
+        assert(len(_SymbolCache) == 1)


### PR DESCRIPTION
This provides a solution to issue #84 

The clean method needs to be explicitly called by the user. 
Otherwise, the symbolic cache keeps expanding and keeping a reference to every data object ever created, blowing up the memory usage.