### PR TITLE
CSE bug fixes

### DIFF
--- a/devito/operator.py
+++ b/devito/operator.py
@@ -117,10 +117,22 @@ def expr_cse(expr):
 
     stencils = [stencil.xreplace(subs_dict) for stencil in stencils]
 
-    for i in range(len(to_keep)):
-        to_keep[i] = Eq(to_keep[i][0], to_keep[i][1].xreplace(subs_dict))
+    to_keep = [Eq(temp[0], temp[1].xreplace(subs_dict)) for temp in to_keep]
 
-    return to_keep + stencils
+    # If the RHS of a temporary variable is the LHS of a stencil,
+    # update the value of the temporary variable after the stencil
+
+    new_stencils = []
+
+    for stencil in stencils:
+        new_stencils.append(stencil)
+
+        for temp in to_keep:
+            if stencil.lhs in preorder_traversal(temp.rhs):
+                new_stencils.append(temp)
+                break
+
+    return to_keep + new_stencils
 
 
 class Operator(object):

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -82,7 +82,7 @@ def expr_cse(expr):
     for temp, value in temps:
         if isinstance(value, IndexedBase):
             to_revert[temp] = value
-        elif isinstance(value, Add):
+        elif isinstance(value, Add) and not set([t, x, y, z]).isdisjoint(set(value.args)):
             to_revert[temp] = value
         else:
             to_keep.append((temp, value))

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -96,6 +96,17 @@ def expr_cse(expr):
                     s_dict[arg] = Indexed(to_revert[value.base.label], *value.indices)
         to_revert[temp] = value.xreplace(s_dict)
 
+    # Make sure that no temporary that has to be reverted depends
+    # on another temporary of the list
+    changing = True
+    while changing:
+        changing = False
+        for temp, value in to_revert.items():
+            n_value = value.xreplace(to_revert)
+            if n_value != value:
+                to_revert[temp] = n_value
+                changing = True
+
     subs_dict = {}
 
     # Builds a dictionary of the replacements

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -96,17 +96,6 @@ def expr_cse(expr):
                     s_dict[arg] = Indexed(to_revert[value.base.label], *value.indices)
         to_revert[temp] = value.xreplace(s_dict)
 
-    # Make sure that no temporary that has to be reverted depends
-    # on another temporary of the list
-    changing = True
-    while changing:
-        changing = False
-        for temp, value in to_revert.items():
-            n_value = value.xreplace(to_revert)
-            if n_value != value:
-                to_revert[temp] = n_value
-                changing = True
-
     subs_dict = {}
 
     # Builds a dictionary of the replacements

--- a/examples/tti_operators.py
+++ b/examples/tti_operators.py
@@ -144,13 +144,13 @@ class ForwardOperator(Operator):
             (4.0 * m * v + (s * damp - 2.0 * m) *
              v.backward + 2.0 * s**2 * (delta * Hp + Hzr))
 
-        Hp = -(.5 * Gxx1 + .5 * Gxx2 + .5 * Gyy1 + .5 * Gyy2)
-        Hzr = -(.5 * Gzz1 + .5 * Gzz2)
-        factorized = {"Hp": Hp, "Hzr": Hzr}
+        Hp_val = -(.5 * Gxx1 + .5 * Gxx2 + .5 * Gyy1 + .5 * Gyy2)
+        Hzr_val = -(.5 * Gzz1 + .5 * Gzz2)
+        factorized = {Hp: Hp_val, Hzr: Hzr_val}
         # Add substitutions for spacing (temporal and spatial)
         subs = [{s: src.dt, h: src.h}, {s: src.dt, h: src.h}]
-        first_stencil = Eq(u.forward, stencilp)
-        second_stencil = Eq(v.forward, stencilr)
+        first_stencil = Eq(u.forward, stencilp.xreplace(factorized))
+        second_stencil = Eq(v.forward, stencilr.xreplace(factorized))
         stencils = [first_stencil, second_stencil]
         super(ForwardOperator, self).__init__(src.nt, m.shape,
                                               stencils=stencils,
@@ -160,7 +160,6 @@ class ForwardOperator(Operator):
                                               forward=True,
                                               dtype=m.dtype,
                                               input_params=parm,
-                                              factorized=factorized,
                                               **kwargs)
 
         # Insert source and receiver terms post-hoc


### PR DESCRIPTION
This PR solves:
 - an issue with the collection of terms that change during the execution of the loop

For example, this could happen:
```
double temp = u[t2][i1][i2]
u[t2][i1][i2] = ….
U[t2][i1][i2] = temp + ….
```

After this fix, this is what we'd get:
```
double temp;
temp = u[t2][i1][i2]
u[t2][i1][i2] = ….
temp = u[t2][i1][i2]
U[t2][i1][i2] = temp + ….
```

- an issue with temporaries depending on other temporaries causing compiler errors (this slows down the code quite a bit)

Thanks to @mloubout for pointing out the issues

EDIT: Also changed tti_operators.ForwardOperator not to use `factorized`.

EDIT2: Fixed another bug that caused some temporaries to be reverted when not needed, making the second issue pointed out in the original post disappear in the process