### PR TITLE
Benchmark for TTI example

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -38,5 +38,5 @@ script:
   - isort --check-only **/*.py
   - py.test -vs tests/
   - python examples/acoustic_example.py
-  - python examples/tti_benchmark.py test -c -a
+  - python examples/tti_benchmark.py test -c -a -d 20 20 20 -n 5
   - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then ./docs/deploy.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,5 +38,5 @@ script:
   - isort --check-only **/*.py
   - py.test -vs tests/
   - python examples/acoustic_example.py
-  - python examples/tti_benchmark.py test -c -a -d 20 20 20 -n 5
+  - python examples/tti_benchmark.py test -a -d 20 20 20 -n 5
   - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then ./docs/deploy.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,9 +33,10 @@ before_script:
   - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
 
 script:
-  - export PYTHONPATH=$PYTHONPATH:$PWD
   - flake8 --builtins=ArgumentError .
   - isort --check-only **/*.py
+  - git clone https://github.com/opesci/opescibench.git
+  - export PYTHONPATH=$PYTHONPATH:$PWD/opescibench:$PWD
   - py.test -vs tests/
   - python examples/acoustic_example.py
   - python examples/tti_benchmark.py test -c -a

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,5 +38,5 @@ script:
   - isort --check-only **/*.py
   - py.test -vs tests/
   - python examples/acoustic_example.py
-  - python examples/tti_example.py
+  - python examples/tti_benchmark.py test -c -a
   - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then ./docs/deploy.sh; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -33,10 +33,9 @@ before_script:
   - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
 
 script:
+  - export PYTHONPATH=$PYTHONPATH:$PWD
   - flake8 --builtins=ArgumentError .
   - isort --check-only **/*.py
-  - git clone https://github.com/opesci/opescibench.git
-  - export PYTHONPATH=$PYTHONPATH:$PWD/opescibench:$PWD
   - py.test -vs tests/
   - python examples/acoustic_example.py
   - python examples/tti_benchmark.py test -c -a

--- a/devito/profiler.py
+++ b/devito/profiler.py
@@ -1,3 +1,5 @@
+import re
+
 from collections import defaultdict
 from ctypes import Structure, byref, c_double, c_longlong
 
@@ -8,6 +10,8 @@ from devito.logger import error
 class Profiler(object):
     """The Profiler class is used to manage profiling information for Devito
     generated C code.
+
+    :param openmp: True if OpenMP is on.
     """
     TIME = 1
     FLOP = 2
@@ -71,7 +75,7 @@ class Profiler(object):
         return ["%s->%s+=%s%s" % (self.f_name, v, self.loop_temp_prefix, v)
                 for v in variables]
 
-    def add_profiling(self, code, name, byte_size=4, omp_flag=None):
+    def add_profiling(self, code, name, byte_size=4, omp_flag=None, to_ignore=None):
         """Function to add profiling code to the given :class:`cgen.Block`.
 
         :param code: A list of :class:`cgen.Generable` with the code to be
@@ -81,18 +85,22 @@ class Profiler(object):
                           Defaults to 4.
         :param omp_flag: OpenMP flag to add before profiling operations,
                          if needed.
+        :param to_ignore: List of strings containing the labels of
+                          symbols used as loop variables
+
         :returns: A list of :class:`cgen.Generable` with the added profiling
                   code.
         """
         if code == []:
             return []
 
+        to_ignore = to_ignore or []
+        omp_flag = omp_flag or []
+
         self.t_fields.append((name, c_double))
         self.f_fields.append((name, c_longlong))
 
-        self.get_oi_and_flops(name, code, byte_size)
-
-        omp_flag = omp_flag or []
+        self.get_oi_and_flops(name, code, byte_size, to_ignore)
 
         init = [
             Statement("struct timeval start_%s, end_%s" % (name, name))
@@ -111,7 +119,7 @@ class Profiler(object):
 
         return init + code + end
 
-    def get_oi_and_flops(self, name, code, size):
+    def get_oi_and_flops(self, name, code, size, to_ignore):
         """Calculates the total operation intensity of the code provided.
         If needed, lets the C code calculate it.
 
@@ -122,14 +130,15 @@ class Profiler(object):
 
         for elem in code:
             if isinstance(elem, Assign):
-                assign_flops = self._get_assign_flops(elem, loads)
+                assign_flops = self._get_assign_flops(elem, loads, to_ignore)
                 self.oi[name] += assign_flops
                 self.flops_defaults[name] += assign_flops
             elif isinstance(elem, For):
-                for_flops = self._get_for_flops(name, elem, loads)
+                for_flops = self._get_for_flops(name, elem, loads, to_ignore)
                 self.oi[name] += for_flops
             elif isinstance(elem, Block):
-                block_oi, block_flops = self._get_block_oi_and_flops(name, elem, loads)
+                block_oi, block_flops = self._get_block_oi_and_flops(
+                    name, elem, loads, to_ignore)
                 self.oi[name] += block_oi
                 self.flops_defaults[name] += block_flops
             else:
@@ -141,17 +150,18 @@ class Profiler(object):
         self.oi_low[name] = float(self.oi[name]) / (size*load_val_sum)
         self.total_load_count[name] = load_val_sum - loads["stores"]
 
-    def _get_for_flops(self, name, loop, loads):
+    def _get_for_flops(self, name, loop, loads, to_ignore):
         loop_flops = 0
         loop_oi_f = 0
 
         if isinstance(loop.body, Assign):
-            loop_flops = self._get_assign_flops(loop.body, loads)
+            loop_flops = self._get_assign_flops(loop.body, loads, to_ignore)
             loop_oi_f = loop_flops
         elif isinstance(loop.body, Block):
-            loop_oi_f, loop_flops = self._get_block_oi_and_flops(name, loop.body, loads)
+            loop_oi_f, loop_flops = self._get_block_oi_and_flops(
+                name, loop.body, loads, to_ignore)
         elif isinstance(loop.body, For):
-            loop_oi_f = self._get_for_flops(name, loop.body, loads)
+            loop_oi_f = self._get_for_flops(name, loop.body, loads, to_ignore)
         else:
             # no op
             pass
@@ -167,69 +177,70 @@ class Profiler(object):
 
         return loop_oi_f
 
-    def _get_block_oi_and_flops(self, name, block, loads):
+    def _get_block_oi_and_flops(self, name, block, loads, to_ignore):
         block_flops = 0
         block_oi = 0
 
         for elem in block.contents:
             if isinstance(elem, Assign):
-                a_flops = self._get_assign_flops(elem, loads)
+                a_flops = self._get_assign_flops(elem, loads, to_ignore)
                 block_flops += a_flops
                 block_oi += a_flops
             elif isinstance(elem, Block):
-                nblock_oi, nblock_flops = self._get_block_oi_and_flops(name, elem, loads)
+                nblock_oi, nblock_flops = self._get_block_oi_and_flops(
+                    name, elem, loads, to_ignore)
                 block_oi += nblock_oi
                 block_flops += nblock_flops
             elif isinstance(elem, For):
-                block_oi += self._get_for_flops(name, elem, loads)
+                block_oi += self._get_for_flops(name, elem, loads, to_ignore)
             else:
                 # no op
                 pass
 
         return block_oi, block_flops
 
-    def _get_assign_flops(self, assign, loads):
+    def _get_assign_flops(self, assign, loads, to_ignore):
         flops = 0
-        cur_load = ""
         loads["stores"] += 1
 
-        idx = 0
-        brackets = 0
         # removing casting statements and function calls to floor
         # that can confuse the parser
-        string = (assign.lvalue + " " + assign.rvalue)\
-            .replace("float", '').replace("int", '').replace("floor", '')
+        string = assign.lvalue + " " + assign.rvalue
 
-        while idx < len(string):
-            char = string[idx]
-            if len(cur_load) == 0:
-                if char == '[':
-                    brackets += 1
-                elif char == ']':
-                    brackets -= 1
-                elif (char in "+-*/" and string[idx - 1] is not 'e' and not
-                      string[idx + 1].isdigit() and brackets == 0):
-                    flops += 1
-                elif (char.isalpha() and not
-                      string[idx - 1].isdigit() and char not in "it"):
-                    cur_load += char
-                idx += 1
-            else:
-                if char is '[':
-                    loads[cur_load] += 1
-                    cur_load = ""
-                    brackets += 1
-                    idx += 1
-                elif char is ' ' and brackets == 0 and len(cur_load) > 0:
-                    loads[cur_load] += 1
-                    cur_load = ""
-                    idx += 1
-                else:
-                    cur_load += char
-                    idx += 1
+        to_ignore = [
+            "int",
+            "float",
+            "double",
+            "F",
+            "i",
+            "t",
+            "fabsf",
+            "e",
+            "temp",
+            "p",  # This one shouldn't be here.
+                  # It should be passed in by an Iteration object.
+                  # Added only because tti_example uses it.
+        ] + to_ignore
 
