### PR TITLE
DSE - code motion and other features

### DIFF
--- a/devito/dse/extended_sympy.py
+++ b/devito/dse/extended_sympy.py
@@ -97,13 +97,13 @@ def eval_taylor_sin(expr):
     try:
         Float(expr)
         return v.doit()
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         return v
 
 
 def eval_taylor_cos(expr):
     expr_square = Mul(expr, expr, evaluate=False)
-    b =  1.0-.5*expr_square*(1.0-expr_square/12.0)
+    b = 1.0-.5*expr_square*(1.0-expr_square/12.0)
     v = 1.0 + Mul(-0.5,
                   Mul(expr, expr, evaluate=False),
                   1.0 + Mul(expr, expr, -1/12.0, evaluate=False),
@@ -111,7 +111,7 @@ def eval_taylor_cos(expr):
     try:
         Float(expr)
         return b, v.doit()
-    except TypeError, ValueError:
+    except (TypeError, ValueError):
         return v
 
 

--- a/devito/dse/extended_sympy.py
+++ b/devito/dse/extended_sympy.py
@@ -39,6 +39,28 @@ class Add(sympy.Add, UnevaluatedExpr):
     pass
 
 
+class taylor_sin(TrigonometricFunction):
+
+    """
+    Approximation of the sine function using a Taylor polynomial.
+    """
+
+    @classmethod
+    def eval(cls, arg):
+        return 0.0 if arg == 0.0 else eval_taylor_sin(arg)
+
+
+class taylor_cos(TrigonometricFunction):
+
+    """
+    Approximation of the cosine function using a Taylor polynomial.
+    """
+
+    @classmethod
+    def eval(cls, arg):
+        return 1.0 if arg == 0.0 else eval_taylor_cos(arg + 1.5708)
+
+
 class bhaskara_sin(TrigonometricFunction):
 
     """
@@ -65,3 +87,11 @@ class bhaskara_cos(TrigonometricFunction):
 
 def eval_bhaskara_sin(angle):
     return 16.0*angle*(3.1416-abs(angle))/(49.3483-4.0*abs(angle)*(3.1416-abs(angle)))
+
+
+def eval_taylor_sin(angle):
+    return angle-(angle*angle*angle/6.0*(1.0-angle*angle/20.0))
+
+
+def eval_taylor_cos(angle):
+    return 1.0-.5*angle*angle*(1.0-angle*angle/12.0)

--- a/devito/dse/extended_sympy.py
+++ b/devito/dse/extended_sympy.py
@@ -4,7 +4,7 @@ Extended SymPy hierarchy.
 
 import sympy
 from sympy import Expr, Float, Indexed, S
-from sympy.core.basic import _aresame, Basic
+from sympy.core.basic import _aresame
 from sympy.functions.elementary.trigonometric import TrigonometricFunction
 
 
@@ -102,15 +102,13 @@ def eval_taylor_sin(expr):
 
 
 def eval_taylor_cos(expr):
-    expr_square = Mul(expr, expr, evaluate=False)
-    b = 1.0-.5*expr_square*(1.0-expr_square/12.0)
     v = 1.0 + Mul(-0.5,
                   Mul(expr, expr, evaluate=False),
                   1.0 + Mul(expr, expr, -1/12.0, evaluate=False),
                   evaluate=False)
     try:
         Float(expr)
-        return b, v.doit()
+        return v.doit()
     except (TypeError, ValueError):
         return v
 

--- a/devito/dse/graph.py
+++ b/devito/dse/graph.py
@@ -79,6 +79,16 @@ class Temporary(Eq):
     def scope(self):
         return self._scope
 
+    def construct(self, rule):
+        """
+        Create a new temporary starting from ``self`` replacing symbols in
+        the equation as specified by the dictionary ``rule``.
+        """
+        reads = set(self.reads) - set(rule.keys()) | set(rule.values())
+        rhs = self.rhs.xreplace(rule)
+        return Temporary(self.lhs, rhs, reads=reads, readby=self.readby,
+                         time_invariant=self.is_time_invariant, scope=self.scope)
+
     def __repr__(self):
         return "DSE(%s, reads=%s, readby=%s)" % (super(Temporary, self).__repr__(),
                                                  str(self.reads), str(self.readby))

--- a/devito/dse/graph.py
+++ b/devito/dse/graph.py
@@ -24,6 +24,7 @@ from collections import OrderedDict, namedtuple
 from sympy import (Eq, Indexed)
 
 from devito.dse.inspection import is_time_invariant, terminals
+from devito.dimension import t
 
 __all__ = ['temporaries_graph']
 
@@ -94,6 +95,20 @@ class Temporary(Eq):
                                                  str(self.reads), str(self.readby))
 
 
+class TemporariesGraph(OrderedDict):
+
+    """
+    A temporaries graph built on top of an OrderedDict.
+    """
+
+    def space_dimensions(self):
+        for v in self.values():
+            if v.is_terminal:
+                found = v.lhs.free_symbols - {t, v.lhs.base.label}
+                return tuple(sorted(found, key=lambda i: v.lhs.indices.index(i)))
+        return ()
+
+
 class Trace(OrderedDict):
 
     """
@@ -148,4 +163,4 @@ def temporaries_graph(temporaries, scope=0):
                        time_invariant=v.time_invariant, scope=scope)
              for k, v in mapper.items()]
 
