### PR TITLE
Vectorise `vp**(-2)` via NumPy

### DIFF
--- a/examples/acoustic/acoustic_example.py
+++ b/examples/acoustic/acoustic_example.py
@@ -42,7 +42,7 @@ def run(dimensions=(150, 150, 50), spacing=(20.0, 20.0, 20.0), tn=250.0,
     # Smooth velocity
     initial_vp = smooth10(true_vp, dimensions)
 
-    dm = true_vp**-2 - initial_vp**-2
+    dm = 1. / (true_vp * true_vp) - 1. / (initial_vp * initial_vp)
 
     model.create_model(origin, spacing, true_vp)
 

--- a/examples/containers.py
+++ b/examples/containers.py
@@ -71,7 +71,7 @@ class IGrid:
         return self.origin
 
     def padm(self):
-        return self.pad(self.vp**(-2))
+        return self.pad(1./(self.vp * self.vp))
 
     def pad(self, m):
         pad_list = []


### PR DESCRIPTION
Profiling the model startup on acoustic suggests that the expression `vp**(-2)` takes up large chunks of time, presumably because it does not use NumPy vectorisation. Replacing it with `1. / vp * vp` seems to be much faster. 

The change in `IGrid.padm()` gives approximately 2x speedup for the initialisation of `m` in `fwi_operators.py:ForwardOperator` and the change in `acoustic_example.py:run()` reduces it's impact from 30% to around 5% in a single-timestep run on a 256^3 grid. 