### PR TITLE
Fix usage of symbolic data grids in cache blocking test

### DIFF
--- a/tests/test_cache_blocking.py
+++ b/tests/test_cache_blocking.py
@@ -3,14 +3,14 @@ import pytest
 from sympy import Eq
 
 from devito.dimension import t, x, y, z
-from devito.interfaces import DenseData
+from devito.interfaces import TimeData
 from devito.operator import SimpleOperator
 
 
 class Test_Cache_Blocking(object):
 
     # Full range testing.   This syntax tests all possible permutations of parameters
-    @pytest.mark.parametrize("shape", [(10, 45), (10, 31, 45), (10, 45, 31, 45)])
+    @pytest.mark.parametrize("shape", [(45, ), (31, 45), (45, 31, 45)])
     @pytest.mark.parametrize("time_order", [2])
     @pytest.mark.parametrize("spc_border", [0, 1, 2, 3, 4, 5, 6, 7, 8])
     @pytest.mark.parametrize("cache_blocking", [2, 3, 4, 5, 6, 7, 8])
@@ -20,35 +20,37 @@ class Test_Cache_Blocking(object):
 
     # Edge cases. Different block sizes, etc
     @pytest.mark.parametrize("shape,time_order,spc_border,cache_blocking", [
-        ((10, 25, 25, 46), 2, 3, [None, None, None]),
-        ((10, 25, 25, 46), 2, 3, [7, None, None]),
-        ((10, 25, 25, 46), 2, 3, [None, None, 7]),
-        ((10, 25, 25, 46), 2, 3, [None, 7, None]),
-        ((10, 25, 25, 46), 2, 3, [5, None, 7]),
-        ((10, 25, 25, 46), 2, 3, [10, 3, None]),
-        ((10, 25, 25, 46), 2, 3, [None, 7, 11]),
-        ((10, 25, 25, 46), 2, 3, [8, 2, 4]),
-        ((10, 25, 25, 46), 2, 3, [2, 4, 8]),
-        ((10, 25, 25, 46), 2, 3, [4, 8, 2]),
-        ((10, 25, 46), 2, 3, [None, 7]),
-        ((10, 25, 46), 2, 3, [7, None])
+        ((25, 25, 46), 2, 3, [None, None, None]),
+        ((25, 25, 46), 2, 3, [7, None, None]),
+        ((25, 25, 46), 2, 3, [None, None, 7]),
+        ((25, 25, 46), 2, 3, [None, 7, None]),
+        ((25, 25, 46), 2, 3, [5, None, 7]),
+        ((25, 25, 46), 2, 3, [10, 3, None]),
+        ((25, 25, 46), 2, 3, [None, 7, 11]),
+        ((25, 25, 46), 2, 3, [8, 2, 4]),
+        ((25, 25, 46), 2, 3, [2, 4, 8]),
+        ((25, 25, 46), 2, 3, [4, 8, 2]),
+        ((25, 46), 2, 3, [None, 7]),
+        ((25, 46), 2, 3, [7, None])
     ])
     def test_cache_blocking_edge_cases(self, shape, time_order,
                                        spc_border, cache_blocking):
         self.cache_blocking_test(shape, time_order, spc_border, cache_blocking)
 
     def cache_blocking_test(self, shape, time_order, spc_border, cache_blocking):
-        symbols_combinations = [(t, ), (t, x), (t, x, z), (t, x, y, z)]
+        symbols_combinations = [(t, x), (t, x, z), (t, x, y, z)]
         indexes = symbols_combinations[len(shape) - 1]
 
         size = 1
         for element in shape:
             size *= element
 
-        input_grid = DenseData(name="input_grid", shape=shape, dtype=np.float64)
+        input_grid = TimeData(name="input_grid", shape=shape, dtype=np.float64,
+                              save=True, time_dim=9)
         input_grid.data[:] = np.arange(size, dtype=np.float64).reshape(shape)
 
-        output_grid_noblock = DenseData(name="output_grid", shape=shape, dtype=np.float64)
+        output_grid_noblock = TimeData(name="output_grid", shape=shape,
+                                       dtype=np.float64, save=True, time_dim=9)
         eq_noblock = Eq(output_grid_noblock.indexed[indexes],
                         output_grid_noblock.indexed[indexes] +
                         input_grid.indexed[indexes] + 3)
@@ -56,7 +58,8 @@ class Test_Cache_Blocking(object):
                                     time_order=time_order, spc_border=spc_border)
         op_noblock.apply()
 
-        output_grid_block = DenseData(name="output_grid", shape=shape, dtype=np.float64)
+        output_grid_block = TimeData(name="output_grid", shape=shape,
+                                     dtype=np.float64, save=True, time_dim=9)
         eq_block = Eq(output_grid_block.indexed[indexes],
                       output_grid_block.indexed[indexes] +
                       input_grid.indexed[indexes] + 3)


### PR DESCRIPTION
Previously the test would hijack `DenseData` objects by enforcing an
artificial time dimension `t` without the use of the dedicated `TimeData`
grid class. This effectively forces Devito to assume a 4-dimensional
space grid, which is currently not supported. This commit fixes this by
making the time dimension implicit through the use of `TimeData` objects.

As a side note, we might also want to separately test cache blocking 
without the time dimension on a `DenseData` grid, but that is left for
another PR. 