### PR TITLE
Benchmark saves only loop_body data

### DIFF
--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -133,7 +133,7 @@ if __name__ == "__main__":
                     np.isclose(res[i], last_res[i])
 
     elif args.execmode == "bench":
-        class TTIExecutor(Executor):
+        class BenchExecutor(Executor):
             """Executor class that defines how to run the benchmark"""
 
             def run(self, *args, **kwargs):
@@ -148,7 +148,7 @@ if __name__ == "__main__":
         bench = Benchmark(
             name=args.problem, resultsdir=args.resultsdir, parameters=parameters
         )
-        bench.execute(TTIExecutor(), warmups=0)
+        bench.execute(BenchExecutor(), warmups=0)
         bench.save()
 
     elif args.execmode == "plot":

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -139,9 +139,10 @@ if __name__ == "__main__":
             def run(self, *args, **kwargs):
                 gflops, oi, timings, _ = run(*args, **kwargs)
 
-                self.register(gflops["loop_body"], measure="gflops")
-                self.register(oi["loop_body"], measure="oi")
-                self.register(timings["loop_body"], measure="timings")
+                for key in timings.keys():
+                    self.register(gflops[key], measure="gflops", event=key)
+                    self.register(oi[key], measure="oi", event=key)
+                    self.register(timings[key], measure="timings", event=key)
 
                 clear_cache()
 
@@ -160,8 +161,8 @@ if __name__ == "__main__":
         oi_dict = {}
         mflops_dict = {}
 
-        gflops = bench.lookup(params=parameters, measure="gflops")
-        oi = bench.lookup(params=parameters, measure="oi")
+        gflops = bench.lookup(params=parameters, measure="gflops", event="loop_body")
+        oi = bench.lookup(params=parameters, measure="oi", event="loop_body")
 
         for key, gflops in gflops.items():
             oi_value = oi[key]

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -139,9 +139,9 @@ if __name__ == "__main__":
             def run(self, *args, **kwargs):
                 gflops, oi, timings, _ = run(*args, **kwargs)
 
-                self.register(gflops["kernel"], measure="gflops")
-                self.register(oi["kernel"], measure="oi")
-                self.register(timings["kernel"], measure="timings")
+                self.register(gflops["loop_body"], measure="gflops")
+                self.register(oi["loop_body"], measure="oi")
+                self.register(timings["loop_body"], measure="timings")
 
                 clear_cache()
 


### PR DESCRIPTION
`benchmark.py` used the data for the whole kernel, while only the main loop is needed (according to discussion with @mloubout on Slack)