### PR TITLE
More work towards a recursive code generator

### DIFF
--- a/devito/dimension.py
+++ b/devito/dimension.py
@@ -9,10 +9,17 @@ class Dimension(Symbol):
     def __new__(cls, name, **kwargs):
         newobj = Symbol.__new__(cls, name)
         newobj.size = kwargs.get('size', None)
+        newobj._count = 0
         return newobj
 
     def __str__(self):
         return self.name
+
+    def get_varname(self):
+        """Generates a new variables name based on an internal counter"""
+        name = "%s%d" % (self.name, self._count)
+        self._count += 1
+        return name
 
 
 # Set of default dimensions for space and time

--- a/devito/dimension.py
+++ b/devito/dimension.py
@@ -4,11 +4,18 @@ __all__ = ['Dimension', 'x', 'y', 'z', 't', 'p']
 
 
 class Dimension(Symbol):
-    """Index object that represents iteration spaces"""
+    """Index object that represents a problem dimension and thus
+    defines a potential iteration space.
+
+    :param size: Optional, size of the array dimension.
+    :param buffered: Optional, boolean flag indicating whether to
+                     buffer variables when iterating this dimension.
+    """
 
     def __new__(cls, name, **kwargs):
         newobj = Symbol.__new__(cls, name)
         newobj.size = kwargs.get('size', None)
+        newobj.buffered = kwargs.get('buffered', None)
         newobj._count = 0
         return newobj
 

--- a/devito/dimension.py
+++ b/devito/dimension.py
@@ -1,6 +1,6 @@
 from sympy import Symbol
 
-__all__ = ['Dimension', 'x', 'y', 'z', 't']
+__all__ = ['Dimension', 'x', 'y', 'z', 't', 'p']
 
 
 class Dimension(Symbol):
@@ -27,3 +27,4 @@ x = Dimension('x')
 y = Dimension('y')
 z = Dimension('z')
 t = Dimension('t')
+p = Dimension('p')

--- a/devito/expression.py
+++ b/devito/expression.py
@@ -1,9 +1,10 @@
 from __future__ import absolute_import
 
-import cgen
 from collections import defaultdict
 from operator import attrgetter
-from sympy import Eq, IndexedBase, Indexed, preorder_traversal
+
+import cgen
+from sympy import Eq, Indexed, IndexedBase, preorder_traversal
 
 from devito.codeprinter import ccode
 from devito.dimension import Dimension

--- a/devito/expression.py
+++ b/devito/expression.py
@@ -2,6 +2,7 @@ import cgen
 from sympy import Eq, IndexedBase, preorder_traversal
 
 from devito.codeprinter import ccode
+from devito.interfaces import SymbolicData
 from devito.symbolics import dse_indexify
 from devito.tools import filter_ordered
 
@@ -19,6 +20,9 @@ class Expression(object):
         self.functions = []
         # Traverse stencil to determine meta information
         for e in preorder_traversal(self.stencil):
+            if isinstance(e, SymbolicData):
+                self.dimensions += list(e.indices)
+                self.functions += [e]
             if isinstance(e, IndexedBase):
                 self.dimensions += list(e.function.indices)
                 self.functions += [e.function]

--- a/devito/expression.py
+++ b/devito/expression.py
@@ -2,6 +2,7 @@ import cgen
 from sympy import Eq, IndexedBase, preorder_traversal
 
 from devito.codeprinter import ccode
+from devito.symbolics import dse_indexify
 from devito.tools import filter_ordered
 
 __all__ = ['Expression']
@@ -47,3 +48,7 @@ class Expression(object):
         :returns: List of unique data objects required by the expression
         """
         return self.functions
+
+    def indexify(self):
+        """Convert stencil expression to "indexed" format"""
+        self.stencil = dse_indexify(self.stencil)

--- a/devito/expression.py
+++ b/devito/expression.py
@@ -2,6 +2,7 @@ from __future__ import absolute_import
 
 import cgen
 from collections import defaultdict
+from operator import attrgetter
 from sympy import Eq, IndexedBase, Indexed, preorder_traversal
 
 from devito.codeprinter import ccode
@@ -55,7 +56,8 @@ class Expression(object):
 
         :returns: List of unique data objects required by the expression
         """