-        if len(cur_load) > 0:
-            loads[cur_load] += 1
+        symbols = re.findall(r"[a-z_]+\d?", string)
+
+        for symbol in symbols:
+            if filter(lambda x: x.isalpha(), symbol) not in to_ignore:
+                loads[symbol] += 1
+
+        brackets = 0
+        for idx in range(len(string)):
+            c = string[idx]
+
+            # We skip index operations. The third check works because in the
+            # generated code constants always precede variables in operations
+            # and is needed because Sympy prints fractions like this: 1.0F/4.0F
+            if brackets == 0 and c in "*/-+" and not string[idx+1].isdigit():
+                flops += 1
+            elif c == "[":
+                brackets += 1
+            elif c == "]":
+                brackets -= 1
 
         return flops
 

--- a/devito/profiler.py
+++ b/devito/profiler.py
@@ -214,17 +214,26 @@ class Profiler(object):
             "float",
             "double",
             "F",
+            "e",
+            "fabsf",
+            "powf",
+            "floor",
+            "ceil",
+            "temp",
             "i",
             "t",
-            "fabsf",
-            "e",
-            "temp",
             "p",  # This one shouldn't be here.
                   # It should be passed in by an Iteration object.
                   # Added only because tti_example uses it.
         ] + to_ignore
 
-        symbols = re.findall(r"[a-z_]+\d?", string)
+        # Matches all variable names
+        # Variable names can contain:
+        # - uppercase and lowercase letters
+        # - underscores
+        # - numbers (at the end)
+        # eg: src_coord, temp123, u
+        symbols = re.findall(r"[a-z_A-Z]+(?:\d?)+", string)
 
         for symbol in symbols:
             if filter(lambda x: x.isalpha(), symbol) not in to_ignore:

--- a/devito/profiler.py
+++ b/devito/profiler.py
@@ -21,6 +21,7 @@ class Profiler(object):
 
     def __init__(self, openmp=False):
         self.openmp = openmp
+        self.profiled = []
         self.t_fields = []
         self.f_fields = []
         self.oi = defaultdict(int)
@@ -94,6 +95,7 @@ class Profiler(object):
         if code == []:
             return []
 
+        self.profiled.append(name)
         to_ignore = to_ignore or []
         omp_flag = omp_flag or []
 

--- a/devito/propagator.py
+++ b/devito/propagator.py
@@ -645,7 +645,11 @@ class Propagator(object):
             self.block_sizes.append(None)
 
         # replace 0 values with optimal block sizes
-        opt_block_size = get_optimal_block_size(self.shape, self.get_number_of_loads())
+        opt_block_size = get_optimal_block_size(
+            self.shape,
+            self.get_number_of_loads(),
+            self.compiler.openmp
+        )
         for i in range(0, len(self.block_sizes)):
             if self.block_sizes[i] is not None:  # replace 0 values with optimal
                 self.block_sizes[i] = (opt_block_size if self.block_sizes[i] == 0

--- a/devito/propagator.py
+++ b/devito/propagator.py
@@ -493,13 +493,16 @@ class Propagator(object):
         def_time_step = [cgen.Value("int", t_var_def.name)
                          for t_var_def in self.time_steppers]
         if self.profile:
+            profiled = self.profiler.profiled
+            profiled.append("kernel")
             body = def_time_step + self.pre_loop +\
                 [cgen.Statement(self.profiler
-                                .get_loop_temp_var_decl("0", self.reduction_list))]\
+                                .get_loop_temp_var_decl(
+                                    "0", profiled))]\
                 + omp_parallel + [loop_body] +\
                 [cgen.Statement(s) for s in
-                 self.profiler.get_loop_flop_update(self.reduction_list)]\
-                + self.post_loop
+                 self.profiler.get_loop_flop_update(
+                     profiled)] + self.post_loop
         else:
             body = def_time_step + self.pre_loop\
                 + omp_parallel + [loop_body] + self.post_loop

--- a/devito/tools.py
+++ b/devito/tools.py
@@ -96,4 +96,4 @@ def get_optimal_block_size(shape, load_c):
 
     optimal_b_size = math.sqrt(
         ((1000 * cache_s) / core_c) / (4 * shape[len(shape) - 1] * load_c))
-    return int(round(optimal_b_size))  # rounds to the nearest integer
+    return int(math.ceil(optimal_b_size))

--- a/devito/tools.py
+++ b/devito/tools.py
@@ -96,10 +96,12 @@ def get_optimal_block_size(shape, load_c, omp):
     cache_s = int(cpuinfo.get_cpu_info()['l2_cache_size'].split(' ')[0])
 
     if omp:
-        thread_c = os.getenv("OMP_NUM_THREADS", cpuinfo.get_cpu_info()['count'])
+        thread_c = int(os.getenv("OMP_NUM_THREADS", cpuinfo.get_cpu_info()['count']))
     else:
         thread_c = 1
 
-    optimal_b_size = math.sqrt(
-        ((1000 * cache_s) / thread_c) / (4 * shape[len(shape) - 1] * load_c))
+    optimal_b_size = max(
+        math.sqrt(
+            float((1000 * cache_s) / thread_c) / (4 * shape[len(shape) - 1] * load_c)
+        ), 1)
     return int(math.ceil(optimal_b_size))

--- a/devito/tools.py
+++ b/devito/tools.py
@@ -1,5 +1,6 @@
 import ctypes
 import math
+import os
 
 import cpuinfo
 import numpy as np
@@ -77,23 +78,28 @@ def aligned(a, alignment=16):
     return aa
 
 
-def get_optimal_block_size(shape, load_c):
+def get_optimal_block_size(shape, load_c, omp):
     """Gets optimal block size based on architecture
 
     :param shape: list - shape of the data buffer
     :param load_c: int - load count
+    :param omp: True if OpenMP is on, else False
     :return: optimal block size
 
     Assuming no prefetching, square block will give the most cache reuse.
-    We then take the cache/core divide by the size of the inner most dimension in which
+    We then take the cache/threads divide by the size of the inner most dimension in which
     we do not block. This gives us the X*Y block space, of which we take the square root
      to get the size of our blocks.
 
-    ((C size / cores) / (4 * length inner most * kernel loads)
+    ((C size / threads) / (4 * length inner most * kernel loads)
     """
