### PR TITLE
Fixed the inconsistence between shape of spacing and dimensions in acoustic example

### DIFF
--- a/devito/interfaces.py
+++ b/devito/interfaces.py
@@ -363,7 +363,7 @@ class TimeData(DenseData):
 
     @property
     def backward(self):
-        """Symbol for the time-forward state of the function"""
+        """Symbol for the time-backward state of the function"""
         i = int(self.time_order / 2) if self.time_order >= 2 else 1
 
         return self.subs(t, t - i * s)

--- a/examples/acoustic_example.py
+++ b/examples/acoustic_example.py
@@ -5,13 +5,10 @@ from containers import IGrid, IShot
 
 dimensions = (50, 50, 50)
 model = IGrid()
-model0 = IGrid()
-model1 = IGrid()
 model.shape = dimensions
-model0.shape = dimensions
-model1.shape = dimensions
-origin = (0., 0.)
-spacing = (20., 20.)
+origin = (0., 0., 0.)
+# spacing can be generalized to different spacing in each direction
+spacing = (20., 20., 20.)
 dtype = np.float32
 t_order = 2
 spc_order = 2

--- a/examples/tti_benchmark.py
+++ b/examples/tti_benchmark.py
@@ -41,7 +41,7 @@ if __name__ == "__main__":
     simulation.add_argument("-d", "--dimensions", nargs=3, default=[50, 50, 50],
                             type=int, help="Dimensions of the grid",
                             metavar=("dim1", "dim2", "dim3"))
-    simulation.add_argument("-s", "--spacing", nargs=2, default=[20, 20], type=int,
+    simulation.add_argument("-s", "--spacing", nargs=2, default=[20, 20, 20], type=int,
                             help="Spacing between grid sizes in meters",
                             metavar=("spc1", "spc2"))
     simulation.add_argument("-n", "--nbpml", default=10, type=int,

--- a/examples/tti_example.py
+++ b/examples/tti_example.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 from containers import IGrid, IShot
-from TTI_codegen import TTI_cg 
+from TTI_codegen import TTI_cg
 
 
 def source(t, f0):

--- a/examples/tti_example.py
+++ b/examples/tti_example.py
@@ -3,7 +3,6 @@ import numpy as np
 from containers import IGrid, IShot
 from TTI_codegen import TTI_cg
 
-# Set up the source as Ricker wavelet for f0
 def source(t, f0):
     r = (np.pi * f0 * (t - 1./f0))
 

--- a/examples/tti_example.py
+++ b/examples/tti_example.py
@@ -1,7 +1,8 @@
 import numpy as np
 
 from containers import IGrid, IShot
-from TTI_codegen import TTI_cg
+from TTI_codegen import TTI_cg 
+
 
 def source(t, f0):
     r = (np.pi * f0 * (t - 1./f0))

--- a/examples/tti_example.py
+++ b/examples/tti_example.py
@@ -6,8 +6,9 @@ from TTI_codegen import TTI_cg
 dimensions = (50, 50, 50)
 model = IGrid()
 model.shape = dimensions
-origin = (0., 0.)
-spacing = (20.0, 20.0)
+origin = (0., 0., 0.)
+# spacing can be generalized to different spacing in each direction
+spacing = (20.0, 20.0, 20.0)
 dtype = np.float32
 t_order = 2
 spc_order = 2

--- a/examples/tti_example.py
+++ b/examples/tti_example.py
@@ -10,7 +10,7 @@ def source(t, f0):
     return (1-2.*r**2)*np.exp(-r**2)
 
 
-def run(dimensions=(50, 50, 50), spacing=(20.0, 20.0), tn=250.0,
+def run(dimensions=(50, 50, 50), spacing=(20.0, 20.0, 20.0), tn=250.0,
         time_order=2, space_order=2, nbpml=10, cse=True,
         auto_tuning=False, compiler=None, cache_blocking=None):
     if auto_tuning:
@@ -18,7 +18,7 @@ def run(dimensions=(50, 50, 50), spacing=(20.0, 20.0), tn=250.0,
 
     model = IGrid()
     model.shape = dimensions
-    origin = (0., 0.)
+    origin = (0., 0., 0.)
 
     # True velocity
     true_vp = np.ones(dimensions) + 1.0


### PR DESCRIPTION
The origin and spacing should be a three dimensional tuple because it's acoustic wave modelling in 3d. 