-        return self.functions
+        return filter_ordered([f for f in self.functions],
+                              key=attrgetter('name'))
 
     def indexify(self):
         """Convert stencil expression to "indexed" format"""

--- a/devito/expression.py
+++ b/devito/expression.py
@@ -4,12 +4,12 @@ from collections import defaultdict
 from operator import attrgetter
 
 import cgen
-from sympy import Eq, Indexed, IndexedBase, preorder_traversal
+from sympy import Eq, IndexedBase, preorder_traversal
 
 from devito.codeprinter import ccode
 from devito.dimension import Dimension
 from devito.interfaces import SymbolicData
-from devito.symbolics import dse_indexify
+from devito.symbolics import dse_indexify, terminals
 from devito.tools import filter_ordered
 
 __all__ = ['Expression']
@@ -70,16 +70,15 @@ class Expression(object):
 
         Note: This assumes we have indexified the stencil expression."""
         offsets = defaultdict(list)
-        for e in preorder_traversal(self.stencil):
-            if isinstance(e, Indexed):
-                for a in e.args[1:]:
-                    d = None
-                    off = []
-                    for idx in a.args:
-                        if isinstance(idx, Dimension):
-                            d = idx
-                        else:
-                            off += [idx]
-                    if d is not None:
-                        offsets[d] += off
+        for e in terminals(self.stencil):
+            for a in e.indices:
+                d = None
+                off = []
+                for idx in a.args:
+                    if isinstance(idx, Dimension):
+                        d = idx
+                    else:
+                        off += [idx]
+                if d is not None:
+                    offsets[d] += off
         return offsets

--- a/devito/interfaces.py
+++ b/devito/interfaces.py
@@ -5,8 +5,9 @@ from sympy import Function, IndexedBase, as_finite_diff, symbols
 from sympy.abc import h, s
 
 from devito.dimension import p, t, x, y, z
-from devito.finite_difference import (centered, cross_derivative, first_derivative,
-                                      left, right, second_derivative)
+from devito.finite_difference import (centered, cross_derivative,
+                                      first_derivative, left, right,
+                                      second_derivative)
 from devito.logger import debug, error
 from devito.memmap_manager import MemmapManager
 from devito.memory import first_touch, free, malloc_aligned

--- a/devito/interfaces.py
+++ b/devito/interfaces.py
@@ -2,9 +2,9 @@ import weakref
 
 import numpy as np
 from sympy import Function, IndexedBase, as_finite_diff, symbols
-from sympy.abc import h, p, s
+from sympy.abc import h, s
 
-from devito.dimension import t, x, y, z
+from devito.dimension import p, t, x, y, z
 from devito.finite_difference import (centered, cross_derivative, first_derivative,
                                       left, right, second_derivative)
 from devito.logger import debug, error

--- a/devito/interfaces.py
+++ b/devito/interfaces.py
@@ -389,6 +389,7 @@ class TimeData(DenseData):
                 time_dim += self.time_order
             else:
                 time_dim = self.time_order + 1
+                self.indices[0].buffered = time_dim
 
             self.shape = (time_dim,) + self.shape
 

--- a/devito/iteration.py
+++ b/devito/iteration.py
@@ -72,3 +72,8 @@ class Iteration(Expression):
         """
         signatures = [e.signature for e in self.expressions]
         return filter_ordered(chain(*signatures))
+
+    def indexify(self):
+        """Convert all enclosed stencil expressions to "indexed" format"""
+        for e in self.expressions:
+            e.indexify()

--- a/devito/iteration.py
+++ b/devito/iteration.py
@@ -89,9 +89,10 @@ class Iteration(Expression):
         loop_body = [s.ccode for s in self.expressions]
         if self.dim.buffered is not None:
             modulo = self.dim.buffered