-    cache_s = int(cpuinfo.get_cpu_info()['l2_cache_size'].split(' ')[0])  # cache size
-    core_c = cpuinfo.get_cpu_info()['count']  # number of cores
+    cache_s = int(cpuinfo.get_cpu_info()['l2_cache_size'].split(' ')[0])
+
+    if omp:
+        thread_c = os.getenv("OMP_NUM_THREADS", cpuinfo.get_cpu_info()['count'])
+    else:
+        thread_c = 1
 
     optimal_b_size = math.sqrt(
-        ((1000 * cache_s) / core_c) / (4 * shape[len(shape) - 1] * load_c))
+        ((1000 * cache_s) / thread_c) / (4 * shape[len(shape) - 1] * load_c))
     return int(math.ceil(optimal_b_size))

--- a/examples/TTI_codegen.py
+++ b/examples/TTI_codegen.py
@@ -3,6 +3,7 @@ from __future__ import print_function
 
 import numpy as np
 
+from devito.at_controller import AutoTuner
 from examples.tti_operators import *
 
 
@@ -62,11 +63,20 @@ class TTI_cg:
                               dtype=self.dtype, nbpml=nbpml)
         self.src.data[:] = data.get_source()[:, np.newaxis]
 
-    def Forward(self, save=False, cse=True, cache_blocking=None):
+    def Forward(self, save=False, cse=True, auto_tuning=False):
         fw = ForwardOperator(self.model, self.src, self.damp, self.data,
                              time_order=self.t_order, spc_order=self.s_order,
-                             profile=True, save=save, cse=cse,
-                             cache_blocking=cache_blocking)
+                             profile=True, save=save, cse=cse)
+
+        if auto_tuning:
+            fw_new = ForwardOperator(self.model, self.src, self.damp, self.data,
+                                     time_order=self.t_order, spc_order=self.s_order,
+                                     save=save, cse=cse)
+
+            at = AutoTuner(fw_new)
+            at.auto_tune_blocks(self.s_order + 1, self.s_order * 4 + 2)
+            fw.propagator.cache_blocking = at.block_size
+
         u, v, rec = fw.apply()
         return (rec.data, u.data, v.data,
                 fw.propagator.gflops, fw.propagator.oi)

--- a/examples/TTI_codegen.py
+++ b/examples/TTI_codegen.py
@@ -76,7 +76,7 @@ class TTI_cg:
                                      profile=True, save=save, cse=cse, compiler=compiler)
 
             at = AutoTuner(fw_new)
-            at.auto_tune_blocks(self.s_order + 1, self.s_order * 4 + 2)
+            at.auto_tune_blocks(3, 30)
             fw.propagator.cache_blocking = at.block_size
 
         u, v, rec = fw.apply()

--- a/examples/TTI_codegen.py
+++ b/examples/TTI_codegen.py
@@ -63,15 +63,15 @@ class TTI_cg:
                               dtype=self.dtype, nbpml=nbpml)
         self.src.data[:] = data.get_source()[:, np.newaxis]
 
-    def Forward(self, save=False, cse=True, auto_tuning=False):
+    def Forward(self, save=False, cse=True, auto_tuning=False, compiler=None):
         fw = ForwardOperator(self.model, self.src, self.damp, self.data,
                              time_order=self.t_order, spc_order=self.s_order,
-                             profile=True, save=save, cse=cse)
+                             profile=True, save=save, cse=cse, compiler=compiler)
 
         if auto_tuning:
             fw_new = ForwardOperator(self.model, self.src, self.damp, self.data,
                                      time_order=self.t_order, spc_order=self.s_order,
-                                     save=save, cse=cse)
+                                     profile=True, save=save, cse=cse, compiler=compiler)
 
             at = AutoTuner(fw_new)
             at.auto_tune_blocks(self.s_order + 1, self.s_order * 4 + 2)

--- a/examples/TTI_codegen.py
+++ b/examples/TTI_codegen.py
@@ -63,10 +63,12 @@ class TTI_cg:
                               dtype=self.dtype, nbpml=nbpml)
         self.src.data[:] = data.get_source()[:, np.newaxis]
 
-    def Forward(self, save=False, cse=True, auto_tuning=False, compiler=None):
+    def Forward(self, save=False, cse=True, auto_tuning=False,
+                cache_blocking=None, compiler=None):
         fw = ForwardOperator(self.model, self.src, self.damp, self.data,
                              time_order=self.t_order, spc_order=self.s_order,
-                             profile=True, save=save, cse=cse, compiler=compiler)
+                             profile=True, save=save, cache_blocking=cache_blocking,
+                             cse=cse, compiler=compiler)
 
         if auto_tuning:
             fw_new = ForwardOperator(self.model, self.src, self.damp, self.data,

--- a/examples/TTI_codegen.py
+++ b/examples/TTI_codegen.py
@@ -76,7 +76,7 @@ class TTI_cg:
                                      profile=True, save=save, cse=cse, compiler=compiler)
 
             at = AutoTuner(fw_new)
-            at.auto_tune_blocks(3, 30)
+            at.auto_tune_blocks(self.s_order + 1, self.s_order * 4 + 2)
             fw.propagator.cache_blocking = at.block_size
 
         u, v, rec = fw.apply()

--- a/examples/TTI_codegen.py
+++ b/examples/TTI_codegen.py
@@ -62,12 +62,14 @@ class TTI_cg:
                               dtype=self.dtype, nbpml=nbpml)
         self.src.data[:] = data.get_source()[:, np.newaxis]
 
-    def Forward(self, save=False, cache_blocking=None):
+    def Forward(self, save=False, cse=True, cache_blocking=None):
         fw = ForwardOperator(self.model, self.src, self.damp, self.data,
                              time_order=self.t_order, spc_order=self.s_order,
-                             save=save, cache_blocking=cache_blocking)
+                             profile=True, save=save, cse=cse,
+                             cache_blocking=cache_blocking)
         u, v, rec = fw.apply()
-        return (rec.data, u.data, v.data)
+        return (rec.data, u.data, v.data,
+                fw.propagator.gflops, fw.propagator.oi)
 
     def Adjoint(self, rec, cache_blocking=None):
         adj = AdjointOperator(self.model, self.damp, self.data, rec,

--- a/examples/tti_benchmark.py
+++ b/examples/tti_benchmark.py
@@ -35,15 +35,18 @@ if __name__ == "__main__":
     parser.add_argument("-o", "--omp", action="store_true",
                         help="Enable OpenMP")
     parser.add_argument("-d", "--dimensions", nargs=3, default=[50, 50, 50], type=int,
-                        help="Dimension of the grid", metavar=("dim1", "dim2", "dim3"))
+                        help="Dimensions of the grid", metavar=("dim1", "dim2", "dim3"))
     parser.add_argument("-s", "--spacing", nargs=2, default=[20, 20], type=int,
-                        help="Spacing on the grid", metavar=("spc1", "spc2"))
+                        help="Spacing between grid sizes in meters",
+                        metavar=("spc1", "spc2"))
+    parser.add_argument("-n", "--nbpml", default=10, type=int,
+                        help="Number of PML points")
     parser.add_argument("-so", "--space_order", nargs="*", default=[2],
                         type=int, help="Space order of the simulation")
     parser.add_argument("-to", "--time_order", nargs="*", default=[2],
                         type=int, help="Time order of the simulation")
     parser.add_argument("-t", "--tn", default=250,
-                        type=int, help="Number of timesteps")
+                        type=int, help="End time of the simulation in ms")
     parser.add_argument("-c", "--cse", action="store_true",
                         help=("Benchmark with CSE on and off. " +
                               "Enables CSE when execmode is run"))

--- a/examples/tti_benchmark.py
+++ b/examples/tti_benchmark.py
@@ -33,30 +33,34 @@ if __name__ == "__main__":
                         default=environ.get("DEVITO_ARCH", "gnu"),
                         choices=compiler_registry.keys(),
                         help="Compiler/architecture to use. Defaults to DEVITO_ARCH")
