### PR TITLE
Improved roofline plotting

### DIFF
--- a/examples/acoustic/Acoustic_codegen.py
+++ b/examples/acoustic/Acoustic_codegen.py
@@ -1,8 +1,8 @@
 # coding: utf-8
 from __future__ import print_function
 
-from examples.acoustic.fwi_operators import *
 from devito.at_controller import AutoTuner
+from examples.acoustic.fwi_operators import *
 from examples.source_type import SourceLike
 
 

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -1,7 +1,7 @@
+import sys
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from itertools import product
 from os import environ
-import sys
 
 import numpy as np
 

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -171,7 +171,7 @@ if __name__ == "__main__":
             label = "%s, AT: %s, SO: %s, TO: %s" % (
                 args.problem, key["auto_tuning"], key["space_order"], key["time_order"]
             )
-            mflops_dict[label] = gflops * 1000
+            mflops_dict[label] = gflops
             oi_dict[label] = oi_value
 
         name = ("%s %s dimensions: %s - spacing: %s -"

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -1,11 +1,13 @@
 from argparse import ArgumentParser, RawDescriptionHelpFormatter
 from itertools import product
 from os import environ
+import sys
 
 import numpy as np
 
 from devito import clear_cache
 from devito.compiler import compiler_registry
+from devito.logger import warning
 from examples.acoustic.acoustic_example import run as acoustic_run
 from examples.tti.tti_example import run as tti_run
 
@@ -158,6 +160,9 @@ if __name__ == "__main__":
             name=args.problem, resultsdir=args.resultsdir, parameters=parameters
         )
         bench.load()
+        if not bench.loaded:
+            warning("Could not load any results, nothing to plot. Exiting...")
+            sys.exit(0)
 
         oi_dict = {}
         mflops_dict = {}

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -168,18 +168,17 @@ if __name__ == "__main__":
         for key, gflops in gflops.items():
             oi_value = oi[key]
             key = dict(key)
-            label = "%s, AT: %s, SO: %s, TO: %s" % (
-                args.problem, key["auto_tuning"], key["space_order"], key["time_order"]
-            )
+            label = "%s, so %s" % ("AT" if key["auto_tuning"] else "noAT",
+                                   key["space_order"])
             mflops_dict[label] = gflops
             oi_dict[label] = oi_value
 
-        name = ("%s %s dimensions: %s - spacing: %s -"
-                " space order: %s - time order: %s.pdf") % \
-            (args.problem, args.compiler, parameters["dimensions"], parameters["spacing"],
-             parameters["space_order"], parameters["time_order"])
-        name = name.replace(" ", "_")
-
+        name = "%s_dim%s_so%s_to%s.pdf" % (args.problem, parameters["dimensions"],
+                                           parameters["space_order"],
+                                           parameters["time_order"])
+        title = "%s - grid: %s, time order: %s" % (args.problem.capitalize(),
+                                                   parameters["dimensions"],
+                                                   parameters["time_order"])
         plotter = Plotter(plotdir=args.plotdir)
         plotter.plot_roofline(
-            name, mflops_dict, oi_dict, args.max_bw, args.max_flops)
+            name, mflops_dict, oi_dict, args.max_bw, args.max_flops, title=title)

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -180,6 +180,6 @@ if __name__ == "__main__":
              parameters["space_order"], parameters["time_order"])
         name = name.replace(" ", "_")
 
-        plotter = Plotter()
+        plotter = Plotter(plotdir=args.plotdir)
         plotter.plot_roofline(
             name, mflops_dict, oi_dict, args.max_bw, args.max_flops)

--- a/examples/tti/TTI_codegen.py
+++ b/examples/tti/TTI_codegen.py
@@ -4,8 +4,8 @@ from __future__ import print_function
 import numpy as np
 
 from devito.at_controller import AutoTuner
-from examples.tti.tti_operators import *
 from examples.source_type import SourceLike
+from examples.tti.tti_operators import *
 
 
 class TTI_cg:


### PR DESCRIPTION
A small set of tweaks to the roofline plotting routine in `benchmark.py` that ensure pretty diagrams. Requires `opescibench` PR #2 to go in with this.

Further pretty plotting (with colour!) will follow soon.