### PR TITLE
Source separated

### DIFF
--- a/examples/acoustic/Acoustic_codegen.py
+++ b/examples/acoustic/Acoustic_codegen.py
@@ -1,6 +1,8 @@
 # coding: utf-8
 from __future__ import print_function
 
+import numpy as np
+
 from devito.at_controller import AutoTuner
 from examples.acoustic.fwi_operators import *
 

--- a/examples/acoustic/Acoustic_codegen.py
+++ b/examples/acoustic/Acoustic_codegen.py
@@ -12,12 +12,13 @@ class Acoustic_cg(object):
 
     Note: s_order must always be greater than t_order
     """
-    def __init__(self, model, data, source=None, nbpml=40, t_order=2, s_order=2,
+    def __init__(self, model, data, source, nbpml=40, t_order=2, s_order=2,
                  auto_tuning=False, dse=True, compiler=None):
         self.model = model
         self.t_order = t_order
         self.s_order = s_order
         self.data = data
+        self.src = source
         self.dtype = np.float32
         # Time step can be \sqrt{3}=1.73 bigger with 4th order
         if t_order == 4:
@@ -26,13 +27,6 @@ class Acoustic_cg(object):
             self.dt = model.get_critical_dt()
         self.model.nbpml = nbpml
         self.model.set_origin(nbpml)
-        if source is not None:
-            self.source = source.read()
-            self.source.reinterpolate(self.dt)
-            source_time = self.source.traces[0, :]
-            while len(source_time) < self.data.nsamples:
-                source_time = np.append(source_time, [0.0])
-            self.data.set_source(source_time, self.dt, self.data.source_coords)
 
         def damp_boundary(damp):
             h = self.model.get_spacing()
@@ -61,16 +55,11 @@ class Acoustic_cg(object):
 
         # Initialize damp by calling the function that can precompute damping
         damp_boundary(self.damp.data)
-        srccoord = np.array(self.data.source_coords, dtype=self.dtype)[np.newaxis, :]
-        if len(self.damp.shape) == 2 and srccoord.shape[1] == 3:
-            srccoord = np.delete(srccoord, 1, 1)
+
+        if len(self.damp.shape) == 2 and self.src.receiver_coords.shape[1] == 3:
+            self.src.receiver_coords = np.delete(self.src.receiver_coords, 1, 1)
         if len(self.damp.shape) == 2 and self.data.receiver_coords.shape[1] == 3:
             self.data.receiver_coords = np.delete(self.data.receiver_coords, 1, 1)
-        self.src = SourceLike(name="src", npoint=1, nt=data.shape[1],
-                              dt=self.dt, h=self.model.get_spacing(),
-                              coordinates=srccoord, ndim=len(self.damp.shape),
-                              dtype=self.dtype, nbpml=nbpml)
-        self.src.data[:] = data.get_source()[:, np.newaxis]
 
         if auto_tuning:  # auto tuning with dummy forward operator
             fw = ForwardOperator(self.model, self.src, self.damp, self.data,
@@ -93,7 +82,7 @@ class Acoustic_cg(object):
         return rec.data, u, fw.propagator.gflopss, fw.propagator.oi, fw.propagator.timings
 
     def Adjoint(self, rec, cache_blocking=None):
-        adj = AdjointOperator(self.model, self.damp, self.data, rec,
+        adj = AdjointOperator(self.model, self.damp, self.data, self.src, rec,
                               time_order=self.t_order, spc_order=self.s_order,
                               cache_blocking=cache_blocking)
         v = adj.apply()[0]

--- a/examples/acoustic/Acoustic_codegen.py
+++ b/examples/acoustic/Acoustic_codegen.py
@@ -3,7 +3,6 @@ from __future__ import print_function
 
 from devito.at_controller import AutoTuner
 from examples.acoustic.fwi_operators import *
-from examples.source_type import SourceLike
 
 
 class Acoustic_cg(object):

--- a/examples/acoustic/acoustic_example.py
+++ b/examples/acoustic/acoustic_example.py
@@ -46,7 +46,7 @@ def run(dimensions=(50, 50, 50), spacing=(20.0, 20.0, 20.0), tn=1000.0,
 
     # Define seismic data.
     data = IShot()
-
+    src = IShot()
     f0 = .010
     if time_order == 4:
         dt = 1.73 * model.get_critical_dt()
@@ -55,22 +55,28 @@ def run(dimensions=(50, 50, 50), spacing=(20.0, 20.0, 20.0), tn=1000.0,
     t0 = 0.0
     nt = int(1+(tn-t0)/dt)
 
-    time_series = source(np.linspace(t0, tn, nt), f0)
-    location = (origin[0] + dimensions[0] * spacing[0] * 0.5,
-                origin[1] + dimensions[1] * spacing[1] * 0.5,
-                origin[2] + 2 * spacing[2])
-    data.set_source(time_series, dt, location)
+    # Source geometry
+    time_series = np.zeros((nt, 1))
 
+    time_series[:, 0] = source(np.linspace(t0, tn, nt), f0)
+
+    location = np.zeros((1, 3))
+    location[0, 0] = origin[0] + dimensions[0] * spacing[0] * 0.5
+    location[0, 1] = origin[1] + dimensions[1] * spacing[1] * 0.5
+    location[0, 2] = origin[1] + 2 * spacing[2]
+    src.set_receiver_pos(location)
+    src.set_shape(nt, 1)
+    src.set_traces(time_series)
+
+    # Receiver geometry
     receiver_coords = np.zeros((101, 3))
-    receiver_coords[:, 0] = np.linspace(2 * spacing[0],
-                                        origin[0] + (dimensions[0] - 2) * spacing[0],
-                                        num=101)
+    receiver_coords[:, 0] = np.linspace(50, 950, num=101)
     receiver_coords[:, 1] = origin[1] + dimensions[1] * spacing[1] * 0.5
-    receiver_coords[:, 2] = location[2]
+    receiver_coords[:, 2] = location[0, 1]
     data.set_receiver_pos(receiver_coords)
     data.set_shape(nt, 101)
 
-    Acoustic = Acoustic_cg(model, data, nbpml=nbpml, t_order=time_order,
+    Acoustic = Acoustic_cg(model, data, src, nbpml=nbpml, t_order=time_order,
                            s_order=space_order, auto_tuning=auto_tuning, dse=dse,
                            compiler=compiler)
 

--- a/examples/acoustic/acoustic_example.py
+++ b/examples/acoustic/acoustic_example.py
@@ -70,7 +70,8 @@ def run(dimensions=(50, 50, 50), spacing=(20.0, 20.0, 20.0), tn=1000.0,
 
     # Receiver geometry
     receiver_coords = np.zeros((101, 3))
-    receiver_coords[:, 0] = np.linspace(50, 950, num=101)
+    receiver_coords[:, 0] = np.linspace(0, origin[0] +
+                                        dimensions[0] * spacing[0], num=101)
     receiver_coords[:, 1] = origin[1] + dimensions[1] * spacing[1] * 0.5
     receiver_coords[:, 2] = location[0, 1]
     data.set_receiver_pos(receiver_coords)

--- a/examples/acoustic/fwi_operators.py
+++ b/examples/acoustic/fwi_operators.py
@@ -1,4 +1,3 @@
-import numpy as np
 from sympy import Eq, symbols
 
 from devito.dimension import t
@@ -92,7 +91,8 @@ class AdjointOperator(Operator):
     :param: time_order: Time discretization order
     :param: spc_order: Space discretization order
     """
