### PR TITLE
More compiler presets

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ matrix:
       python: "2.7"
       env: DEVITO_ARCH=gcc-4.9 DEVITO_OPENMP=0
     - os: linux
+      python: "2.7"
+      env: DEVITO_ARCH=gcc-5 DEVITO_OPENMP=0
+    - os: linux
       python: "3.5"
       env: DEVITO_ARCH=gcc-4.9 DEVITO_OPENMP=0
     - os: linux
@@ -28,10 +31,12 @@ matrix:
 addons:
   apt:
     sources:
-      - ubuntu-toolchain-r-test     # For gcc 4.9
+      - ubuntu-toolchain-r-test     # For gcc 4.9 and 5
     packages:
       - gcc-4.9
       - g++-4.9
+      - gcc-5
+      - g++-5
 
 install:
   - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then brew update; brew install python; brew link --overwrite python ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,13 +22,16 @@ matrix:
       env: DEVITO_ARCH=gcc DEVITO_OPENMP=1 OMP_NUM_THREADS=2
   allow_failures:
     - os: osx
+      python: "2.7"
       env: DEVITO_ARCH=clang DEVITO_OPENMP=0
 
 addons:
   apt:
+    sources:
+      - ubuntu-toolchain-r-test     # For gcc 4.9
     packages:
-        - python-dev
-        - python-pip
+      - gcc-4.9
+      - g++-4.9
 
 install:
   - if [[ $TRAVIS_OS_NAME == 'osx' ]]; then brew update; brew install python; brew link --overwrite python ; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,13 +13,13 @@ matrix:
   include:
     - os: linux
       python: "2.7"
-      env: DEVITO_ARCH=gcc DEVITO_OPENMP=0
+      env: DEVITO_ARCH=gcc-4.9 DEVITO_OPENMP=0
     - os: linux
       python: "3.5"
-      env: DEVITO_ARCH=gcc DEVITO_OPENMP=0
+      env: DEVITO_ARCH=gcc-4.9 DEVITO_OPENMP=0
     - os: linux
       python: "2.7"
-      env: DEVITO_ARCH=gcc DEVITO_OPENMP=1 OMP_NUM_THREADS=2
+      env: DEVITO_ARCH=gcc-4.9 DEVITO_OPENMP=1 OMP_NUM_THREADS=2
   allow_failures:
     - os: osx
       python: "2.7"

--- a/devito/codeprinter.py
+++ b/devito/codeprinter.py
@@ -12,8 +12,8 @@ class CodePrinter(CCodePrinter):
     def __init__(self, settings={}):
         CCodePrinter.__init__(self, settings)
         custom_functions = {
-            'INT': 'int',
-            'FLOAT': 'float'
+            'INT': '(int)',
+            'FLOAT': '(float)'
         }
         self.known_functions.update(custom_functions)
 

--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -165,9 +165,9 @@ class CustomCompiler(Compiler):
 
     def __init__(self, *args, **kwargs):
         super(CustomCompiler, self).__init__(*args, **kwargs)
-        self.cc = environ.get('CC', 'g++')
+        self.cc = environ.get('CXX', 'g++')
         self.ld = environ.get('LD', 'g++')
-        self.cflags = environ.get('CFLAGS', '-O3 -g -fPIC -Wall').split(' ')
+        self.cflags = environ.get('CXXFLAGS', '-O3 -g -fPIC -Wall').split(' ')
         self.ldflags = environ.get('LDFLAGS', '-shared').split(' ')
 
 

--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -36,6 +36,8 @@ class Compiler(GCCToolchain):
         * :data:`self.libraries`
         * :data:`self.library_dirs`
         * :data:`self.defines`
+        * :data:`self.src_ext`
+        * :data:`self.lib_ext`
         * :data:`self.undefines`
         * :data:`self.pragma_ivdep`
 
@@ -50,6 +52,8 @@ class Compiler(GCCToolchain):
         self.library_dirs = []
         self.defines = []
         self.undefines = []
+        self.src_ext = 'c'
+        self.lib_ext = 'so'
         # Devito-specific flags and properties
         self.openmp = openmp
         self.pragma_ivdep = [Pragma('ivdep')]
@@ -93,6 +97,7 @@ class ClangCompiler(Compiler):
         self.ld = 'clang'
         self.cflags = ['-O3', '-g', '-fPIC', '-Wall', '-std=c99']
         self.ldflags = ['-shared']