-            v_subs = [cgen.Assign(v, "(%s) %% %d" % (s, modulo))
+            v_subs = [cgen.Initializer(cgen.Value('int', v),
+                                       "(%s) %% %d" % (s, modulo))
                       for s, v in self.subs.items()]
-            loop_body = [cgen.Block(v_subs)] + loop_body
+            loop_body = v_subs + loop_body
         loop_init = cgen.InlineInitializer(
             cgen.Value("int", self.index), self.limits[0])
         loop_cond = '%s %s %s' % (self.index, '<' if forward else '>', self.limits[1])

--- a/devito/iteration.py
+++ b/devito/iteration.py
@@ -1,11 +1,11 @@
-from collections import defaultdict, Iterable
+from collections import Iterable, defaultdict
 from itertools import chain
-from sympy import Symbol
 
 import cgen
+from sympy import Symbol
 
-from devito.expression import Expression
 from devito.dimension import Dimension
+from devito.expression import Expression
 from devito.logger import warning
 from devito.tools import filter_ordered
 

--- a/devito/iteration.py
+++ b/devito/iteration.py
@@ -18,9 +18,10 @@ class Iteration(Expression):
                   to iterate.
     :param limits: Limits for the iteration space, either the loop size or a
                    tuple of the form (start, finish, stepping).
+    :param offsets: Optional map list of offsets to honour in the loop
     """
 
-    def __init__(self, expressions, index, limits):
+    def __init__(self, expressions, index, limits, offsets=None):
         # Ensure we deal with a list of Expression objects internally
         self.expressions = expressions if isinstance(expressions, list) else [expressions]
         self.expressions = [e if isinstance(e, Expression) else Expression(e)
@@ -28,9 +29,17 @@ class Iteration(Expression):
         self.index = str(index)
         if isinstance(limits, Iterable):
             assert(len(limits) == 3)
-            self.limits = limits
+            self.limits = list(limits)
         else:
-            self.limits = (0, limits, 1)
+            self.limits = list((0, limits, 1))
+
+        # Adjust loop limits according to provided offsets
+        o_min, o_max = 0, 0
+        for off in offsets:
+            o_min = min(o_min, int(off))
+            o_max = max(o_max, int(off))
+        self.limits[0] += -o_min
+        self.limits[1] -= o_max
 
     def __repr__(self):
         str_expr = "\n\t".join([str(s) for s in self.expressions])

--- a/devito/iteration.py
+++ b/devito/iteration.py
@@ -32,7 +32,9 @@ class Iteration(Expression):
         # Check that index is a dimension
         if not isinstance(dimension, Dimension):
             warning("Generating Iteration without Dimension object")
-        self.index = str(dimension.get_varname())
+            self.index = str(dimension)
+        else:
+            self.index = str(dimension.get_varname())
 
         # Propagate variable names to the lower expressions
         self.substitute({dimension: Symbol(self.index)})
@@ -46,7 +48,7 @@ class Iteration(Expression):
 
         # Adjust loop limits according to provided offsets
         o_min, o_max = 0, 0
-        for off in offsets:
+        for off in (offsets or {}):
             o_min = min(o_min, int(off))
             o_max = max(o_max, int(off))
         self.limits[0] += -o_min

--- a/devito/memory.py
+++ b/devito/memory.py
@@ -7,7 +7,7 @@ from operator import mul
 
 import numpy as np
 from sympy import Eq
-from sympy.abc import p
+from devito.dimension import p
 
 from devito.logger import error
 from devito.tools import convert_dtype_to_ctype

--- a/devito/memory.py
+++ b/devito/memory.py
@@ -7,8 +7,8 @@ from operator import mul
 
 import numpy as np
 from sympy import Eq
-from devito.dimension import p
 
+from devito.dimension import p
 from devito.logger import error
 from devito.tools import convert_dtype_to_ctype
 

--- a/devito/memory.py
+++ b/devito/memory.py
@@ -75,7 +75,7 @@ def first_touch(array):
         space_dims = array.indices[1:]
     else:
         if isinstance(array, PointData):
-            it_init = [Iteration(exp_init, index=p, limits=array.shape[1])]
+            it_init = [Iteration(exp_init, dimension=p, limits=array.shape[1])]
             exp_init = []
             time_steps = array.shape[0]
             shape = []

--- a/devito/memory.py
+++ b/devito/memory.py
@@ -9,7 +9,6 @@ import numpy as np
 from sympy import Eq
 from sympy.abc import p
 
-from devito.iteration import Iteration
 from devito.logger import error
 from devito.tools import convert_dtype_to_ctype
 
@@ -65,6 +64,7 @@ def first_touch(array):
     """
     from devito.propagator import Propagator
     from devito.interfaces import TimeData, PointData
+    from devito.iteration import Iteration
 
     exp_init = [Eq(array.indexed[array.indices], 0)]
     it_init = []

--- a/devito/stencilkernel.py
+++ b/devito/stencilkernel.py
@@ -36,8 +36,9 @@ class StencilKernel(object):
         # Wrap expressions with Iterations according to dimensions
         for i, expr in enumerate(self.expressions):
             newexpr = expr
+            offsets = newexpr.index_offsets
             for d in reversed(expr.dimensions):
-                newexpr = Iteration(newexpr, d, d.size)
+                newexpr = Iteration(newexpr, d, d.size, offsets=offsets[d])
             self.expressions[i] = newexpr
 
         # TODO: Merge Iterations iff outermost variables agree

--- a/devito/stencilkernel.py
+++ b/devito/stencilkernel.py
@@ -29,6 +29,10 @@ class StencilKernel(object):
         stencils = stencils if isinstance(stencils, list) else [stencils]
         self.expressions = [Expression(s) for s in stencils]
 
+        # Lower all expressions to "indexed" API
+        for e in self.expressions:
+            e.indexify()
+
         # Wrap expressions with Iterations according to dimensions
         for i, expr in enumerate(self.expressions):
             newexpr = expr

--- a/devito/stencilkernel.py
+++ b/devito/stencilkernel.py
@@ -17,9 +17,19 @@ __all__ = ['StencilKernel']
 
 
 class StencilKernel(object):
-    """Code generation class, alternative to Propagator"""
+    """Code generation class, alternative to Propagator
 
-    def __init__(self, stencils, name="Kernel", compiler=None):
+    :param stencils: SymPy equation or list of equations that define the
+                     stencil used to create the kernel of this Operator.
+    :param name: Name of the kernel function - defaults to "Kernel"
+    :param subs: Dict or list of dicts containing the SymPy symbol
+                 substitutions for each stencil respectively.
+    :param compiler: Compiler class used to perform JIT compilation.
+                     If not provided, the compiler will be inferred from the
+                     environment variable DEVITO_ARCH, or default to GNUCompiler.
+    """
+
+    def __init__(self, stencils, name="Kernel", subs=None, compiler=None):
         # Default attributes required for compilation
         self.name = name
         self.compiler = compiler or get_compiler_from_env()
@@ -32,6 +42,11 @@ class StencilKernel(object):
         # Lower all expressions to "indexed" API
         for e in self.expressions:
             e.indexify()
+
+        # Apply supplied substitutions
+        if subs is not None:
+            for expr in self.expressions:
+                expr.substitute(subs)
 
         # Wrap expressions with Iterations according to dimensions
         for i, expr in enumerate(self.expressions):

--- a/devito/stencilkernel.py
+++ b/devito/stencilkernel.py
@@ -53,7 +53,8 @@ class StencilKernel(object):
             newexpr = expr
             offsets = newexpr.index_offsets
             for d in reversed(expr.dimensions):
-                newexpr = Iteration(newexpr, d, d.size, offsets=offsets[d])
+                newexpr = Iteration(newexpr, dimension=d,
+                                    limits=d.size, offsets=offsets[d])
             self.expressions[i] = newexpr
 
         # TODO: Merge Iterations iff outermost variables agree

--- a/devito/tools.py
+++ b/devito/tools.py
@@ -8,10 +8,12 @@ def flatten(l):
     return [item for sublist in l for item in sublist]
 
 
-def filter_ordered(elements):
+def filter_ordered(elements, key=None):
     """Filter elements in a list while preserving order"""
     seen = set()
-    return [e for e in elements if not (e in seen or seen.add(e))]
+    if key is None:
+        key = lambda x: x
+    return [e for e in elements if not (key(e) in seen or seen.add(key(e)))]
 
 
 def convert_dtype_to_ctype(dtype):

--- a/examples/source_type.py
+++ b/examples/source_type.py
@@ -1,7 +1,6 @@
 from sympy import Eq, Function, Matrix, symbols
-from sympy.abc import p
 
-from devito.dimension import t
+from devito.dimension import t, p
 from devito.interfaces import PointData
 from devito.iteration import Iteration
 

--- a/examples/source_type.py
+++ b/examples/source_type.py
@@ -1,6 +1,6 @@
 from sympy import Eq, Function, Matrix, symbols
 
-from devito.dimension import t, p
+from devito.dimension import p, t
 from devito.interfaces import PointData
 from devito.iteration import Iteration
 

--- a/examples/source_type.py
+++ b/examples/source_type.py
@@ -104,13 +104,13 @@ class SourceLike(PointData):
     def read(self, u):
         """Read the value of the wavefield u at point locations with grid2point."""
         interp_expr = Eq(self.indexed[t, p], self.grid2point(u))
-        return [Iteration(interp_expr, index=p, limits=self.shape[1])]
+        return [Iteration(interp_expr, dimension=p, limits=self.shape[1])]
 
     def read2(self, u, v):
         """Read the value of the wavefield (u+v) at point locations with grid2point."""
         interp_expr = Eq(self.indexed[t, p], self.grid2point(u) + self.grid2point(v))
-        return [Iteration(interp_expr, index=p, limits=self.shape[1])]
+        return [Iteration(interp_expr, dimension=p, limits=self.shape[1])]
 
     def add(self, m, u, t=t):
         """Add a point source term to the wavefield u at time t"""
-        return [Iteration(self.point2grid(u, m, t), index=p, limits=self.shape[1])]
+        return [Iteration(self.point2grid(u, m, t), dimension=p, limits=self.shape[1])]

--- a/tests/test_stencil_arithmetic.py
+++ b/tests/test_stencil_arithmetic.py
@@ -74,7 +74,6 @@ def test_arithmetic_deep(i, j, k, l, expr, result, mode):
     assert np.allclose(fa.data, result, rtol=1e-12)
 
 
-@pytest.mark.xfail(reason='Loop boundaries need adjusting with access offsets')
 @pytest.mark.parametrize('expr, result', [
     ('Eq(a[k, l], a[k - 1 , l] + 1.)',
      np.meshgrid(np.arange(2., 8.), np.arange(2., 7.))[1]),

--- a/tests/test_stencil_arithmetic.py
+++ b/tests/test_stencil_arithmetic.py
@@ -6,27 +6,23 @@ from devito import DenseData, Dimension, StencilKernel
 
 
 @pytest.fixture
-def x(xdim=4):
-    return Dimension(name='x', size=xdim)
+def i(size=3):
+    return Dimension(name='i', size=size)
 
 
 @pytest.fixture
-def y(ydim=6):
-    return Dimension(name='y', size=ydim)
+def j(size=4):
+    return Dimension(name='j', size=size)
 
 
 @pytest.fixture
-def ai(x, y, name='a', value=2.):
-    a = DenseData(name=name, dimensions=(x, y))
-    a.data[:] = value
-    return a.indexify()
+def k(size=5):
+    return Dimension(name='k', size=size)
 
 
 @pytest.fixture
-def bi(x, y, name='b', value=3.):
-    b = DenseData(name=name, dimensions=(x, y))
-    b.data[:] = value
-    return b.indexify()
+def l(size=6):
+    return Dimension(name='l', size=size)
 
 
 @pytest.mark.parametrize('expr, result', [
@@ -35,8 +31,16 @@ def bi(x, y, name='b', value=3.):
     ('Eq(ai, 4 * (bi * ai))', 24.),
     ('Eq(ai, (6. / bi) + (8. * ai))', 18.),
 ])
-def test_arithmetic_flat(ai, bi, expr, result):
+def test_arithmetic_flat(i, j, expr, result):
     """Tests basic point-wise arithmetic on two-dimensional data"""
+
+    a = DenseData(name='a', dimensions=(i, j))
+    a.data[:] = 2.
+    ai = a.indexify()
+    b = DenseData(name='b', dimensions=(i, j))
+    b.data[:] = 3.
+    bi = b.indexify()
+
     eqn = eval(expr)
     StencilKernel(eqn)(ai.base.function, bi.base.function)
     assert np.allclose(ai.base.function.data, result, rtol=1e-12)
@@ -48,12 +52,8 @@ def test_arithmetic_flat(ai, bi, expr, result):
     ('Eq(ai, 4 * (bi * ai))', 24.),
     ('Eq(ai, (6. / bi) + (8. * ai))', 18.),
 ])
-def test_arithmetic_deep(expr, result):
+def test_arithmetic_deep(i, j, k, l, expr, result):
     """Tests basic point-wise arithmetic on multi-dimensional data"""
-    i = Dimension(name='i', size=3)
-    j = Dimension(name='j', size=4)
-    k = Dimension(name='k', size=5)
-    l = Dimension(name='l', size=6)
 
     a = DenseData(name='a', dimensions=(i, j, k, l))
     a.data[:] = 2.

--- a/tests/test_stencil_arithmetic.py
+++ b/tests/test_stencil_arithmetic.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 from sympy import Eq  # noqa
 
-from devito import DenseData, Dimension, StencilKernel, clear_cache
+from devito import DenseData, Dimension, StencilKernel
 
 
 @pytest.fixture
@@ -43,7 +43,6 @@ def symbol(name, dimensions, value=0., mode='function'):
 @pytest.mark.parametrize('mode', ['function', 'indexed'])
 def test_arithmetic_flat(i, j, expr, result, mode):
     """Tests basic point-wise arithmetic on two-dimensional data"""
-    clear_cache()
     a = symbol(name='a', dimensions=(i, j), value=2., mode=mode)
     b = symbol(name='b', dimensions=(i, j), value=3., mode=mode)
     fa = a.base.function if mode == 'indexed' else a
@@ -63,7 +62,6 @@ def test_arithmetic_flat(i, j, expr, result, mode):
 @pytest.mark.parametrize('mode', ['function', 'indexed'])
 def test_arithmetic_deep(i, j, k, l, expr, result, mode):
     """Tests basic point-wise arithmetic on multi-dimensional data"""
-    clear_cache()
     a = symbol(name='a', dimensions=(i, j, k, l), value=2., mode=mode)
     b = symbol(name='b', dimensions=(j, k), value=3., mode=mode)
     fa = a.base.function if mode == 'indexed' else a
@@ -82,7 +80,6 @@ def test_arithmetic_deep(i, j, k, l, expr, result, mode):
 ])
 def test_arithmetic_indexed_increment(i, j, k, l, expr, result):
     """Tests point-wise increments with stencil offsets in one dimension"""