-    parser.add_argument("-o", "--omp", action="store_true",
-                        help="Enable OpenMP")
-    parser.add_argument("-d", "--dimensions", nargs=3, default=[50, 50, 50], type=int,
-                        help="Dimensions of the grid", metavar=("dim1", "dim2", "dim3"))
-    parser.add_argument("-s", "--spacing", nargs=2, default=[20, 20], type=int,
-                        help="Spacing between grid sizes in meters",
-                        metavar=("spc1", "spc2"))
-    parser.add_argument("-n", "--nbpml", default=10, type=int,
-                        help="Number of PML points")
-    parser.add_argument("-so", "--space_order", nargs="*", default=[2],
-                        type=int, help="Space order of the simulation")
-    parser.add_argument("-to", "--time_order", nargs="*", default=[2],
-                        type=int, help="Time order of the simulation")
-    parser.add_argument("-t", "--tn", default=250,
-                        type=int, help="End time of the simulation in ms")
-    parser.add_argument("-c", "--cse", action="store_true",
-                        help=("Benchmark with CSE on and off. " +
-                              "Enables CSE when execmode is run"))
-    parser.add_argument("-a", "--auto_tuning", action="store_true",
+    simulation = parser.add_argument_group("Simulation")
+    simulation.add_argument("-o", "--omp", action="store_true",
+                            help="Enable OpenMP")
+    simulation.add_argument("-d", "--dimensions", nargs=3, default=[50, 50, 50],
+                            type=int, help="Dimensions of the grid",
+                            metavar=("dim1", "dim2", "dim3"))
+    simulation.add_argument("-s", "--spacing", nargs=2, default=[20, 20], type=int,
+                            help="Spacing between grid sizes in meters",
+                            metavar=("spc1", "spc2"))
+    simulation.add_argument("-n", "--nbpml", default=10, type=int,
+                            help="Number of PML points")
+    simulation.add_argument("-so", "--space_order", nargs="*", default=[2],
+                            type=int, help="Space order of the simulation")
+    simulation.add_argument("-to", "--time_order", nargs="*", default=[2],
+                            type=int, help="Time order of the simulation")
+    simulation.add_argument("-t", "--tn", default=250,
+                            type=int, help="End time of the simulation in ms")
+
+    devito = parser.add_argument_group("Devito")
+    devito.add_argument("--no_cse", action="store_true",
+                        help="Disables CSE")
+    devito.add_argument("-a", "--auto_tuning", action="store_true",
                         help=("Benchmark with auto tuning on and off. " +
                               "Enables auto tuning when execmode is run"))
-    parser.add_argument("-cb", "--cache_blocking", nargs=2, type=int,
+    devito.add_argument("-cb", "--cache_blocking", nargs=2, type=int,
                         default=None, metavar=("blockDim1", "blockDim2"),
                         help="Uses provided block sizes when AT is off")
+
     benchmarking = parser.add_argument_group("Benchmarking")
     benchmarking.add_argument("-r", "--resultsdir", default="results",
                               help="Directory containing results")
@@ -76,11 +80,15 @@ if __name__ == "__main__":
     del parameters["max_bw"]
     del parameters["max_flops"]
     del parameters["omp"]
+    del parameters["no_cse"]
 
     parameters["dimensions"] = tuple(parameters["dimensions"])
     parameters["spacing"] = tuple(parameters["spacing"])
+
     if parameters["cache_blocking"]:
         parameters["cache_blocking"] = parameters["cache_blocking"] + [None]
+    if args.no_cse:
+        parameters["cse"] = False
 
     parameters["compiler"] = compiler_registry[args.compiler](openmp=args.omp)
 
@@ -95,8 +103,6 @@ if __name__ == "__main__":
 
         if parameters["auto_tuning"]:
             parameters["auto_tuning"] = [True, False]
-        if parameters["cse"]:
-            parameters["cse"] = [True, False]
 
     if args.execmode == "test":
         values_sweep = [v if isinstance(v, list) else [v] for v in parameters.values()]
@@ -152,7 +158,7 @@ if __name__ == "__main__":
         for key, gflops in gflops.items():
             oi_value = oi[key]
             key = dict(key)
-            label = "TTI, CSE: %s, AT: %s" % (key["cse"], key["auto_tuning"])
+            label = "TTI, AT: %s" % (key["auto_tuning"])
             mflops_dict[label] = gflops * 1000
             oi_dict[label] = oi_value
 

--- a/examples/tti_benchmark.py
+++ b/examples/tti_benchmark.py
@@ -1,4 +1,4 @@
-from argparse import ArgumentParser
+from argparse import ArgumentParser, RawDescriptionHelpFormatter
 
 from devito.compiler import compiler_registry
 from tti_example import run
@@ -12,20 +12,28 @@ except:
 
 
 if __name__ == "__main__":
-    description = "Example script for TTI."
-    parser = ArgumentParser(description=description)
+    description = ("Benchmarking script for TTI example.\n\n" +
+                   "Exec modes:\n" +
+                   "\trun:   executes tti_example.py once " +
+                   "with the provided parameters\n" +
+                   "\tbench: runs a benchmark of tti_example.py\n" +
+                   "\tplot:  plots a roofline plot using the results from the benchmark\n"
+                   )
+    parser = ArgumentParser(description=description,
+                            formatter_class=RawDescriptionHelpFormatter)
 
     parser.add_argument(dest="execmode", nargs="?", default="run",
                         choices=["run", "bench", "plot"],
-                        help="Script mode. Either 'run', 'bench' or 'plot'")
+                        help="Exec modes")
     parser.add_argument(dest="compiler", nargs="?", default="gnu",
-                        choices=compiler_registry.keys())
+                        choices=compiler_registry.keys(),
+                        help="Compiler/architecture to use. Defaults to 'gnu'")
     parser.add_argument("-o", "--omp", action="store_true",
                         help="Enable OpenMP")
     parser.add_argument("-d", "--dimensions", nargs=3, default=[50, 50, 50],
-                        help="Dimension of the grid")
+                        help="Dimension of the grid", metavar=("dim1", "dim2", "dim3"))
     parser.add_argument("-s", "--spacing", nargs=2, default=[20.0, 20.0],
-                        help="Spacing on the grid")
+                        help="Spacing on the grid", metavar=("spc1", "spc2"))
     parser.add_argument("-t", "--tn", default=250,
                         type=int, help="Number of timesteps")
     parser.add_argument("-c", "--cse", action="store_true",
@@ -35,13 +43,17 @@ if __name__ == "__main__":
                         help=("Benchmark with auto tuning on and off. " +
                               "Enables auto tuning when execmode is run"))
     parser.add_argument("-cb", "--cache_blocking", nargs=2, type=int,
-                        default=None, help="Uses provided block sizes when AT is off")
-    parser.add_argument("-r", "--resultsdir", default="results",
-                        help="Directory containing results")
-    parser.add_argument("-p", "--plotdir", default="plots",
-                        help="Directory containing plots")
-    parser.add_argument("--max_bw", type=float, help="Maximum bandwith of the system")
-    parser.add_argument("--max_flops", type=float, help="Maximum FLOPS of the system")
+                        default=None, metavar=("blockDim1", "blockDim2"),
+                        help="Uses provided block sizes when AT is off")
+    benchmarking = parser.add_argument_group("Benchmarking")
+    benchmarking.add_argument("-r", "--resultsdir", default="results",
+                              help="Directory containing results")
+
+    plotting = parser.add_argument_group("Plotting")
+    plotting.add_argument("-p", "--plotdir", default="plots",
+                          help="Directory containing plots")
+    plotting.add_argument("--max_bw", type=float, help="Maximum bandwith of the system")
+    plotting.add_argument("--max_flops", type=float, help="Maximum FLOPS of the system")
 
     args = parser.parse_args()
 

