### PR TITLE
Fixed the issue #108 (quality of generated code), reduced the generated file size

### DIFF
--- a/devito/propagator.py
+++ b/devito/propagator.py
@@ -342,11 +342,8 @@ class Propagator(object):
             stencil = self.convert_equality_to_cgen(equality)
             stmts.append(stencil)
 
-        def simplify(dec, stmt):
-            return cgen.Assign(dec.inline(), stmt.rvalue)
-
         for idx, dec in enumerate(decl):
-            stmts[idx] = simplify(dec, stmts[idx])
+            stmts[idx] = cgen.Assign(dec.inline(), stmts[idx].rvalue)
 
         kernel = self._pre_kernel_steps
         kernel += stmts

--- a/devito/propagator.py
+++ b/devito/propagator.py
@@ -342,11 +342,16 @@ class Propagator(object):
             stencil = self.convert_equality_to_cgen(equality)
             stmts.append(stencil)
 
+        nest_decl = lambda dec, stmt: cgen.Assign(dec.__str__()[:-1], stmt.rvalue)
+
+        for idx, dec in enumerate(decl):
+            stmts[idx] = nest_decl(dec, stmts[idx])
+
         kernel = self._pre_kernel_steps
         kernel += stmts
         kernel += self._post_kernel_steps
 
-        return cgen.Block(factors+decl+kernel)
+        return cgen.Block(factors+kernel)
 
     def expr_dtype(self, expr):
         """Gets the resulting dtype of an expression.

--- a/devito/propagator.py
+++ b/devito/propagator.py
@@ -342,10 +342,11 @@ class Propagator(object):
             stencil = self.convert_equality_to_cgen(equality)
             stmts.append(stencil)
 
-        nest_decl = lambda dec, stmt: cgen.Assign(dec.__str__()[:-1], stmt.rvalue)
+        def simplify(dec, stmt):
+            return cgen.Assign(dec.inline(), stmt.rvalue)
 
         for idx, dec in enumerate(decl):
-            stmts[idx] = nest_decl(dec, stmts[idx])
+            stmts[idx] = simplify(dec, stmts[idx])
 
         kernel = self._pre_kernel_steps
         kernel += stmts


### PR DESCRIPTION
Now, All the temps in the generated code is defined in this way:
```c
float temp = ....;
```

instead of : 
```c
float temp;
temp = ....;
```

Reduce the file size. 