-    clear_cache()
     a = symbol(name='a', dimensions=(k, l), value=2., mode='indexed').base
     fa = a.function
     fa.data[1:, 1:] = 0
@@ -101,7 +98,6 @@ def test_arithmetic_indexed_increment(i, j, k, l, expr, result):
 def test_arithmetic_indexed_stencil(i, j, k, l, expr, result):
     """Test point-wise arithmetic with stencil offsets across two
     functions in indexed expression format"""
-    clear_cache()
     a = symbol(name='a', dimensions=(k, l), value=0., mode='indexed').base
     fa = a.function
     b = symbol(name='b', dimensions=(k, l), value=2., mode='indexed').base
@@ -121,7 +117,6 @@ def test_arithmetic_indexed_stencil(i, j, k, l, expr, result):
 def test_arithmetic_indexed_buffered(i, j, k, l, expr, result):
     """Test point-wise arithmetic with stencil offsets across a single
     functions with buffering dimension in indexed expression format"""
-    clear_cache()
     a = symbol(name='a', dimensions=(i, k, l), value=2., mode='indexed').base
     fa = a.function
 

--- a/tests/test_stencil_arithmetic.py
+++ b/tests/test_stencil_arithmetic.py
@@ -2,7 +2,7 @@ import numpy as np
 import pytest
 from sympy import Eq  # noqa
 