-    def __init__(self, model, damp, data, src, recin, time_order=2, spc_order=6, **kwargs):
+    def __init__(self, model, damp, data, src, recin,
+                 time_order=2, spc_order=6, **kwargs):
         nt, nrec = data.shape
         s, h = symbols('s h')
         v = TimeData(name="v", shape=model.get_shape_comp(), time_dim=nt,
@@ -278,7 +278,8 @@ class BornOperator(Operator):
              u.backward + 2.0 * s ** 2 * (laplacianu + s**2 / 12 * biharmonicu))
         stencil2 = 1.0 / (2.0 * m + s * damp) * \
             (4.0 * m * u + (s * damp - 2.0 * m) *
-             u.backward + 2.0 * s ** 2 * (laplacianU + s**2 / 12 * biharmonicU - dm * u.dt2))
+             u.backward + 2.0 * s ** 2 * (laplacianU +
+                                          s**2 / 12 * biharmonicU - dm * u.dt2))
         # Add substitutions for spacing (temporal and spatial)
         subs = {s: dt, h: model.get_spacing()}
         # Add Born-specific updates and resets

--- a/examples/containers.py
+++ b/examples/containers.py
@@ -9,6 +9,7 @@ class IGrid:
     :param origin: Origin of the model in m as a Tuple
     :param spacing:grid size in m as a Tuple
     :param vp: Velocity in km/s
