### PR TITLE
Added missing rules to Propagator.t_replace

### DIFF
--- a/devito/propagator.py
+++ b/devito/propagator.py
@@ -211,6 +211,10 @@ class Propagator(object):
             for i, t_var in enumerate(reversed(self.time_steppers)):
                 self.t_replace[self.time_dim - i*self._time_step] = t_var
 
+            for i in range(1, len(self.time_steppers)):
+                idx = self.time_dim + i*self._time_step
+                self.t_replace[idx] = self.time_steppers[i - abs(self._time_step)]
+
         self._save = self._save and save
 
     @property


### PR DESCRIPTION
In `acoustic_example` we have a stencil of this form:
```
Eq(U[t, x, y, z], 2.85234567901235*(0.70117728531856*u[t, x, y, z] - 0.35058864265928*u[t - 1, x, y, z] - 0.35058864265928*u[t + 1, x, y, z])*dm[x, y, z]/m[x, y, z] + U[t, x, y, z])
```

That generates this line of code with the current rules:
```
U[t2][i1][i2][i3] = 2.85234567901235F*(-3.5058864265928e-1F*u[t1][i1][i2][i3] + 7.0117728531856e-1F*u[t2][i1][i2][i3] - 3.5058864265928e-1F*u[t2 + 1][i1][i2][i3])*    dm[i1][i2][i3]/m[i1][i2][i3] + U[t2][i1][i2][i3];
```

This goes out of bounds when `t2 = 2`.
This PR fixes that.