-from devito import DenseData, Dimension, StencilKernel
+from devito import DenseData, Dimension, StencilKernel, clear_cache
 
 
 @pytest.fixture
@@ -43,7 +43,7 @@ def symbol(name, dimensions, value=0., mode='function'):
 @pytest.mark.parametrize('mode', ['function', 'indexed'])
 def test_arithmetic_flat(i, j, expr, result, mode):
     """Tests basic point-wise arithmetic on two-dimensional data"""
-
+    clear_cache()
     a = symbol(name='a', dimensions=(i, j), value=2., mode=mode)
     b = symbol(name='b', dimensions=(i, j), value=3., mode=mode)
     fa = a.base.function if mode == 'indexed' else a
@@ -63,7 +63,7 @@ def test_arithmetic_flat(i, j, expr, result, mode):
 @pytest.mark.parametrize('mode', ['function', 'indexed'])
 def test_arithmetic_deep(i, j, k, l, expr, result, mode):
     """Tests basic point-wise arithmetic on multi-dimensional data"""
-
+    clear_cache()
     a = symbol(name='a', dimensions=(i, j, k, l), value=2., mode=mode)
     b = symbol(name='b', dimensions=(j, k), value=3., mode=mode)
     fa = a.base.function if mode == 'indexed' else a
@@ -84,6 +84,7 @@ def test_arithmetic_deep(i, j, k, l, expr, result, mode):
 def test_arithmetic_indexed_single(i, j, k, l, expr, result):
     """Tests basic point-wise arithmetic with stencil offsets
     in indexed expression format"""