-    return OrderedDict([(i.lhs, i) for i in nodes])
+    return TemporariesGraph([(i.lhs, i) for i in nodes])

--- a/devito/dse/inspection.py
+++ b/devito/dse/inspection.py
@@ -4,7 +4,7 @@ from devito.logger import warning
 from devito.dse.extended_sympy import Add, Mul
 
 import numpy as np
-from sympy import (Indexed, Function, S, Symbol,
+from sympy import (Indexed, Function, Symbol,
                    count_ops, flatten, lambdify, preorder_traversal)
 
 __all__ = ['indexify', 'retrieve_dimensions', 'retrieve_dtype', 'retrieve_symbols',
@@ -65,31 +65,6 @@ def estimate_cost(handle):
         return total_ops - non_flops
     except:
         warning("Cannot estimate cost of %s" % str(handle))
-
-
-def unevaluate_arithmetic(expr):
-    """
-    Reconstruct ``expr`` turning all :class:`sympy.Mul` and :class:`sympy.Add`
-    into, respectively, :class:`devito.Mul` and :class:`devito.Add`.
-    """
-    if expr.is_Float:
-        return expr.func(*expr.atoms())
-    elif isinstance(expr, Indexed):
-        return expr.func(*expr.args)
-    elif expr.is_Symbol:
-        return expr.func(expr.name)
-    elif expr in [S.Zero, S.One, S.NegativeOne, S.Half]:
-        return expr.func()
-    elif expr.is_Atom:
-        return expr.func(*expr.atoms())
-    elif expr.is_Add:
-        rebuilt_args = [unevaluate_arithmetic(e) for e in expr.args]
-        return Add(*rebuilt_args, evaluate=False)
-    elif expr.is_Mul:
-        rebuilt_args = [unevaluate_arithmetic(e) for e in expr.args]
-        return Mul(*rebuilt_args, evaluate=False)
-    else:
-        return expr.func(*[unevaluate_arithmetic(e) for e in expr.args])
 
 
 def retrieve_dimensions(expr):

--- a/devito/dse/inspection.py
+++ b/devito/dse/inspection.py
@@ -99,7 +99,8 @@ def collect_aliases(exprs):
     return found, clusters
 
 
-def estimate_cost(handle):
+def estimate_cost(handle, estimate_external_functions=False):
+    internal_ops = {'trigonometry': 50}
     try:
         # Is it a plain SymPy object ?
         iter(handle)
@@ -120,6 +121,9 @@ def estimate_cost(handle):
         handle = [i.rhs if i.is_Equality else i for i in handle]
         total_ops = sum(count_ops(i.args) for i in handle)
         non_flops = sum(count_ops(i.find(Indexed)) for i in handle)
+        if estimate_external_functions:
+            costly_ops = [retrieve_trigonometry(i) for i in handle]
+            total_ops += sum([internal_ops['trigonometry']*len(i) for i in costly_ops])
         return total_ops - non_flops
     except:
         warning("Cannot estimate cost of %s" % str(handle))

--- a/devito/dse/inspection.py
+++ b/devito/dse/inspection.py
@@ -2,8 +2,6 @@ from devito.dimension import t
 from devito.interfaces import SymbolicData
 from devito.logger import warning
 
-from devito.dse.extended_sympy import Add, Mul
-
 import numpy as np
 from sympy import (Indexed, Function, Symbol,
                    count_ops, flatten, lambdify, preorder_traversal)

--- a/devito/dse/symbolics.py
+++ b/devito/dse/symbolics.py
@@ -129,12 +129,11 @@ class Rewriter(object):
         self._optimize_trigonometry(state, mode=mode)
         self._replace_time_invariants(state, mode=mode)
 
-        from IPython import embed; embed()
         self._finalize(state)
 
         self._summary(mode)
 
-        return state
+        return state.exprs
 
     @dse_transformation
     def _factorize(self, state, **kwargs):
@@ -357,7 +356,8 @@ class Rewriter(object):
         Make sure that any subsequent sympy operation applied to the expressions
         in ``state.exprs`` does not alter the structure of the transformed objects.
         """
-        state.update(exprs=[unevaluate_arithmetic(e) for e in state.exprs])
+        exprs = [Eq(k, v) for k, v in state.mapper.items()] + state.exprs
+        state.update(exprs=[unevaluate_arithmetic(e) for e in exprs])
 
     def _summary(self, mode):
         """

--- a/devito/dse/symbolics.py
+++ b/devito/dse/symbolics.py
@@ -18,8 +18,8 @@ from sympy import (Add, Eq, Indexed, IndexedBase, S,
 from devito.dimension import t, x, y, z
 from devito.logger import perfbad, perfok, warning
 
-from devito.dse.extended_sympy import taylor_sin, taylor_cos
-from devito.dse.inspection import estimate_cost, terminals, unevaluate_arithmetic
+from devito.dse.extended_sympy import taylor_sin, taylor_cos, unevaluate_arithmetic
+from devito.dse.inspection import estimate_cost, terminals
 
 __all__ = ['rewrite']
 

--- a/devito/dse/symbolics.py
+++ b/devito/dse/symbolics.py
@@ -18,7 +18,7 @@ from sympy import (Add, Eq, Indexed, IndexedBase, S,
 from devito.dimension import t, x, y, z
 from devito.logger import perfbad, perfok, warning
 
-from devito.dse.extended_sympy import bhaskara_sin, bhaskara_cos
+from devito.dse.extended_sympy import taylor_sin, taylor_cos
 from devito.dse.inspection import estimate_cost, terminals, unevaluate_arithmetic
 
 __all__ = ['rewrite']
@@ -241,8 +241,8 @@ class Rewriter(object):
 
         processed = []
         for expr in exprs:
-            handle = expr.replace(sin, bhaskara_sin)
-            handle = handle.replace(cos, bhaskara_cos)
+            handle = expr.replace(sin, taylor_sin)
+            handle = handle.replace(cos, taylor_cos)
             processed.append(handle)
 
         return processed

--- a/devito/dse/symbolics.py
+++ b/devito/dse/symbolics.py
@@ -76,13 +76,13 @@ def rewrite(expr, mode='advanced'):
 def dse_transformation(func):
 
     def wrapper(self, state, **kwargs):
-        if kwargs['mode'].intersection(set(self.triggers[func.func_name])):
+        if kwargs['mode'].intersection(set(self.triggers[func.__name__])):
             tic = time()
             state.update(**func(self, state))
             toc = time()
 
-            self.ops[func.func_name] = estimate_cost(state.exprs)
-            self.timings[func.func_name] = toc - tic
+            self.ops[func.__name__] = estimate_cost(state.exprs)
+            self.timings[func.__name__] = toc - tic
 
     return wrapper
 
@@ -370,7 +370,7 @@ class Rewriter(object):
             baseline = self.ops['_cse']
             steps = " --> ".join("(%s) %d" % (k, v) for k, v in self.ops.items())
             try:
-                gain = float(baseline) / self.ops.values()[-1]
+                gain = float(baseline) / list(self.ops.values())[-1]
                 summary = " %s flops; gain: %.2f X" % (steps, gain)
             except ZeroDivisionError:
                 pass

--- a/devito/dse/symbolics.py
+++ b/devito/dse/symbolics.py
@@ -364,18 +364,16 @@ class Rewriter(object):
         Print a summary of the DSE transformations
         """
 
+        summary = ""
         if mode.intersection({'basic', 'advanced'}):
             baseline = self.ops['_cse']
-        else:
-            summary = ""
-
-        if baseline:
             steps = " --> ".join("(%s) %d" % (k, v) for k, v in self.ops.items())
-            gain = float(baseline) / self.ops.values()[-1]
-            summary = " %s flops; gain: %.2f X" % (steps, gain)
-
+            try:
+                gain = float(baseline) / self.ops.values()[-1]
+                summary = " %s flops; gain: %.2f X" % (steps, gain)
+            except ZeroDivisionError:
+                pass
         elapsed = sum(self.timings.values())
-
         dse("Rewriter:%s [%.2f s]" % (summary, elapsed))
 
 

--- a/devito/dse/symbolics.py
+++ b/devito/dse/symbolics.py
@@ -19,7 +19,8 @@ from sympy import (Add, Atom, Eq, Indexed, IndexedBase, S,
 from devito.dimension import t, x, y, z
 from devito.logger import dse, dse_warning
 
-from devito.dse.extended_sympy import taylor_sin, taylor_cos, unevaluate_arithmetic
+from devito.dse.extended_sympy import (bhaskara_sin, bhaskara_cos, unevaluate_arithmetic,
+                                       flip_indices)
 from devito.dse.graph import temporaries_graph
 from devito.dse.inspection import estimate_cost, terminals
 
@@ -272,8 +273,8 @@ class Rewriter(object):
 
         processed = []
         for expr in state.exprs:
-            handle = expr.replace(sin, taylor_sin)
-            handle = handle.replace(cos, taylor_cos)
+            handle = expr.replace(sin, bhaskara_sin)
+            handle = handle.replace(cos, bhaskara_cos)
             processed.append(handle)
 
         return {'exprs': processed}

--- a/devito/function_manager.py
+++ b/devito/function_manager.py
@@ -136,7 +136,7 @@ class FunctionManager(object):
                                                 '*%s' % (param[1]+"_pointer"))
                 statements.append(cast_pointer)
 
-        statements.append(function_descriptor.body)
+        statements.extend(function_descriptor.body)
         statements.append(cgen.Statement("return 0"))
 
         return cgen.Block(statements)

--- a/devito/interfaces.py
+++ b/devito/interfaces.py
@@ -73,6 +73,11 @@ class SymbolicData(Function, CachedSymbol):
     to (re-)create the dimension arguments of the symbolic function.
     """
 
+    is_DenseData = False
+    is_TimeData = False
+    is_Coordinates = False
+    is_PointData = False
+
     def __new__(cls, *args, **kwargs):
         if cls in _SymbolCache:
             newobj = Function.__new__(cls, *args)
@@ -115,6 +120,9 @@ class DenseData(SymbolicData):
     therefore do not support time derivatives. Use :class:`TimeData` for
     time-varying grid data.
     """
+
+    is_DenseData = True
+
     def __init__(self, *args, **kwargs):
         if not self._cached():
             self.name = kwargs.get('name')
@@ -371,6 +379,8 @@ class TimeData(DenseData):
     and whether we want to write intermediate timesteps in the buffer.
     """
 
+    is_TimeData = True
+
     def __init__(self, *args, **kwargs):
         if not self._cached():
             super(TimeData, self).__init__(*args, **kwargs)
@@ -462,9 +472,11 @@ class TimeData(DenseData):
 
 
 class CoordinateData(SymbolicData):
-    """Data object for sparse coordinate data that acts as a Function symbol
-
     """
+    Data object for sparse coordinate data that acts as a Function symbol
+    """
+
+    is_Coordinates = True
 
     def __init__(self, *args, **kwargs):
         if not self._cached():
@@ -501,7 +513,8 @@ class CoordinateData(SymbolicData):
 
 
 class PointData(DenseData):
-    """Data object for sparse point data that acts as a Function symbol
+    """
+    Data object for sparse point data that acts as a Function symbol
 
     :param name: Name of the resulting :class:`sympy.Function` symbol
     :param npoint: Number of points to sample
@@ -513,6 +526,8 @@ class PointData(DenseData):
     full-fledged sparse data container. For now, the naming and
     symbolic behaviour follows the use in the current problem.
     """
+
+    is_PointData = True
 
     def __init__(self, *args, **kwargs):
         if not self._cached():

--- a/devito/logger.py
+++ b/devito/logger.py
@@ -4,9 +4,9 @@ import logging
 import sys
 
 __all__ = ('set_log_level', 'set_log_noperf', 'log',
-           'DEBUG', 'INFO', 'AUTOTUNER', 'PERF_OK', 'PERF_WARN',
-           'WARNING', 'ERROR', 'CRITICAL',
-           'log', 'warning', 'error', 'info_at', 'perfok', 'perfbad',
+           'DEBUG', 'INFO', 'AUTOTUNER', 'DSE', 'DSE_WARN', 'WARNING',
+           'ERROR', 'CRITICAL',
+           'log', 'warning', 'error', 'info_at', 'dse', 'dse_warning',
            'RED', 'GREEN', 'BLUE')
 
 
@@ -18,15 +18,15 @@ logger.addHandler(_ch)
 DEBUG = logging.DEBUG
 INFO = logging.INFO
 AUTOTUNER = 27
-PERF_OK = 28
-PERF_WARN = 29
+DSE = 28
+DSE_WARN = 29
 WARNING = logging.WARNING
 ERROR = logging.ERROR
 CRITICAL = logging.CRITICAL
 
 logging.addLevelName(AUTOTUNER, "AUTOTUNER")
-logging.addLevelName(PERF_OK, "PERF_OK")
-logging.addLevelName(PERF_WARN, "PERF_WARN")
+logging.addLevelName(DSE, "DSE")
+logging.addLevelName(DSE_WARN, "DSE_WARN")
 
 logger.setLevel(INFO)
 
@@ -39,8 +39,8 @@ COLORS = {
     DEBUG: RED,
     INFO: NOCOLOR,
     AUTOTUNER: GREEN,
-    PERF_OK: GREEN,
-    PERF_WARN: BLUE,
+    DSE: NOCOLOR,
+    DSE_WARN: BLUE,
     WARNING: BLUE,
     ERROR: RED,
     CRITICAL: RED
@@ -51,7 +51,7 @@ def set_log_level(level):
     """
     Set the log level of the Devito logger.
 
-    :param level: accepted values are: DEBUG, INFO, AUTOTUNER, PERF_OK, PERF_WARN,
+    :param level: accepted values are: DEBUG, INFO, AUTOTUNER, DSE, DSE_WARN,
                   WARNING, ERROR, CRITICAL
     """
     logger.setLevel(level)
@@ -68,10 +68,10 @@ def log(msg, level=INFO, *args, **kwargs):
     the severity 'level'.
 
     :param msg: the message to be printed.
-    :param level: accepted values are: DEBUG, INFO, AUTOTUNER, PERF_OK, PERF_WARN,
+    :param level: accepted values are: DEBUG, INFO, AUTOTUNER, DSE, DSE_WARN,
                   WARNING, ERROR, CRITICAL
     """
-    assert level in [DEBUG, INFO, AUTOTUNER, PERF_OK, PERF_WARN,
+    assert level in [DEBUG, INFO, AUTOTUNER, DSE, DSE_WARN,
                      WARNING, ERROR, CRITICAL]
 
     color = COLORS[level] if sys.stdout.isatty() and sys.stderr.isatty() else '%s'
@@ -98,9 +98,9 @@ def debug(msg, *args, **kwargs):
     log(msg, DEBUG, *args, **kwargs)
 
 
-def perfok(msg, *args, **kwargs):
-    log(msg, PERF_OK, *args, **kwargs)
+def dse(msg, *args, **kwargs):
+    log("DSE: %s" % msg, DSE, *args, **kwargs)
 
 
-def perfbad(msg, *args, **kwargs):
-    log(msg, PERF_WARN, *args, **kwargs)
+def dse_warning(msg, *args, **kwargs):
+    log(msg, DSE_WARN, *args, **kwargs)


### PR DESCRIPTION
This PR introduces:

* the concept of ``DSE transformation step`` (see the ``dse_transformation`` decorator in symbolics.py)
* a complete new DSE transformation step: code motion. This is implemented in ``_replace_time_invariants``. Time-invariant sub-expressions are sought and given a score. If the score is greater than an empirically determined threshold, then the sub-expression at hand is "lifted" outside the time loop and evaluated in a temporary
* taylor-based approximation of sin/cos. The default choice, however, is still Bhaskara, as tests start failing with Taylor. I wonder if this is due to the remarkably bad approximation that Taylor gives as one gets far from default center, 0
* refactoring and improvements of various nature for the DSE
* extended propagator to emit time-invariant code outside of the time loop
* new tests

I run some tests to verify the impact of the new transformation (single socket, 8 threads, icc O2 xHost, pinning, etc):

* TTI space order 4: runtime drops from 127s to 91s (~1.4X speed-up)
* TTI space order 10: runtime drops from 373s to 322s (1.16X speed-up)

If *no* code motion is performed and sin/cos are replaced with the respective Bhaskara approximations, the execution time in TTI space order 4 only drops from 127s to 105s. 
If code motion is performed and *no* Bhaskara approximation is introduced, than the run-time is pretty much the same (92s in TTI space order 4) *but* the compile time is much higher (icc takes more to vectorize loops with sin/cos). For example, in TTI space order 10, the compilation time drops from 74s to 16s thanks to Bhaskara