+        self.lib_ext = 'dylib'
 
         if self.openmp:
             log("WARNING: Disabling OpenMP because clang does not support it.")
@@ -232,8 +237,8 @@ def jit_compile(ccode, basename, compiler=GNUCompiler):
     :param compiler: The toolchain used for compilation. GNUCompiler by default.
     :return: Path to compiled lib
     """
-    src_file = "%s.c" % basename
-    lib_file = "%s.so" % basename
+    src_file = "%s.%s" % (basename, compiler.src_ext)
+    lib_file = "%s.%s" % (basename, compiler.lib_ext)
     log("%s: Compiling %s" % (compiler, src_file))
     extension_file_from_string(toolchain=compiler, ext_file=lib_file,
                                source_string=ccode, source_name=src_file)
@@ -251,7 +256,7 @@ def load(basename, compiler=GNUCompiler):
     Note: If the provided compiler is of type `IntelMICCompiler`
     we utilise the `pymic` package to manage device streams.
     """
-    lib_file = "%s.so" % basename
+    lib_file = "%s.%s" % (basename, compiler.lib_ext)
 
     if isinstance(compiler, IntelMICCompiler):
         compiler._device = compiler._mic.devices[0]

--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -69,9 +69,9 @@ class GNUCompiler(Compiler):
     def __init__(self, *args, **kwargs):
         super(GNUCompiler, self).__init__(*args, **kwargs)
         self.version = kwargs.get('version', None)
-        self.cc = 'g++' if self.version is None else 'g++-%s' % self.version
-        self.ld = 'g++' if self.version is None else 'g++-%s' % self.version
-        self.cflags = ['-O3', '-g', '-fPIC', '-Wall']
+        self.cc = 'gcc' if self.version is None else 'gcc-%s' % self.version
+        self.ld = 'gcc' if self.version is None else 'gcc-%s' % self.version
+        self.cflags = ['-O3', '-g', '-fPIC', '-Wall', '-std=c99']
         self.ldflags = ['-shared']
 
         if self.openmp:
@@ -91,7 +91,7 @@ class ClangCompiler(Compiler):
         super(ClangCompiler, self).__init__(*args, **kwargs)
         self.cc = 'clang'
         self.ld = 'clang'
-        self.cflags = ['-O3', '-g', '-fPIC', '-Wall']
+        self.cflags = ['-O3', '-g', '-fPIC', '-Wall', '-std=c99']
         self.ldflags = ['-shared']
 
         if self.openmp:
@@ -107,9 +107,9 @@ class IntelCompiler(Compiler):
 
     def __init__(self, *args, **kwargs):
         super(IntelCompiler, self).__init__(*args, **kwargs)
-        self.cc = 'icpc'
-        self.ld = 'icpc'
-        self.cflags = ['-O3', '-g', '-fPIC', '-Wall', "-xhost"]
+        self.cc = 'icc'
+        self.ld = 'icc'
+        self.cflags = ['-O3', '-g', '-fPIC', '-Wall', '-std=c99', "-xhost"]
         self.ldflags = ['-shared']
 
         if self.openmp:
@@ -127,9 +127,9 @@ class IntelMICCompiler(Compiler):
 
     def __init__(self, *args, **kwargs):
         super(IntelMICCompiler, self).__init__(*args, **kwargs)
-        self.cc = 'icpc'
-        self.ld = 'icpc'
-        self.cflags = ['-O3', '-g', '-fPIC', '-Wall', "-mmic"]
+        self.cc = 'icc'
+        self.ld = 'icc'
+        self.cflags = ['-O3', '-g', '-fPIC', '-Wall', '-std=c99', "-mmic"]
         self.ldflags = ['-shared']
 
         if self.openmp:
@@ -144,9 +144,9 @@ class IntelKNLCompiler(Compiler):
 
     def __init__(self, *args, **kwargs):
         super(IntelKNLCompiler, self).__init__(*args, **kwargs)
-        self.cc = 'icpc'
-        self.ld = 'icpc'
-        self.cflags = ['-O3', '-g', '-fPIC', '-Wall', "-xMIC-AVX512"]
+        self.cc = 'icc'
+        self.ld = 'icc'
+        self.cflags = ['-O3', '-g', '-fPIC', '-Wall', '-std=c99', "-xMIC-AVX512"]
         self.ldflags = ['-shared']
         if self.openmp:
             self.ldflags += ['-qopenmp']