+    clear_cache()
     a = symbol(name='a', dimensions=(k, l), value=2., mode='indexed').base
     fa = a.function
     fa.data[1:, 1:] = 0

--- a/tests/test_stencil_arithmetic.py
+++ b/tests/test_stencil_arithmetic.py
@@ -26,42 +26,38 @@ def l(size=6):
 
 
 @pytest.mark.parametrize('expr, result', [
-    ('Eq(ai, ai + bi + 5.)', 10.),
-    ('Eq(ai, bi - ai)', 1.),
-    ('Eq(ai, 4 * (bi * ai))', 24.),
-    ('Eq(ai, (6. / bi) + (8. * ai))', 18.),
+    ('Eq(a, a + b + 5.)', 10.),
+    ('Eq(a, b - a)', 1.),
+    ('Eq(a, 4 * (b * a))', 24.),
+    ('Eq(a, (6. / b) + (8. * a))', 18.),
 ])
 def test_arithmetic_flat(i, j, expr, result):
     """Tests basic point-wise arithmetic on two-dimensional data"""
 
     a = DenseData(name='a', dimensions=(i, j))
     a.data[:] = 2.
-    ai = a.indexify()
     b = DenseData(name='b', dimensions=(i, j))
     b.data[:] = 3.
-    bi = b.indexify()
 
     eqn = eval(expr)