--- a/examples/tti_benchmark.py
+++ b/examples/tti_benchmark.py
@@ -1,4 +1,5 @@
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
+from os import environ
 
 import numpy as np
 
@@ -28,9 +29,10 @@ if __name__ == "__main__":
     parser.add_argument(dest="execmode", nargs="?", default="run",
                         choices=["run", "test", "bench", "plot"],
                         help="Exec modes")
-    parser.add_argument(dest="compiler", nargs="?", default="gnu",
+    parser.add_argument(dest="compiler", nargs="?",
+                        default=environ.get("DEVITO_ARCH", "gnu"),
                         choices=compiler_registry.keys(),
-                        help="Compiler/architecture to use. Defaults to 'gnu'")
+                        help="Compiler/architecture to use. Defaults to DEVITO_ARCH")
     parser.add_argument("-o", "--omp", action="store_true",
                         help="Enable OpenMP")
     parser.add_argument("-d", "--dimensions", nargs=3, default=[50, 50, 50],
@@ -72,6 +74,7 @@ if __name__ == "__main__":
     parameters["spacing"] = tuple(parameters["spacing"])
     if parameters["cache_blocking"]:
         parameters["cache_blocking"] = parameters["cache_blocking"] + [None]
+
     parameters["compiler"] = compiler_registry[args.compiler](openmp=args.omp)
 
     if args.execmode == "run":

--- a/examples/tti_benchmark.py
+++ b/examples/tti_benchmark.py
@@ -4,6 +4,7 @@ from os import environ
 
 import numpy as np
 
+from devito import clear_cache
 from devito.compiler import compiler_registry
 from tti_example import run
 try:
@@ -115,6 +116,7 @@ if __name__ == "__main__":
 
         for params in params_sweep:
             _, _, rec, u, v = run(**params)
+            clear_cache()
 
             if last_rec is not None:
                 np.isclose(rec, last_rec)
@@ -140,6 +142,8 @@ if __name__ == "__main__":
 
                 self.register(gflops["kernel"], measure="gflops")
                 self.register(oi["kernel"], measure="oi")
+
+                clear_cache()
 
         bench = Benchmark(name="TTI", resultsdir=args.resultsdir, parameters=parameters)
         bench.execute(TTIExecutor(), warmups=0)

--- a/examples/tti_benchmark.py
+++ b/examples/tti_benchmark.py
@@ -1,6 +1,5 @@
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from os import environ
-import sys
 
 import numpy as np
 
@@ -39,6 +38,10 @@ if __name__ == "__main__":
                         help="Dimension of the grid", metavar=("dim1", "dim2", "dim3"))
     parser.add_argument("-s", "--spacing", nargs=2, default=[20, 20], type=int,
                         help="Spacing on the grid", metavar=("spc1", "spc2"))
+    parser.add_argument("-so", "--space_order", nargs="*", default=[2],
+                        type=int, help="Space order of the simulation")
+    parser.add_argument("-to", "--time_order", nargs="*", default=[2],
+                        type=int, help="Time order of the simulation")
     parser.add_argument("-t", "--tn", default=250,
                         type=int, help="Number of timesteps")
     parser.add_argument("-c", "--cse", action="store_true",
@@ -78,6 +81,8 @@ if __name__ == "__main__":
     parameters["compiler"] = compiler_registry[args.compiler](openmp=args.omp)
 
     if args.execmode == "run":
+        parameters["space_order"] = parameters["space_order"][0]
+        parameters["time_order"] = parameters["time_order"][0]
         run(**parameters)
     else:
         if Benchmark is None:
@@ -150,8 +155,10 @@ if __name__ == "__main__":
             mflops_dict[label] = gflops * 1000
             oi_dict[label] = oi_value
 
-        name = "TTI %s dimensions: %s - spacing: %s.pdf" % \
-            (args.compiler, parameters["dimensions"], parameters["spacing"])
+        name = ("TTI %s dimensions: %s - spacing: %s -"
+                " space order: %s - time order: %s.pdf") % \
+            (args.compiler, parameters["dimensions"], parameters["spacing"],
+             parameters["space_order"], parameters["time_order"])
         name = name.replace(" ", "_")
 
         plotter = Plotter()

--- a/examples/tti_benchmark.py
+++ b/examples/tti_benchmark.py
@@ -1,0 +1,117 @@
+from argparse import ArgumentParser
+
+from devito.compiler import compiler_registry
+from tti_example import run
+
+try:
+    from opescibench import Benchmark, Executor, Plotter
+except:
+    Benchmark = None
+    Executor = None
+    Plotter = None
+
+
+if __name__ == "__main__":
+    description = "Example script for TTI."
+    parser = ArgumentParser(description=description)
+
+    parser.add_argument(dest="execmode", nargs="?", default="run",
+                        choices=["run", "bench", "plot"],
+                        help="Script mode. Either 'run', 'bench' or 'plot'")
+    parser.add_argument(dest="compiler", nargs="?", default="gnu",
+                        choices=["gnu", "intel", "clang", "mic", "knl"])
+    parser.add_argument("-o", "--omp", action="store_true",
+                        help="Enable OpenMP")
+    parser.add_argument("-d", "--dimensions", nargs=3, default=[50, 50, 50],
+                        help="Dimension of the grid")
+    parser.add_argument("-s", "--spacing", nargs=2, default=[20.0, 20.0],
+                        help="Spacing on the grid")
+    parser.add_argument("-t", "--tn", default=250,
+                        type=int, help="Number of timesteps")
+    parser.add_argument("-c", "--cse", action="store_true",
+                        help=("Benchmark with CSE on and off. " +
+                              "Enables CSE when execmode is run"))
+    parser.add_argument("-a", "--auto_tuning", action="store_true",
+                        help=("Benchmark with auto tuning on and off. " +
+                              "Enables auto tuning when execmode is run"))
+    parser.add_argument("-cb", "--cache_blocking", nargs=2, type=int,
+                        default=None, help="Uses provided block sizes when AT is off")
+    parser.add_argument("-r", "--resultsdir", default="results",
+                        help="Directory containing results")
+    parser.add_argument("-p", "--plotdir", default="plots",
+                        help="Directory containing plots")
+    parser.add_argument("--max_bw", type=float, help="Maximum bandwith of the system")
+    parser.add_argument("--max_flops", type=float, help="Maximum FLOPS of the system")
+
+    args = parser.parse_args()
+
+    parameters = vars(args).copy()
+    del parameters["execmode"]
+    del parameters["resultsdir"]
+    del parameters["plotdir"]
+    del parameters["max_bw"]
+    del parameters["max_flops"]
+    del parameters["omp"]
+
+    parameters["dimensions"] = tuple(parameters["dimensions"])
+    parameters["spacing"] = tuple(parameters["spacing"])
+    if parameters["cache_blocking"]:
+        parameters["cache_blocking"] = parameters["cache_blocking"] + [None]
+    parameters["compiler"] = compiler_registry[args.compiler](openmp=args.omp)
+
+    if args.execmode == "run":
+        run(**parameters)
+
+    if args.execmode == "bench":
+        if Benchmark is None:
+            raise ImportError("Could not find opescibench utility package.\n"
+                              "Please install from https://github.com/opesci/opescibench")
+
+        if parameters["auto_tuning"]:
+            parameters["auto_tuning"] = [True, False]
+
+        if parameters["cse"]:
+            parameters["cse"] = [True, False]
+
+        class TTIExecutor(Executor):
+            """Executor class that defines how to run TTI benchmark"""
+
+            def run(self, *args, **kwargs):
+                gflops, oi = run(*args, **kwargs)
+
+                self.register(gflops["kernel"], measure="gflops")
+                self.register(oi["kernel"], measure="oi")
+
+        bench = Benchmark(name="TTI", resultsdir=args.resultsdir, parameters=parameters)
+        bench.execute(TTIExecutor(), warmups=0)
+        bench.save()
+
+    if args.execmode == "plot":
+        if parameters["auto_tuning"]:
+            parameters["auto_tuning"] = [True, False]
+
+        if parameters["cse"]:
+            parameters["cse"] = [True, False]
+
+        bench = Benchmark(name="TTI", resultsdir=args.resultsdir, parameters=parameters)
+        bench.load()
+
+        oi_dict = {}
+        mflops_dict = {}
+
+        gflops = bench.lookup(params=parameters, measure="gflops")
+        oi = bench.lookup(params=parameters, measure="oi")
+
+        for key, gflops in gflops.items():
+            oi_value = oi[key]
+            key = dict(key)
+            label = "TTI, CSE: %s, AT: %s" % (key["cse"], key["auto_tuning"])
+            mflops_dict[label] = gflops * 1000
+            oi_dict[label] = oi_value
+
+        name = "TTI - Dimensions: %s, Spacing: %s.pdf" % \
+            (parameters["dimensions"], parameters["spacing"])
+
+        plotter = Plotter()
+        plotter.plot_roofline(
+            name, mflops_dict, oi_dict, args.max_bw, args.max_flops)

--- a/examples/tti_benchmark.py
+++ b/examples/tti_benchmark.py
@@ -158,7 +158,9 @@ if __name__ == "__main__":
         for key, gflops in gflops.items():
             oi_value = oi[key]
             key = dict(key)
-            label = "TTI, AT: %s" % (key["auto_tuning"])
+            label = "TTI, AT: %s, SO: %s, TO: %s" % (
+                key["auto_tuning"], key["space_order"], key["time_order"]
+            )
             mflops_dict[label] = gflops * 1000
             oi_dict[label] = oi_value
 

--- a/examples/tti_benchmark.py
+++ b/examples/tti_benchmark.py
@@ -1,11 +1,11 @@
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from os import environ
+import sys
 
 import numpy as np
 
 from devito.compiler import compiler_registry
 from tti_example import run
-
 try:
     from opescibench import Benchmark, Executor, Plotter
 except:
@@ -35,9 +35,9 @@ if __name__ == "__main__":
                         help="Compiler/architecture to use. Defaults to DEVITO_ARCH")
     parser.add_argument("-o", "--omp", action="store_true",
                         help="Enable OpenMP")
