### PR TITLE
Profiler: Byte size fix

### DIFF
--- a/devito/propagator.py
+++ b/devito/propagator.py
@@ -97,7 +97,7 @@ class Propagator(object):
         # Settings for performance profiling
         self.profile = profile
         # Profiler needs to know whether openmp is set
-        self.profiler = Profiler(self.compiler.openmp)
+        self.profiler = Profiler(self.compiler.openmp, self.dtype)
 
         # Cache blocking and block sizes
         self.cache_blocking = cache_blocking


### PR DESCRIPTION
The `dtype` was never passed to the Profiler, so it always calculated OI based on 4 bytes long floats. This fixes it by having the propagator pass its dtype to the profiler.

Also changed name from `byte_size` to `float_size`