-    StencilKernel(eqn)(ai.base.function, bi.base.function)
-    assert np.allclose(ai.base.function.data, result, rtol=1e-12)
+    StencilKernel(eqn)(a, b)
+    assert np.allclose(a.data, result, rtol=1e-12)
 
 
 @pytest.mark.parametrize('expr, result', [
-    ('Eq(ai, ai + bi + 5.)', 10.),
-    ('Eq(ai, bi - ai)', 1.),
-    ('Eq(ai, 4 * (bi * ai))', 24.),
-    ('Eq(ai, (6. / bi) + (8. * ai))', 18.),
+    ('Eq(a, a + b + 5.)', 10.),
+    ('Eq(a, b - a)', 1.),
+    ('Eq(a, 4 * (b * a))', 24.),
+    ('Eq(a, (6. / b) + (8. * a))', 18.),
 ])
 def test_arithmetic_deep(i, j, k, l, expr, result):
     """Tests basic point-wise arithmetic on multi-dimensional data"""
 
     a = DenseData(name='a', dimensions=(i, j, k, l))
     a.data[:] = 2.
-    ai = a.indexify()
     b = DenseData(name='b', dimensions=(j, k))
     b.data[:] = 3.
-    bi = b.indexify()
 
     eqn = eval(expr)
-    StencilKernel(eqn)(ai.base.function, bi.base.function)
-    assert np.allclose(ai.base.function.data, result, rtol=1e-12)
+    StencilKernel(eqn)(a, b)
+    assert np.allclose(a.data, result, rtol=1e-12)


### PR DESCRIPTION
Ok, this is a bit of a blanket PR for the next steps in the re-development of the low-level code generator (currently `StencilKernel`). It adds a set of features that allow us to switch the diffusion example over to the new API and includes in detail:

* Additional tests for the low-level "indexed" API in stencil kernels
* Compatibility with the high-level API through "indexification" in `Expression`
* Automatic derivation of loop bounds from the stencil indices
* Automatic derivation and substitution of loop variables in `Iteration`
* Global symbol substitution in stencil kernel
* `Dimension` objects define "buffered" loops, eg. over dimension "time"

Note: `StencilKernel` objects now behave equivalently to `Operator/Propagator` objects in terms of "baked-in" loop limits. However, these now need to be defined via the default `Dimension` objects (`x`, `y`, `t` or `p`). Generalisation for "open" loop limits will come on a follow-on PR.