@@ -165,9 +165,9 @@ class CustomCompiler(Compiler):
 
     def __init__(self, *args, **kwargs):
         super(CustomCompiler, self).__init__(*args, **kwargs)
-        self.cc = environ.get('CXX', 'g++')
-        self.ld = environ.get('LD', 'g++')
-        self.cflags = environ.get('CXXFLAGS', '-O3 -g -fPIC -Wall').split(' ')
+        self.cc = environ.get('CC', 'gcc')
+        self.ld = environ.get('LD', 'gcc')
+        self.cflags = environ.get('CFLAGS', '-O3 -g -fPIC -Wall -std=c99').split(' ')
         self.ldflags = environ.get('LDFLAGS', '-shared').split(' ')
 
 
@@ -178,9 +178,7 @@ class CustomCompiler(Compiler):
 compiler_registry = {
     'gcc': GNUCompiler, 'gnu': GNUCompiler,
     'gcc-4.9': partial(GNUCompiler, version='4.9'),
-    'g++-4.9': partial(GNUCompiler, version='4.9'),
     'gcc-5': partial(GNUCompiler, version='5'),
-    'g++-5': partial(GNUCompiler, version='5'),
     'clang': ClangCompiler, 'osx': ClangCompiler,
     'intel': IntelCompiler, 'icpc': IntelCompiler,
     'icc': IntelCompiler,
@@ -196,8 +194,8 @@ def get_compiler_from_env():
 
     The key environment variable DEVITO_ARCH supports the following values:
      * 'gcc' or 'gnu' - (Default) Standard GNU compiler toolchain
-     * 'gcc-4.9' or 'g++-4.9' - GNU compiler toolchain version 4.9
-     * 'gcc-5' or 'g++-5' - GNU compiler toolchain version 5
+     * 'gcc-4.9' - GNU compiler toolchain version 4.9
+     * 'gcc-5' - GNU compiler toolchain version 5
      * 'clang' or 'osx' - Clang compiler toolchain for Mac OSX
      * 'intel' or 'icpc' - Intel compiler toolchain via icpc
      * 'intel-mic' or 'mic' - Intel MIC using offload mode via pymic
@@ -234,7 +232,7 @@ def jit_compile(ccode, basename, compiler=GNUCompiler):
     :param compiler: The toolchain used for compilation. GNUCompiler by default.
     :return: Path to compiled lib
     """
-    src_file = "%s.cpp" % basename
+    src_file = "%s.c" % basename
     lib_file = "%s.so" % basename
     log("%s: Compiling %s" % (compiler, src_file))
     extension_file_from_string(toolchain=compiler, ext_file=lib_file,

--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -162,6 +162,8 @@ compiler_registry = {
     'gcc': GNUCompiler, 'gnu': GNUCompiler,
     'gcc-4.9': partial(GNUCompiler, version='4.9'),
     'g++-4.9': partial(GNUCompiler, version='4.9'),
+    'gcc-5': partial(GNUCompiler, version='5'),
+    'g++-5': partial(GNUCompiler, version='5'),
     'clang': ClangCompiler, 'osx': ClangCompiler,
     'intel': IntelCompiler, 'icpc': IntelCompiler,
     'icc': IntelCompiler,
@@ -178,6 +180,7 @@ def get_compiler_from_env():
     The key environment variable DEVITO_ARCH supports the following values:
      * 'gcc' or 'gnu' - (Default) Standard GNU compiler toolchain
      * 'gcc-4.9' or 'g++-4.9' - GNU compiler toolchain version 4.9
+     * 'gcc-5' or 'g++-5' - GNU compiler toolchain version 5
      * 'clang' or 'osx' - Clang compiler toolchain for Mac OSX
      * 'intel' or 'icpc' - Intel compiler toolchain via icpc
      * 'intel-mic' or 'mic' - Intel MIC using offload mode via pymic

--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -1,3 +1,4 @@
+from functools import partial
 from os import environ, getuid, mkdir, path
 from tempfile import gettempdir
 
@@ -39,7 +40,7 @@ class Compiler(GCCToolchain):
         * :data:`self.pragma_ivdep`
 
     """
-    def __init__(self, openmp=False):
+    def __init__(self, openmp=False, **kwargs):
         self.cc = 'unknown'
         self.ld = 'unknown'
         self.cflags = []
@@ -67,8 +68,9 @@ class GNUCompiler(Compiler):
 
     def __init__(self, *args, **kwargs):
         super(GNUCompiler, self).__init__(*args, **kwargs)
-        self.cc = 'g++'
-        self.ld = 'g++'
+        self.version = kwargs.get('version', None)
+        self.cc = 'g++' if self.version is None else 'g++-%s' % self.version
+        self.ld = 'g++' if self.version is None else 'g++-%s' % self.version
         self.cflags = ['-O3', '-g', '-fPIC', '-Wall']
         self.ldflags = ['-shared']
 
@@ -158,6 +160,8 @@ class IntelKNLCompiler(Compiler):
 # the docstring of get_compiler_from_env().
 compiler_registry = {
     'gcc': GNUCompiler, 'gnu': GNUCompiler,
+    'gcc-4.9': partial(GNUCompiler, version='4.9'),
+    'g++-4.9': partial(GNUCompiler, version='4.9'),
     'clang': ClangCompiler, 'osx': ClangCompiler,
     'intel': IntelCompiler, 'icpc': IntelCompiler,
     'icc': IntelCompiler,
@@ -173,6 +177,7 @@ def get_compiler_from_env():
 
     The key environment variable DEVITO_ARCH supports the following values:
      * 'gcc' or 'gnu' - (Default) Standard GNU compiler toolchain
+     * 'gcc-4.9' or 'g++-4.9' - GNU compiler toolchain version 4.9
      * 'clang' or 'osx' - Clang compiler toolchain for Mac OSX
      * 'intel' or 'icpc' - Intel compiler toolchain via icpc
      * 'intel-mic' or 'mic' - Intel MIC using offload mode via pymic

--- a/devito/function_manager.py
+++ b/devito/function_manager.py
@@ -12,9 +12,8 @@ class FunctionManager(object):
     :param mic_flag: True if using MIC. Default is False
     :param openmp: True if using OpenMP. Default is False
     """
-    libraries = ['cassert', 'cstdlib', 'cmath', 'iostream',
-                 'fstream', 'vector', 'cstdio', 'string',
-                 'inttypes.h', 'sys/time.h', 'math.h']
+    libraries = ['assert.h', 'stdlib.h', 'math.h',
+                 'stdio.h', 'string.h', 'sys/time.h']
 
     _pymic_attribute = 'PYMIC_KERNEL'
 
@@ -34,7 +33,7 @@ class FunctionManager(object):
         """
         statements = []
         statements += self._defines
-        statements += [cgen.Include(s) for s in self.libraries]
+        statements += [cgen.Include(s, system=False) for s in self.libraries]
 
         if self.mic_flag:
             statements += [cgen.Include('pymic_kernel.h')]
@@ -107,10 +106,8 @@ class FunctionManager(object):
                 cgen.Value(self._pymic_attribute + '\nint', function_descriptor.name),
                 function_params)
         else:
-            return cgen.Extern("C",
-                               cgen.FunctionDeclaration(
-                                   cgen.Value('int', function_descriptor.name),
-                                   function_params))
+            return cgen.FunctionDeclaration(cgen.Value('int', function_descriptor.name),
+                                            function_params)
 
     def generate_function_body(self, function_descriptor):
         """Generates a function body from a :class:`FunctionDescriptor`

--- a/devito/stencilkernel.py
+++ b/devito/stencilkernel.py
@@ -76,8 +76,7 @@ class StencilKernel(object):
         """
         header_vars = [c.Pointer(c.POD(v.dtype, '%s_vec' % v.name))
                        for v in self.signature]
-        header = c.Extern("C", c.FunctionDeclaration(
-            c.Value('int', self.name), header_vars))
+        header = c.FunctionDeclaration(c.Value('int', self.name), header_vars)
         cast_shapes = [(v, ''.join(['[%d]' % d for d in v.shape[1:]]))
                        for v in self.signature]
         casts = [c.Initializer(c.POD(v.dtype, '(*%s)%s' % (v.name, shape)),


### PR DESCRIPTION
This merge adds version-specific compiler presets for the GNU toolchain `gcc-4.9` and `gcc-5` and switches travis to use both. It also adds a `CustomCompiler` class which reads the `CC`, `CFLAGS`, `LD` and `LDFLAGS` flags if `DEVITO_ARCH` is not set.

EDIT: This merge now also switches back to C99 compilation during JIT.