+    :param rho: Density in kg/cm^3 (rho=1 for water)
     :param epsilon: Thomsen epsilon parameter (0<epsilon<1)
     :param delta: Thomsen delta parameter (0<delta<1), delta<epsilon
     :param: theta: Tilt angle in radian
@@ -19,6 +20,7 @@ class IGrid:
         self.vp = vp
         self.spacing = spacing
         self.dimensions = vp.shape
+
         if epsilon is not None:
             self.epsilon = 1 + 2 * epsilon
             self.scale = np.sqrt(1 + 2 * np.max(self.epsilon))
@@ -31,21 +33,9 @@ class IGrid:
         else:
             self.delta = None
 
-        if phi is not None:
-            self.phi = phi
-        else:
-            self.phi = None
-
-        if theta is not None:
-            self.theta = theta
-        else:
-            self.theta = None
-
-        if rho is not None:
-            self.rho = rho
-        else:
-            self.rho = None
-
+        self.phi = phi
+        self.theta = theta
+        self.rho = rho
         self.origin = origin
 
     def get_shape(self):

--- a/examples/containers.py
+++ b/examples/containers.py
@@ -14,7 +14,7 @@ class IGrid:
     :param: theta: Tilt angle in radian
     :param phi : Asymuth angle in radian
     """
-    def __init__(self, origin, spacing, vp, epsilon=None,
+    def __init__(self, origin, spacing, vp, rho=None, epsilon=None,
                  delta=None, theta=None, phi=None):
         self.vp = vp
         self.spacing = spacing
@@ -24,12 +24,27 @@ class IGrid:
             self.scale = np.sqrt(1 + 2 * np.max(self.epsilon))
         else:
             self.scale = 1
+            self.epsilon = None
+
         if delta is not None:
             self.delta = np.sqrt(1 + 2 * delta)
+        else:
+            self.delta = None
+
         if phi is not None:
             self.phi = phi
+        else:
+            self.phi = None
+
         if theta is not None:
             self.theta = theta
+        else:
+            self.theta = None
+
+        if rho is not None:
+            self.rho = rho
+        else:
+            self.rho = None
 
         self.origin = origin
 
@@ -151,7 +166,11 @@ class IShot:
 
     def set_shape(self, nt, nrec):
         """Set the data array shape"""
-        self.shape = (nrec, nt)
+        self.shape = (nt, nrec)
+
+    def set_traces(self, traces):
+        """ Add traces data  """
+        self.traces = traces
 
     def get_source(self, ti=None):
         """Return the source signature"""

--- a/examples/tti/TTI_codegen.py
+++ b/examples/tti/TTI_codegen.py
@@ -4,7 +4,6 @@ from __future__ import print_function
 import numpy as np
 
 from devito.at_controller import AutoTuner
-from examples.source_type import SourceLike
 from examples.tti.tti_operators import *
 
 

--- a/examples/tti/TTI_codegen.py
+++ b/examples/tti/TTI_codegen.py
@@ -12,23 +12,16 @@ class TTI_cg:
     """ Class to setup the problem for the anisotropic Wave
         Note: s_order must always be greater than t_order
     """
-    def __init__(self, model, data, source=None, t_order=2, s_order=2, nbpml=40):
+    def __init__(self, model, data, source, t_order=2, s_order=2, nbpml=40):
         self.model = model
         self.t_order = t_order
         self.s_order = s_order
         self.data = data
+        self.src = source
         self.dtype = np.float32
         self.dt = model.get_critical_dt()
         self.model.nbpml = nbpml
         self.model.set_origin(nbpml)
-
-        if source is not None:
-            self.source = source.read()
-            self.source.reinterpolate(self.dt)
-            source_time = self.source.traces[0, :]
-            while len(source_time) < self.data.nsamples:
-                source_time = np.append(source_time, [0.0])
-            self.data.set_source(source_time, self.dt, self.data.source_coords)
 
         def damp_boundary(damp):
             h = self.model.get_spacing()
@@ -55,16 +48,11 @@ class TTI_cg:
                               dtype=self.dtype)
         # Initialize damp by calling the function that can precompute damping
         damp_boundary(self.damp.data)
-        srccoord = np.array(self.data.source_coords, dtype=self.dtype)[np.newaxis, :]
-        if len(self.damp.shape) == 2 and srccoord.shape[1] == 3:
-            srccoord = np.delete(srccoord, 1, 1)
+
+        if len(self.damp.shape) == 2 and self.src.receiver_coords.shape[1] == 3:
+            self.src.receiver_coords = np.delete(self.src.receiver_coords, 1, 1)
         if len(self.damp.shape) == 2 and self.data.receiver_coords.shape[1] == 3:
             self.data.receiver_coords = np.delete(self.data.receiver_coords, 1, 1)
-        self.src = SourceLike(name="src", npoint=1, nt=data.shape[1],
-                              dt=self.dt, h=self.model.get_spacing(),
-                              coordinates=srccoord, ndim=len(self.damp.shape),
-                              dtype=self.dtype, nbpml=nbpml)
-        self.src.data[:] = data.get_source()[:, np.newaxis]
 
     def Forward(self, save=False, dse='advanced', auto_tuning=False,
                 cache_blocking=None, compiler=None):

--- a/examples/tti/tti_example.py
+++ b/examples/tti/tti_example.py
@@ -30,6 +30,7 @@ def setup(dimensions=(50, 50, 50), spacing=(20.0, 20.0, 20.0), tn=250.0,
 
     # Define seismic data.
     data = IShot()
+    src = IShot()
 
     f0 = .010
     dt = model.get_critical_dt()
@@ -37,22 +38,28 @@ def setup(dimensions=(50, 50, 50), spacing=(20.0, 20.0, 20.0), tn=250.0,
     nt = int(1+(tn-t0)/dt)
     # Set up the source as Ricker wavelet for f0
 
-    time_series = source(np.linspace(t0, tn, nt), f0)
-    location = (origin[0] + dimensions[0] * spacing[0] * 0.5,
-                origin[1] + dimensions[1] * spacing[1] * 0.5,
-                origin[1] + 2 * spacing[1])
-    data.set_source(time_series, dt, location)
+    # Source geometry
+    time_series = np.zeros((nt, 1))
+
+    time_series[:, 0] = source(np.linspace(t0, tn, nt), f0)
+
+    location = np.zeros((1, 3))
+    location[0, 0] = origin[0] + dimensions[0] * spacing[0] * 0.5
+    location[0, 1] = origin[1] + dimensions[1] * spacing[1] * 0.5
+    location[0, 2] = origin[1] + 2 * spacing[2]
+    src.set_receiver_pos(location)
+    src.set_shape(nt, 1)
+    src.set_traces(time_series)
+
+    # Receiver geometry
     receiver_coords = np.zeros((101, 3))
-    receiver_coords[:, 0] = np.linspace(50,
-                                        origin[0] +
-                                        (dimensions[0] - 2) * spacing[0],
-                                        num=101)
+    receiver_coords[:, 0] = np.linspace(50, 950, num=101)
     receiver_coords[:, 1] = origin[1] + dimensions[1] * spacing[1] * 0.5
-    receiver_coords[:, 2] = location[2]
+    receiver_coords[:, 2] = location[0, 1]
     data.set_receiver_pos(receiver_coords)
     data.set_shape(nt, 101)
 
-    TTI = TTI_cg(model, data, None, t_order=time_order, s_order=space_order, nbpml=nbpml)
+    TTI = TTI_cg(model, data, src, t_order=time_order, s_order=space_order, nbpml=nbpml)
     return TTI
 
 

--- a/examples/tti/tti_example.py
+++ b/examples/tti/tti_example.py
@@ -53,7 +53,8 @@ def setup(dimensions=(50, 50, 50), spacing=(20.0, 20.0, 20.0), tn=250.0,
 
     # Receiver geometry
     receiver_coords = np.zeros((101, 3))
-    receiver_coords[:, 0] = np.linspace(50, 950, num=101)
+    receiver_coords[:, 0] = np.linspace(0, origin[0] +
+                                        dimensions[0] * spacing[0], num=101)
     receiver_coords[:, 1] = origin[1] + dimensions[1] * spacing[1] * 0.5
     receiver_coords[:, 2] = location[0, 1]
     data.set_receiver_pos(receiver_coords)

--- a/examples/tti/tti_example2D.py
+++ b/examples/tti/tti_example2D.py
@@ -47,7 +47,8 @@ src.set_traces(time_series)
 
 # Receiver geometry
 receiver_coords = np.zeros((101, 2))
-receiver_coords[:, 0] = np.linspace(50, 950, num=101)
+receiver_coords[:, 0] = np.linspace(0, origin[0] +
+                                    dimensions[0] * spacing[0], num=101)
 receiver_coords[:, 1] = location[0, 1]
 data.set_receiver_pos(receiver_coords)
 data.set_shape(nt, 101)

--- a/examples/tti/tti_example2D.py
+++ b/examples/tti/tti_example2D.py
@@ -19,7 +19,7 @@ model = IGrid(origin, spacing, true_vp, 0.1*(true_vp - 2),
 
 # Define seismic data.
 data = IShot()
-
+src = IShot()
 f0 = .010
 dt = model.get_critical_dt()
 t0 = 0.0
@@ -34,14 +34,23 @@ def source(t, f0):
     return (1-2.*r**2)*np.exp(-r**2)
 
 
-time_series = source(np.linspace(t0, tn, nt), f0)
-location = (origin[0] + dimensions[0] * spacing[0] * 0.5, 40)
-data.set_source(time_series, dt, location)
-receiver_coords = np.zeros((301, 2))
-receiver_coords[:, 0] = np.linspace(50, 2950, num=301)
-receiver_coords[:, 1] = 40
-data.set_receiver_pos(receiver_coords)
-data.set_shape(nt, 301)
+# Source geometry
+time_series = np.zeros((nt, 1))
+time_series[:, 0] = source(np.linspace(t0, tn, nt), f0)
 
-TTI = TTI_cg(model, data, None, t_order=2, s_order=spc_order, nbpml=10)
+location = np.zeros((1, 2))
+location[0, 0] = origin[0] + dimensions[0] * spacing[0] * 0.5
+location[0, 1] = origin[1] + 2 * spacing[1]
+src.set_receiver_pos(location)
+src.set_shape(nt, 1)
+src.set_traces(time_series)
+
+# Receiver geometry
+receiver_coords = np.zeros((101, 2))
+receiver_coords[:, 0] = np.linspace(50, 950, num=101)
+receiver_coords[:, 1] = location[0, 1]
+data.set_receiver_pos(receiver_coords)
+data.set_shape(nt, 101)
+
+TTI = TTI_cg(model, data, src, t_order=2, s_order=spc_order, nbpml=10)
 rec, u, v, gflopss, oi, timings = TTI.Forward()

--- a/tests/test_adjointA.py
+++ b/tests/test_adjointA.py
@@ -54,7 +54,8 @@ class TestAdjointA(object):
         src.set_traces(time_series)
 
         receiver_coords = np.zeros((101, 3))
-        receiver_coords[:, 0] = np.linspace(50, 950, num=101)
+        receiver_coords[:, 0] = np.linspace(0, origin[0] +
+                                            dimensions[0] * spacing[0], num=101)
         receiver_coords[:, 1] = location[0, 1]
         if len(dimensions) == 3:
             receiver_coords[:, 1] = origin[1] + dimensions[1] * spacing[1] * 0.5

--- a/tests/test_gradient.py
+++ b/tests/test_gradient.py
@@ -30,9 +30,9 @@ class TestGradient(object):
         # True velocity
         true_vp = np.ones(dimensions) + .5
         if len(dimensions) == 2:
-            true_vp[:, int(dimensions[1] / 3):] = 2.5
+            true_vp[:, int(dimensions[1] / 2):] = 2
         else:
-            true_vp[:, :, int(dimensions[2] / 3):] = 2.5
+            true_vp[:, :, int(dimensions[2] / 2):] = 2
         # Smooth velocity
         initial_vp = smooth10(true_vp)
         dm = true_vp**-2 - initial_vp**-2
@@ -40,6 +40,7 @@ class TestGradient(object):
         model0 = IGrid(origin, spacing, initial_vp)
         # Define seismic data.
         data = IShot()
+        src = IShot()
         f0 = .010
         if time_order == 4:
             dt = 1.73 * model.get_critical_dt()
@@ -54,25 +55,32 @@ class TestGradient(object):
             r = (np.pi * f0 * (t - 1./f0))
             return (1-2.*r**2)*np.exp(-r**2)
 
-        time_series = source(np.linspace(t0, tn, nt), f0)
-        location = (origin[0] + dimensions[0] * spacing[0] * 0.5,
-                    origin[-1] + 2 * spacing[-1])
+        # Source geometry
+        time_series = np.zeros((nt, 1))
+        time_series[:, 0] = source(np.linspace(t0, tn, nt), f0)
+
+        location = np.zeros((1, 3))
+        location[0, 0] = origin[0] + dimensions[0] * spacing[0] * 0.5
+        location[0, 1] = origin[1] + 2 * spacing[1]
         if len(dimensions) == 3:
-            location = (location[0], origin[1] + dimensions[1] * spacing[1] * 0.5,
-                        location[1])
-        data.set_source(time_series, dt, location)
-        receiver_coords = np.zeros((50, len(dimensions)))
-        receiver_coords[:, 0] = np.linspace(50, origin[0] + dimensions[0]*spacing[0] - 50,
-                                            num=50)
-        receiver_coords[:, 1] = location[1]
+            location[0, 1] = origin[1] + dimensions[1] * spacing[1] * 0.5
+            location[0, 2] = origin[1] + 2 * spacing[2]
+        src.set_receiver_pos(location)
+        src.set_shape(nt, 1)
+        src.set_traces(time_series)
+
+        receiver_coords = np.zeros((101, 3))
+        receiver_coords[:, 0] = np.linspace(50, 950, num=101)
+        receiver_coords[:, 1] = location[0, 1]
         if len(dimensions) == 3:
-            receiver_coords[:, 2] = location[2]
+            receiver_coords[:, 1] = origin[1] + dimensions[1] * spacing[1] * 0.5
+            receiver_coords[:, 2] = location[0, 2]
         data.set_receiver_pos(receiver_coords)
-        data.set_shape(nt, 50)
+        data.set_shape(nt, 101)
         # Adjoint test
-        wave_true = Acoustic_cg(model, data, None, t_order=time_order,
+        wave_true = Acoustic_cg(model, data, src, t_order=time_order,
                                 s_order=space_order, nbpml=40)
-        wave_0 = Acoustic_cg(model0, data, None, t_order=time_order,
+        wave_0 = Acoustic_cg(model0, data, src, t_order=time_order,
                              s_order=space_order, nbpml=40)
         return wave_true, wave_0, dm, initial_vp
 
@@ -123,5 +131,5 @@ if __name__ == "__main__":
     t = TestGradient()
     request = type('', (), {})()
     request.param = (60, 70)
-    ac = t.acoustic(request, 4, 2)
+    ac = t.acoustic(request, 2, 4)
     t.test_grad(ac)

--- a/tests/test_gradient.py
+++ b/tests/test_gradient.py
@@ -70,7 +70,8 @@ class TestGradient(object):
         src.set_traces(time_series)
 
         receiver_coords = np.zeros((101, 3))
-        receiver_coords[:, 0] = np.linspace(50, 950, num=101)
+        receiver_coords[:, 0] = np.linspace(0, origin[0] +
+                                            dimensions[0] * spacing[0], num=101)
         receiver_coords[:, 1] = location[0, 1]
         if len(dimensions) == 3:
             receiver_coords[:, 1] = origin[1] + dimensions[1] * spacing[1] * 0.5

--- a/tests/test_rewriter.py
+++ b/tests/test_rewriter.py
@@ -11,8 +11,8 @@ from examples.tti.tti_operators import ForwardOperator
 
 def run_acoustic_forward(dse=None):
     dimensions = (50, 50, 50)
-    origin = (0., 0.)
-    spacing = (10., 10.)
+    origin = (0., 0., 0.)
+    spacing = (10., 10., 10.)
 
     # True velocity
     true_vp = np.ones(dimensions) + 2.0
@@ -22,7 +22,7 @@ def run_acoustic_forward(dse=None):
 
     # Define seismic data.
     data = IShot()
-
+    src = IShot()
     f0 = .010
     dt = model.get_critical_dt()
     t0 = 0.0
@@ -31,20 +31,27 @@ def run_acoustic_forward(dse=None):
 
     t = np.linspace(t0, tn, nt)
     r = (np.pi * f0 * (t - 1./f0))
-    time_series = (1-2.*r**2)*np.exp(-r**2)
-    location = (origin[0] + dimensions[0] * spacing[0] * 0.5, 500,
-                origin[1] + 2 * spacing[1])
-    data.set_source(time_series, dt, location)
+    # Source geometry
+    time_series = np.zeros((nt, 1))
+    time_series[:, 0] = (1-2.*r**2)*np.exp(-r**2)
 
+    location = np.zeros((1, 3))
+    location[0, 0] = origin[0] + dimensions[0] * spacing[0] * 0.5
+    location[0, 1] = origin[1] + dimensions[1] * spacing[1] * 0.5
+    location[0, 2] = origin[1] + 2 * spacing[2]
+    src.set_receiver_pos(location)
+    src.set_shape(nt, 1)
+    src.set_traces(time_series)
+
+    # Receiver geometry
     receiver_coords = np.zeros((101, 3))
-    receiver_coords[:, 0] = np.linspace(0,
-                                        origin[0] + dimensions[0] * spacing[0],
-                                        num=101)
+    receiver_coords[:, 0] = np.linspace(0, origin[0] +
+                                        dimensions[0] * spacing[0], num=101)
     receiver_coords[:, 1] = origin[1] + dimensions[1] * spacing[1] * 0.5
-    receiver_coords[:, 2] = location[2]
+    receiver_coords[:, 2] = location[0, 1]
     data.set_receiver_pos(receiver_coords)
     data.set_shape(nt, 101)
-    acoustic = Acoustic_cg(model, data, dse=dse)
+    acoustic = Acoustic_cg(model, data, src, dse=dse)
     rec, u, _, _, _ = acoustic.Forward(save=False, dse=dse)
 
     return rec, u


### PR DESCRIPTION
Small PR to make the examples a bit more usable by people. The source and data are now separated avoiding the `None` argument at every operator call. Everything else is the same.