-    parser.add_argument("-d", "--dimensions", nargs=3, default=[50, 50, 50],
+    parser.add_argument("-d", "--dimensions", nargs=3, default=[50, 50, 50], type=int,
                         help="Dimension of the grid", metavar=("dim1", "dim2", "dim3"))
-    parser.add_argument("-s", "--spacing", nargs=2, default=[20.0, 20.0],
+    parser.add_argument("-s", "--spacing", nargs=2, default=[20, 20], type=int,
                         help="Spacing on the grid", metavar=("spc1", "spc2"))
     parser.add_argument("-t", "--tn", default=250,
                         type=int, help="Number of timesteps")

--- a/examples/tti_benchmark.py
+++ b/examples/tti_benchmark.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
                         choices=["run", "bench", "plot"],
                         help="Script mode. Either 'run', 'bench' or 'plot'")
     parser.add_argument(dest="compiler", nargs="?", default="gnu",
-                        choices=["gnu", "intel", "clang", "mic", "knl"])
+                        choices=compiler_registry.keys())
     parser.add_argument("-o", "--omp", action="store_true",
                         help="Enable OpenMP")
     parser.add_argument("-d", "--dimensions", nargs=3, default=[50, 50, 50],

--- a/examples/tti_benchmark.py
+++ b/examples/tti_benchmark.py
@@ -109,8 +109,9 @@ if __name__ == "__main__":
             mflops_dict[label] = gflops * 1000
             oi_dict[label] = oi_value
 
-        name = "TTI - Dimensions: %s, Spacing: %s.pdf" % \
-            (parameters["dimensions"], parameters["spacing"])
+        name = "TTI %s dimensions: %s - spacing: %s.pdf" % \
+            (args.compiler, parameters["dimensions"], parameters["spacing"])
+        name = name.replace(" ", "_")
 
         plotter = Plotter()
         plotter.plot_roofline(

--- a/examples/tti_example.py
+++ b/examples/tti_example.py
@@ -1,37 +1,16 @@
+from argparse import ArgumentParser
+
 import numpy as np
 
 from containers import IGrid, IShot
 from TTI_codegen import TTI_cg
 
-dimensions = (50, 50, 50)
-model = IGrid()
-model.shape = dimensions
-origin = (0., 0.)
-spacing = (20.0, 20.0)
-dtype = np.float32
-t_order = 2
-spc_order = 2
-
-# True velocity
-true_vp = np.ones(dimensions) + 1.0
-true_vp[:, :, int(dimensions[0] / 3):int(2*dimensions[0]/3)] = 3.0
-true_vp[:, :, int(2*dimensions[0] / 3):int(dimensions[0])] = 4.0
-
-model.create_model(
-    origin, spacing, true_vp, .3*np.ones(dimensions), .2*np.ones(dimensions),
-    np.pi/5*np.ones(dimensions), np.pi/5*np.ones(dimensions))
-
-# Define seismic data.
-data = IShot()
-
-f0 = .010
-dt = model.get_critical_dt()
-t0 = 0.0
-tn = 250.0
-nt = int(1+(tn-t0)/dt)
-h = model.get_spacing()
-data.reinterpolate(dt)
-# Set up the source as Ricker wavelet for f0
+try:
+    from opescibench import Benchmark, Executor, Plotter
+except:
+    Benchmark = None
+    Executor = None
+    Plotter = None
 
 
 def source(t, f0):
@@ -39,21 +18,114 @@ def source(t, f0):
 
     return (1-2.*r**2)*np.exp(-r**2)
 
-time_series = source(np.linspace(t0, tn, nt), f0)
-location = (origin[0] + dimensions[0] * spacing[0] * 0.5,
-            origin[1] + dimensions[1] * spacing[1] * 0.5,
-            origin[1] + 2 * spacing[1])
-data.set_source(time_series, dt, location)
-receiver_coords = np.zeros((101, 3))
-receiver_coords[:, 0] = np.linspace(50, 950, num=101)
-receiver_coords[:, 1] = 500
-receiver_coords[:, 2] = location[2]
-data.set_receiver_pos(receiver_coords)
-data.set_shape(nt, 101)
 
-TTI = TTI_cg(model, data, None, t_order=2, s_order=2, nbpml=10)
-(rec, u, v) = TTI.Forward()
+def run(dimensions=(50, 50, 50), spacing=(20.0, 20.0),
+        tn=250.0, cse=True, cache_blocking=None):
+    model = IGrid()
+    model.shape = dimensions
+    origin = (0., 0.)
+    t_order = 2
+    spc_order = 2
 
-# recf = open('RecTTI','w')
-# recf.write(rec.data)
-# recf.close()
+    # True velocity
+    true_vp = np.ones(dimensions) + 1.0
+    true_vp[:, :, int(dimensions[0] / 3):int(2*dimensions[0]/3)] = 3.0
+    true_vp[:, :, int(2*dimensions[0] / 3):int(dimensions[0])] = 4.0
+
+    model.create_model(
+        origin, spacing, true_vp, .3*np.ones(dimensions), .2*np.ones(dimensions),
+        np.pi/5*np.ones(dimensions), np.pi/5*np.ones(dimensions))
+
+    # Define seismic data.
+    data = IShot()
+
+    f0 = .010
+    dt = model.get_critical_dt()
+    t0 = 0.0
+    nt = int(1+(tn-t0)/dt)
+    data.reinterpolate(dt)
+    # Set up the source as Ricker wavelet for f0
+
+    time_series = source(np.linspace(t0, tn, nt), f0)
+    location = (origin[0] + dimensions[0] * spacing[0] * 0.5,
+                origin[1] + dimensions[1] * spacing[1] * 0.5,
+                origin[1] + 2 * spacing[1])
+    data.set_source(time_series, dt, location)
+    receiver_coords = np.zeros((101, 3))
+    receiver_coords[:, 0] = np.linspace(50, 950, num=101)
+    receiver_coords[:, 1] = 500
+    receiver_coords[:, 2] = location[2]
+    data.set_receiver_pos(receiver_coords)
+    data.set_shape(nt, 101)
+
+    TTI = TTI_cg(model, data, None, t_order=t_order, s_order=spc_order, nbpml=10)
+    rec, u, v, gflops, oi = TTI.Forward(cse=cse, cache_blocking=cache_blocking)
+    return gflops, oi
+
+if __name__ == "__main__":
+    description = "Example script for TTI."
+    parser = ArgumentParser(description=description)
+
+    parser.add_argument(dest="execmode", nargs="?", default="run",
+                        choices=["run", "bench", "plot"],
+                        help="Script mode. Either 'run', 'bench' or 'plot'")
+    parser.add_argument("-d", "--dimensions", nargs=3, default=[50, 50, 50],
+                        help="Dimension of the grid")
+    parser.add_argument("-s", "--spacing", nargs=2, default=[20.0, 20.0],
+                        help="Spacing on the grid")
+    parser.add_argument("-t", "--tn", default=250,
+                        type=int, help="Number of timesteps")
+    parser.add_argument("-c", "--cse", action="store_true",
+                        help="Enables common subexpression elimination")
+    parser.add_argument("-C", "--cache_blocking", nargs="*", type=int,
+                        help="Define block sizes for cache blocking")
+    parser.add_argument("-i", "--resultsdir", default="results",
+                        help="Directory containing results")
+    parser.add_argument("-o", "--plotdir", default="plots",
+                        help="Directory containing plots")
+    parser.add_argument("--max_bw", type=float, help="Maximum bandwith of the system")
+    parser.add_argument("--max_flops", type=float, help="Maximum FLOPS of the system")
+
+    args = parser.parse_args()
+
+    parameters = vars(args).copy()
+    del parameters["execmode"]
+    del parameters["resultsdir"]
+    del parameters["plotdir"]
+    del parameters["max_bw"]
+    del parameters["max_flops"]
+
+    parameters["dimensions"] = tuple(parameters["dimensions"])
+    parameters["spacing"] = tuple(parameters["spacing"])
+
+    if args.execmode == "run":
+        run(parameters)
+
+    if args.execmode == "bench":
+        if Benchmark is None:
+            raise ImportError("Could not find opescibench utility package.\n"
+                              "Please install from https://github.com/opesci/opescibench")
+
+        class TTIExecutor(Executor):
+            """Executor class that defines how to run TTI benchmark"""
+
+            def run(self, *args, **kwargs):
+                gflops, oi = run(*args, **kwargs)
+
+                self.register(gflops["kernel"], measure="gflops")
+                self.register(oi["kernel"], measure="oi")
+
+        bench = Benchmark(name="TTI", resultsdir=args.resultsdir, parameters=parameters)
+        bench.execute(TTIExecutor(), warmups=0)
+        bench.save()
+
+    if args.execmode == "plot":
+        bench = Benchmark(name="TTI", resultsdir=args.resultsdir, parameters=parameters)
+        bench.load()
+
+        mflops = bench.lookup(measure="gflops") * 1000
+        oi = bench.lookup(measure="oi")
+
+        plotter = Plotter()
+        plotter.plot_roofline(
+            "TTI.pdf", {"TTI": mflops}, {"TTI": oi}, args.max_bw, args.max_flops)

--- a/examples/tti_example.py
+++ b/examples/tti_example.py
@@ -98,8 +98,10 @@ if __name__ == "__main__":
     parameters["dimensions"] = tuple(parameters["dimensions"])
     parameters["spacing"] = tuple(parameters["spacing"])
 
+    print parameters
+
     if args.execmode == "run":
-        run(parameters)
+        run(**parameters)
 
     if args.execmode == "bench":
         if Benchmark is None:

--- a/examples/tti_example.py
+++ b/examples/tti_example.py
@@ -1,17 +1,7 @@
-from argparse import ArgumentParser
-
 import numpy as np
 
 from containers import IGrid, IShot
-from devito.compiler import compiler_registry
 from TTI_codegen import TTI_cg
-
-try:
-    from opescibench import Benchmark, Executor, Plotter
-except:
-    Benchmark = None
-    Executor = None
-    Plotter = None
 
 
 def source(t, f0):
@@ -69,106 +59,4 @@ def run(dimensions=(50, 50, 50), spacing=(20.0, 20.0), tn=250.0,
     return gflops, oi
 
 if __name__ == "__main__":
-    description = "Example script for TTI."
-    parser = ArgumentParser(description=description)
-
-    parser.add_argument(dest="execmode", nargs="?", default="run",
-                        choices=["run", "bench", "plot"],
-                        help="Script mode. Either 'run', 'bench' or 'plot'")
-    parser.add_argument(dest="compiler", nargs="?", default="gnu",
-                        choices=["gnu", "intel", "clang", "mic", "knl"])
-    parser.add_argument("-o", "--omp", action="store_true",
-                        help="Enable OpenMP")
-    parser.add_argument("-d", "--dimensions", nargs=3, default=[50, 50, 50],
-                        help="Dimension of the grid")
-    parser.add_argument("-s", "--spacing", nargs=2, default=[20.0, 20.0],
-                        help="Spacing on the grid")
-    parser.add_argument("-t", "--tn", default=250,
-                        type=int, help="Number of timesteps")
-    parser.add_argument("-c", "--cse", action="store_true",
-                        help=("Benchmark with CSE on and off. " +
-                              "Enables CSE when execmode is run"))
-    parser.add_argument("-a", "--auto_tuning", action="store_true",
-                        help=("Benchmark with auto tuning on and off. " +
-                              "Enables auto tuning when execmode is run"))
-    parser.add_argument("-cb", "--cache_blocking", nargs=2, type=int,
-                        default=None, help="Uses provided block sizes when AT is off")
-    parser.add_argument("-r", "--resultsdir", default="results",
-                        help="Directory containing results")
-    parser.add_argument("-p", "--plotdir", default="plots",
-                        help="Directory containing plots")
-    parser.add_argument("--max_bw", type=float, help="Maximum bandwith of the system")
-    parser.add_argument("--max_flops", type=float, help="Maximum FLOPS of the system")
-
-    args = parser.parse_args()
-
-    parameters = vars(args).copy()
-    del parameters["execmode"]
-    del parameters["resultsdir"]
-    del parameters["plotdir"]
-    del parameters["max_bw"]
-    del parameters["max_flops"]
-    del parameters["omp"]
-
-    parameters["dimensions"] = tuple(parameters["dimensions"])
-    parameters["spacing"] = tuple(parameters["spacing"])
-    if parameters["cache_blocking"]:
-        parameters["cache_blocking"] = parameters["cache_blocking"] + [None]
-    parameters["compiler"] = compiler_registry[args.compiler](openmp=args.omp)
-
-    if args.execmode == "run":
-        run(**parameters)
-
-    if args.execmode == "bench":
-        if Benchmark is None:
-            raise ImportError("Could not find opescibench utility package.\n"
-                              "Please install from https://github.com/opesci/opescibench")
-
-        if parameters["auto_tuning"]:
-            parameters["auto_tuning"] = [True, False]
-
-        if parameters["cse"]:
-            parameters["cse"] = [True, False]
-
-        class TTIExecutor(Executor):
-            """Executor class that defines how to run TTI benchmark"""
-
-            def run(self, *args, **kwargs):
-                gflops, oi = run(*args, **kwargs)
-
-                self.register(gflops["kernel"], measure="gflops")
-                self.register(oi["kernel"], measure="oi")
-
-        bench = Benchmark(name="TTI", resultsdir=args.resultsdir, parameters=parameters)
-        bench.execute(TTIExecutor(), warmups=0)
-        bench.save()
-
-    if args.execmode == "plot":
-        if parameters["auto_tuning"]:
-            parameters["auto_tuning"] = [True, False]
-
-        if parameters["cse"]:
-            parameters["cse"] = [True, False]
-
-        bench = Benchmark(name="TTI", resultsdir=args.resultsdir, parameters=parameters)
-        bench.load()
-
-        oi_dict = {}
-        mflops_dict = {}
-
-        gflops = bench.lookup(params=parameters, measure="gflops")
-        oi = bench.lookup(params=parameters, measure="oi")
-
-        for key, gflops in gflops.items():
-            oi_value = oi[key]
-            key = dict(key)
-            label = "TTI, CSE: %s, AT: %s" % (key["cse"], key["auto_tuning"])
-            mflops_dict[label] = gflops * 1000
-            oi_dict[label] = oi_value
-
-        name = "TTI - Dimensions: %s, Spacing: %s.pdf" % \
-            (parameters["dimensions"], parameters["spacing"])
-
-        plotter = Plotter()
-        plotter.plot_roofline(
-            name, mflops_dict, oi_dict, args.max_bw, args.max_flops)
+    run()

--- a/examples/tti_example.py
+++ b/examples/tti_example.py
@@ -84,9 +84,11 @@ if __name__ == "__main__":
     parser.add_argument("-t", "--tn", default=250,
                         type=int, help="Number of timesteps")
     parser.add_argument("-c", "--cse", action="store_true",
-                        help="Benchmark with CSE on and off")
+                        help=("Benchmark with CSE on and off. " +
+                              "Enables CSE when execmode is run"))
     parser.add_argument("-a", "--auto_tuning", action="store_true",
-                        help="Benchmark with auto tuning on and off")
+                        help=("Benchmark with auto tuning on and off. " +
+                              "Enables auto tuning when execmode is run"))
     parser.add_argument("-r", "--resultsdir", default="results",
                         help="Directory containing results")
     parser.add_argument("-p", "--plotdir", default="plots",
@@ -109,8 +111,6 @@ if __name__ == "__main__":
     parameters["compiler"] = compiler_registry[args.compiler](openmp=args.omp)
 
     if args.execmode == "run":
-        del parameters["auto_tuning"]
-        del parameters["cse"]
         run(**parameters)
 
     if args.execmode == "bench":

--- a/examples/tti_example.py
+++ b/examples/tti_example.py
@@ -11,15 +11,14 @@ def source(t, f0):
 
 
 def run(dimensions=(50, 50, 50), spacing=(20.0, 20.0), tn=250.0,
-        cse=True, auto_tuning=False, compiler=None, cache_blocking=None):
+        time_order=2, space_order=2, cse=True, auto_tuning=False,
+        compiler=None, cache_blocking=None):
     if auto_tuning:
         cache_blocking = None
 
     model = IGrid()
     model.shape = dimensions
     origin = (0., 0.)
-    t_order = 2
-    spc_order = 2
 
     # True velocity
     true_vp = np.ones(dimensions) + 1.0
@@ -52,7 +51,7 @@ def run(dimensions=(50, 50, 50), spacing=(20.0, 20.0), tn=250.0,
     data.set_receiver_pos(receiver_coords)
     data.set_shape(nt, 101)
 
-    TTI = TTI_cg(model, data, None, t_order=t_order, s_order=spc_order, nbpml=10)
+    TTI = TTI_cg(model, data, None, t_order=time_order, s_order=space_order, nbpml=10)
     rec, u, v, gflops, oi = TTI.Forward(
         cse=cse, auto_tuning=auto_tuning, cache_blocking=cache_blocking, compiler=compiler
     )

--- a/examples/tti_example.py
+++ b/examples/tti_example.py
@@ -11,8 +11,8 @@ def source(t, f0):
 
 
 def run(dimensions=(50, 50, 50), spacing=(20.0, 20.0), tn=250.0,
-        time_order=2, space_order=2, cse=True, auto_tuning=False,
-        compiler=None, cache_blocking=None):
+        time_order=2, space_order=2, nbpml=10, cse=True,
+        auto_tuning=False, compiler=None, cache_blocking=None):
     if auto_tuning:
         cache_blocking = None
 
@@ -51,7 +51,7 @@ def run(dimensions=(50, 50, 50), spacing=(20.0, 20.0), tn=250.0,
     data.set_receiver_pos(receiver_coords)
     data.set_shape(nt, 101)
 
-    TTI = TTI_cg(model, data, None, t_order=time_order, s_order=space_order, nbpml=10)
+    TTI = TTI_cg(model, data, None, t_order=time_order, s_order=space_order, nbpml=nbpml)
     rec, u, v, gflops, oi = TTI.Forward(
         cse=cse, auto_tuning=auto_tuning, cache_blocking=cache_blocking, compiler=compiler
     )

--- a/examples/tti_example.py
+++ b/examples/tti_example.py
@@ -56,7 +56,7 @@ def run(dimensions=(50, 50, 50), spacing=(20.0, 20.0), tn=250.0,
     rec, u, v, gflops, oi = TTI.Forward(
         cse=cse, auto_tuning=auto_tuning, cache_blocking=cache_blocking, compiler=compiler
     )
-    return gflops, oi
+    return gflops, oi, rec, u, v
 
 if __name__ == "__main__":
     run()


### PR DESCRIPTION
This is on top of #102 #103 and #106 

Allows users to benchmark and plot `tti_example.py` using `opescibench`.

```
usage: tti_benchmark.py [-h] [-o] [-d DIMENSIONS DIMENSIONS DIMENSIONS]
                      [-s SPACING SPACING] [-t TN] [-c] [-a]
                      [-cb CACHE_BLOCKING CACHE_BLOCKING] [-r RESULTSDIR]
                      [-p PLOTDIR] [--max_bw MAX_BW] [--max_flops MAX_FLOPS]
                      [{run,bench,plot}] [{gnu,intel,clang,mic,knl}]

Example script for TTI.

positional arguments:
  {run,bench,plot}      Script mode. Either 'run', 'bench' or 'plot'
  {gnu,intel,clang,mic,knl}

optional arguments:
  -h, --help            show this help message and exit
  -o, --omp             Enable OpenMP
  -d DIMENSIONS DIMENSIONS DIMENSIONS, --dimensions DIMENSIONS DIMENSIONS DIMENSIONS
                        Dimension of the grid
  -s SPACING SPACING, --spacing SPACING SPACING
                        Spacing on the grid
  -t TN, --tn TN        Number of timesteps
  -c, --cse             Benchmark with CSE on and off. Enables CSE when
                        execmode is run
  -a, --auto_tuning     Benchmark with auto tuning on and off. Enables auto
                        tuning when execmode is run
  -cb CACHE_BLOCKING CACHE_BLOCKING, --cache_blocking CACHE_BLOCKING CACHE_BLOCKING
                        Uses provided block sizes when AT is off
  -r RESULTSDIR, --resultsdir RESULTSDIR
                        Directory containing results
  -p PLOTDIR, --plotdir PLOTDIR
                        Directory containing plots
  --max_bw MAX_BW       Maximum bandwidth of the system
  --max_flops MAX_FLOPS
                        Maximum FLOPS of the system

```

Next step after this would be moving all this code to a different script and have the user select `tti` or `acoustic`, since the two examples take exactly the same parameters.