### PR TITLE
Pip install, license and housekeeping

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2016, Imperial College, London
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -14,12 +14,18 @@ prototype Full Waveform Inversion (FWI) code that can be found
 
 ## Quickstart
 
-Devito should be installed directly from github via:
+Devito can be installed from github via pip:
+```
+pip install --user git+https://github.com/opesci/devito.git
+```
+
+Alternatively Devito can be be installed manually from github via:
 ```
 git clone https://github.com/opesci/devito.git
 cd devito && pip install --user -r requirements.txt
 ```
-Please make sure you also add Devito to your `PYTHONPATH`.
+When manually installing Devito please make sure you also add Devito
+to your `PYTHONPATH`.
 
 ## Examples
 

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ allow users to create efficient FD kernels from SymPy expressions.
 Examples of how to configure operators are provided:
 
 * A simple example of how to solve the 2D diffusion equation can be
-  found in `tests/test_diffusion.py`. This example also demonstrates
-  how the equation can be solved via pure Python and optimised
-  `numpy`, as well as Devito.
+  found in `examples/diffusion/example_diffusion.py`. This example
+  also demonstrates how the equation can be solved via pure Python and
+  optimised `numpy`, as well as Devito.
 * A more practical example of acoustic Forward, Adjoint, Gradient and Born
   operators for use in FWI can be found in
   `examples/acoustic/acoustic_example.py` and `examples/acoustic/fwi_operators.py`.

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,6 @@
 [flake8]
 max-line-length = 90
 ignore = F403,E226,E731,W503,F405
-exclude = AcousticWave2D.py
 
-[pytest]
+[tool:pytest]
 python_files = test_*.py example_*.py

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,18 @@ except ImportError:
 
 setup(name='devito',
       version='2.0.1',
-      description="""Finite Difference DSL for symbolic stencil computation.""",
+      description="Finite Difference DSL for symbolic computation.",
+      long_descritpion="""Devito is a new tool for performing
+      optimised Finite Difference (FD) computation from high-level
+      symbolic problem definitions. Devito performs automated code
+      generation and Just-In-time (JIT) compilation based on symbolic
+      equations defined in SymPy to create and execute highly
+      optimised Finite Difference kernels on multiple computer
+      platforms.""",
+      url='http://www.opesci.org/devito',
       author="Imperial College London",
+      author_email='opesci@imperial.ac.uk',
       license='MIT',
-      packages=['devito'])
+      packages=['devito'],
+      install_requires=['numpy', 'sympy', 'mpmath', 'cgen', 'codepy'],
+      test_requires=['pytest', 'flake8', 'isort'])

--- a/setup.py
+++ b/setup.py
@@ -6,5 +6,6 @@ except ImportError:
 setup(name='devito',
       version='2.0.1',
       description="""Finite Difference DSL for symbolic stencil computation.""",
-      author="Devito dev team",
+      author="Imperial College London",
+      license='MIT',
       packages=['devito'])

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,10 @@
+try:
+    from setuptools import setup
+except ImportError:
+    from distutils.core import setup
+
+setup(name='devito',
+      version='2.0.1',
+      description="""Finite Difference DSL for symbolic stencil computation.""",
+      author="Devito dev team",
+      packages=['devito'])


### PR DESCRIPTION
This merge adds a license file (MIT) and a `setup.py` to allow Devito to be installed via pip, as well as other minor housekeeping changes.