### PR TITLE
Auto tuning now done inside Operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,10 +99,5 @@ Note:
 
 Example usage:
 ```
-op = Operator(...)
-at = AutoTuner(op, [True, True, False], <at_report_directory_path>)
-at.auto_tune_blocks(min_block_size, max_block_size)
-
-#using auto tuned block size
-new_op = Operator(..., cache_blocking=at.block_size)
+op = Operator(..., auto_tuning=True, blocked_dims=[True, True, False], at_range=(4, 32))
 ```

--- a/devito/at_controller.py
+++ b/devito/at_controller.py
@@ -2,12 +2,11 @@ import random
 from os import mkdir, path
 
 import logger
-from devito.operator import Operator
 
 
 class AutoTuner(object):
 
-    def __init__(self, op, blocked_dims=None, at_report_dir=None):
+    def __init__(self, op, blocked_dims, at_report_dir=None):
         """Object responsible for auto tuning block sizes.
 
         :param op: Operator object.
@@ -19,15 +18,9 @@ class AutoTuner(object):
         :raises ValueError: if operator is not of Operator type
         """
 
-        if not isinstance(op, Operator):
-            raise ValueError("AT requires Operator object to be passed as an argument")
-
         self.op = op
         self.nt_full = self.op.nt
-
-        default_blocked_dims = ([True] * (len(self.op.shape) - 1))
-        default_blocked_dims.append(False)  # By default we don't auto tune inner most dim
-        self.blocked_dims = blocked_dims or default_blocked_dims
+        self.blocked_dims = blocked_dims
 
         default_at_dir = path.join(path.dirname(path.realpath(__file__)), "At Report")
         self.report_dir = at_report_dir or default_at_dir

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -260,7 +260,7 @@ class Operator(object):
             at_op = Operator(
                 nt=nt, shape=shape, dtype=dtype, stencils=stencils, subs=subs,
                 spc_border=spc_border, time_order=time_order, forward=forward,
-                compiler=compiler, profile=profile, cse=cse, input_params=input_params,
+                compiler=compiler, profile=profile, cse=False, input_params=input_params,
                 output_params=output_params, factorized=factorized
             )
             blocked_dims = blocked_dims or (([True] * (len(shape) - 1)) + [False])

--- a/examples/TTI_codegen.py
+++ b/examples/TTI_codegen.py
@@ -3,7 +3,6 @@ from __future__ import print_function
 
 import numpy as np
 
-from devito.at_controller import AutoTuner
 from examples.tti_operators import *
 
 
@@ -68,16 +67,8 @@ class TTI_cg:
         fw = ForwardOperator(self.model, self.src, self.damp, self.data,
                              time_order=self.t_order, spc_order=self.s_order,
                              profile=True, save=save, cache_blocking=cache_blocking,
-                             cse=cse, compiler=compiler)
-
-        if auto_tuning:
-            fw_new = ForwardOperator(self.model, self.src, self.damp, self.data,
-                                     time_order=self.t_order, spc_order=self.s_order,
-                                     profile=True, save=save, cse=cse, compiler=compiler)
-
-            at = AutoTuner(fw_new)
-            at.auto_tune_blocks(self.s_order + 1, self.s_order * 4 + 2)
-            fw.propagator.cache_blocking = at.block_size
+                             cse=cse, compiler=compiler, auto_tuning=auto_tuning,
+                             at_range=(self.s_order + 1, self.s_order * 4 + 2))
 
         u, v, rec = fw.apply()
         return (rec.data, u.data, v.data,

--- a/tests/test_auto_tuning.py
+++ b/tests/test_auto_tuning.py
@@ -5,7 +5,6 @@ import numpy as np
 import pytest
 from sympy import Eq
 
-from devito.at_controller import AutoTuner
 from devito.dimension import t, x, y, z
 from devito.interfaces import DenseData
 from devito.operator import SimpleOperator
@@ -41,9 +40,9 @@ class Test_Auto_Tuning(object):
         eq = Eq(output_grid.indexed[indexes],
                 output_grid.indexed[indexes] + input_grid.indexed[indexes] + 3)
 
-        op = SimpleOperator(input_grid, output_grid, [eq], time_order=2, spc_border=2)
+        op = SimpleOperator(
+            input_grid, output_grid, [eq], time_order=2, spc_border=2,
+            auto_tuning=True, blocked_dims=block_dims, at_range=tune_range
+        )
 
-        auto_tuner = AutoTuner(op, block_dims, self.test_dir)
-        auto_tuner.auto_tune_blocks(tune_range[0], tune_range[1])
-
-        assert auto_tuner.block_size == expected_result
+        assert op.propagator.cache_blocking == expected_result


### PR DESCRIPTION
Instead of having the user manually create an `Operator` to perform autotuning and then assign the tuned block sizes by hand, this PR makes the whole process easier by performing AT inside the operator.

