### PR TITLE
Move profiling to DSE

### DIFF
--- a/devito/dse/extended_sympy.py
+++ b/devito/dse/extended_sympy.py
@@ -3,7 +3,7 @@ Extended SymPy hierarchy.
 """
 
 import sympy
-from sympy import Expr, Float, Indexed, S
+from sympy import Expr, Float
 from sympy.core.basic import _aresame
 from sympy.functions.elementary.trigonometric import TrigonometricFunction
 
@@ -111,58 +111,3 @@ def eval_taylor_cos(expr):
         return v.doit()
     except (TypeError, ValueError):
         return v
-
-
-def unevaluate_arithmetic(expr):
-    """
-    Reconstruct ``expr`` turning all :class:`sympy.Mul` and :class:`sympy.Add`
-    into, respectively, :class:`devito.Mul` and :class:`devito.Add`.
-    """
-    if expr.is_Float:
-        return expr.func(*expr.atoms())
-    elif isinstance(expr, Indexed):
-        return expr.func(*expr.args)
-    elif expr.is_Symbol:
-        return expr.func(expr.name)
-    elif expr in [S.Zero, S.One, S.NegativeOne, S.Half]:
-        return expr.func()
-    elif expr.is_Atom:
-        return expr.func(*expr.atoms())
-    elif expr.is_Add:
-        rebuilt_args = [unevaluate_arithmetic(e) for e in expr.args]
-        return Add(*rebuilt_args, evaluate=False)
-    elif expr.is_Mul:
-        rebuilt_args = [unevaluate_arithmetic(e) for e in expr.args]
-        return Mul(*rebuilt_args, evaluate=False)
-    else:
-        return expr.func(*[unevaluate_arithmetic(e) for e in expr.args])
-
-
-def flip_indices(expr, rule):
-    """
-    Construct a new ``expr'`` from ``expr`` such that all indices are shifted as
-    established by ``rule``.
-
-    For example: ::
-
-        (rule=(x, y)) a[i][j+2] + b[j][i] --> a[x][y] + b[x][y]
-    """
-
-    def run(expr, flipped):
-        if expr.is_Float:
-            return expr.func(*expr.atoms())
-        elif isinstance(expr, Indexed):
-            flipped.add(expr.indices)
-            return Indexed(expr.base, *rule)
-        elif expr.is_Symbol:
-            return expr.func(expr.name)
-        elif expr in [S.Zero, S.One, S.NegativeOne, S.Half]:
-            return expr.func()
-        elif expr.is_Atom:
-            return expr.func(*expr.atoms())
-        else:
-            return expr.func(*[run(e, flipped) for e in expr.args], evaluate=False)
-
-    flipped = set()
-    handle = run(expr, flipped)
-    return handle, flipped

--- a/devito/dse/inspection.py
+++ b/devito/dse/inspection.py
@@ -1,5 +1,5 @@
 import numpy as np
-from sympy import (Indexed, Function, Symbol,
+from sympy import (Indexed, Function, Number, Symbol,
                    count_ops, lambdify, preorder_traversal, sin, cos)
 
 from devito.dimension import t
@@ -252,6 +252,17 @@ def is_time_invariant(expr, graph=None):
             to_visit.append(graph[i].rhs)
 
     return True
+
+
+def is_binary_op(expr):
+    """
+    Return True if ``expr`` is a binary operation, False otherwise.
+    """
+
+    if not (expr.is_Add or expr.is_Mul) and not len(expr.args) == 2:
+        return False
+
+    return all(isinstance(a, (Number, Symbol, Indexed)) for a in expr.args)
 
 
 def indexify(expr):

--- a/devito/dse/inspection.py
+++ b/devito/dse/inspection.py
@@ -119,8 +119,8 @@ def estimate_cost(handle, estimate_external_functions=False):
         # At this point it must be a list of SymPy objects
         # We don't count non floating point operations
         handle = [i.rhs if i.is_Equality else i for i in handle]
-        total_ops = sum(count_ops(i.args) for i in handle)
-        non_flops = sum(count_ops(i.find(Indexed)) for i in handle)
+        total_ops = count_ops(handle)
+        non_flops = sum(count_ops(retrieve_indexed(i, mode='all')) for i in handle)
         if estimate_external_functions:
             costly_ops = [retrieve_trigonometry(i) for i in handle]
             total_ops += sum([internal_ops['trigonometry']*len(i) for i in costly_ops])

--- a/devito/dse/manipulation.py
+++ b/devito/dse/manipulation.py
@@ -1,0 +1,76 @@
+"""
+Routines to construct new SymPy expressions transforming the provided input.
+"""
+
+from sympy import Indexed, S
+
+from devito.dse.extended_sympy import Add, Mul
+
+
+def unevaluate_arithmetic(expr):
+    """
+    Reconstruct ``expr`` turning all :class:`sympy.Mul` and :class:`sympy.Add`
+    into, respectively, :class:`devito.Mul` and :class:`devito.Add`.
+    """
+    if expr.is_Float:
+        return expr.func(*expr.atoms())
+    elif isinstance(expr, Indexed):
+        return expr.func(*expr.args)
+    elif expr.is_Symbol:
+        return expr.func(expr.name)
+    elif expr in [S.Zero, S.One, S.NegativeOne, S.Half]:
+        return expr.func()
+    elif expr.is_Atom:
+        return expr.func(*expr.atoms())
+    elif expr.is_Add:
+        rebuilt_args = [unevaluate_arithmetic(e) for e in expr.args]
+        return Add(*rebuilt_args, evaluate=False)
+    elif expr.is_Mul:
+        rebuilt_args = [unevaluate_arithmetic(e) for e in expr.args]
+        return Mul(*rebuilt_args, evaluate=False)
+    else:
+        return expr.func(*[unevaluate_arithmetic(e) for e in expr.args])
+
+
+def flip_indices(expr, rule):
+    """
+    Construct a new ``expr'`` from ``expr`` such that all indices are shifted as
+    established by ``rule``.
+
+    For example: ::
+
+        (rule=(x, y)) a[i][j+2] + b[j][i] --> a[x][y] + b[x][y]
+    """
+
+    def run(expr, flipped):
+        if expr.is_Float:
+            return expr.func(*expr.atoms())
+        elif isinstance(expr, Indexed):
+            flipped.add(expr.indices)
+            return Indexed(expr.base, *rule)
+        elif expr.is_Symbol:
+            return expr.func(expr.name)
+        elif expr in [S.Zero, S.One, S.NegativeOne, S.Half]:
+            return expr.func()
+        elif expr.is_Atom:
+            return expr.func(*expr.atoms())
+        else:
+            return expr.func(*[run(e, flipped) for e in expr.args], evaluate=False)
+
+    flipped = set()
+    handle = run(expr, flipped)
+    return handle, flipped
+
+
+def rxreplace(exprs, mapper):
+    """
+    Apply Sympy's xreplace recursively.
+    """
+
+    replaced = []
+    for i in exprs:
+        old, new = i, i.xreplace(mapper)
+        while new != old:
+            old, new = new, new.xreplace(mapper)
+        replaced.append(new)
+    return replaced

--- a/devito/dse/symbolics.py
+++ b/devito/dse/symbolics.py
@@ -21,7 +21,7 @@ from devito.logger import dse, dse_warning
 
 from devito.dse.extended_sympy import bhaskara_sin, bhaskara_cos
 from devito.dse.graph import temporaries_graph
-from devito.dse.inspection import (collect_aliases, estimate_cost,
+from devito.dse.inspection import (collect_aliases, estimate_cost, estimate_memory,
                                    is_binary_op, is_time_invariant, terminals)
 from devito.dse.manipulation import flip_indices, rxreplace, unevaluate_arithmetic
 
@@ -117,6 +117,18 @@ class State(object):
     @property
     def ops(self):
         return self.ops_time_invariants + self.ops_time_varying
+
+    @property
+    def memory_time_invariants(self):
+        return estimate_memory(self.time_invariants)
+
+    @property
+    def memory_time_varying(self):
+        return estimate_memory(self.time_varying)
+
+    @property
+    def memory(self):
+        return self.memory_time_invariants + self.memory_time_varying
 
 
 class Rewriter(object):
@@ -364,6 +376,7 @@ class Rewriter(object):
         """
         exprs = [Eq(k, v) for k, v in state.mapper.items()] + state.exprs
         state.update(exprs=[unevaluate_arithmetic(e) for e in exprs])
+
 
     def _summary(self, mode):
         """

--- a/devito/dse/symbolics.py
+++ b/devito/dse/symbolics.py
@@ -228,7 +228,7 @@ class Rewriter(object):
                     mapper[i] = revert[i]
             revert[k] = v.xreplace(mapper)
         mapper = {}
-        for e in leaves + keep.values():
+        for e in leaves + list(keep.values()):
             for i in preorder_traversal(e):
                 if isinstance(i, Indexed):
                     new_indices = []

--- a/devito/dse/symbolics.py
+++ b/devito/dse/symbolics.py
@@ -129,6 +129,7 @@ class Rewriter(object):
         self._factorize(state, mode=mode)
         self._optimize_trigonometry(state, mode=mode)
         self._replace_time_invariants(state, mode=mode)
+        self._factorize(state, mode=mode)
 
         self._finalize(state)
 

--- a/devito/dse/symbolics.py
+++ b/devito/dse/symbolics.py
@@ -365,7 +365,6 @@ class Rewriter(object):
         exprs = [Eq(k, v) for k, v in state.mapper.items()] + state.exprs
         state.update(exprs=[unevaluate_arithmetic(e) for e in exprs])
 
-
     def _summary(self, mode):
         """
         Print a summary of the DSE transformations

--- a/devito/dse/symbolics.py
+++ b/devito/dse/symbolics.py
@@ -98,6 +98,26 @@ class State(object):
         self.exprs = exprs or self.exprs
         self.mapper = mapper or self.mapper
 
+    @property
+    def time_invariants(self):
+        return [i for i in self.exprs if i.lhs in self.mapper]
+
+    @property
+    def time_varying(self):
+        return [i for i in self.exprs if i not in self.time_invariants]
+
+    @property
+    def ops_time_invariants(self):
+        return estimate_cost(self.time_invariants)
+
+    @property
+    def ops_time_varying(self):
+        return estimate_cost(self.time_varying)
+
+    @property
+    def ops(self):
+        return self.ops_time_invariants + self.ops_time_varying
+
 
 class Rewriter(object):
 
@@ -344,6 +364,7 @@ class Rewriter(object):
         """
         exprs = [Eq(k, v) for k, v in state.mapper.items()] + state.exprs
         state.update(exprs=[unevaluate_arithmetic(e) for e in exprs])
+
 
     def _summary(self, mode):
         """

--- a/devito/dse/symbolics.py
+++ b/devito/dse/symbolics.py
@@ -378,7 +378,6 @@ class Rewriter(object):
         exprs = [Eq(k, v) for k, v in state.mapper.items()] + state.exprs
         state.update(exprs=[unevaluate_arithmetic(e) for e in exprs])
 
-
     def _summary(self, mode):
         """
         Print a summary of the DSE transformations

--- a/devito/dse/symbolics.py
+++ b/devito/dse/symbolics.py
@@ -19,11 +19,11 @@ from sympy import (Add, Eq, Indexed, IndexedBase, S,
 from devito.dimension import t, x, y, z
 from devito.logger import dse, dse_warning
 
-from devito.dse.extended_sympy import (bhaskara_sin, bhaskara_cos, unevaluate_arithmetic,
-                                       flip_indices)
+from devito.dse.extended_sympy import bhaskara_sin, bhaskara_cos
 from devito.dse.graph import temporaries_graph
 from devito.dse.inspection import (collect_aliases, estimate_cost,
-                                   is_time_invariant, terminals)
+                                   is_binary_op, is_time_invariant, terminals)
+from devito.dse.manipulation import flip_indices, rxreplace, unevaluate_arithmetic
 
 __all__ = ['rewrite']
 

--- a/devito/function_manager.py
+++ b/devito/function_manager.py
@@ -13,7 +13,8 @@ class FunctionManager(object):
     :param openmp: True if using OpenMP. Default is False
     """
     libraries = ['assert.h', 'stdlib.h', 'math.h',
-                 'stdio.h', 'string.h', 'sys/time.h']
+                 'stdio.h', 'string.h', 'sys/time.h',
+                 'xmmintrin.h', 'pmmintrin.h']
 
     _pymic_attribute = 'PYMIC_KERNEL'
 

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -7,7 +7,6 @@ from devito.compiler import get_compiler_from_env
 from devito.dimension import t, x, y, z
 from devito.dse.inspection import (indexify, retrieve_dimensions,
                                    retrieve_symbols, tolambda)
-from devito.dse.symbolics import rewrite
 from devito.interfaces import TimeData
 from devito.propagator import Propagator
 
@@ -115,10 +114,7 @@ class Operator(object):
         # Apply user-defined subs to stencil
         self.stencils = [eqn.subs(subs[0]) for eqn in self.stencils]
 
-        # Use the Devito Symbolic Engine to reduce the operation count
-        self.stencils = rewrite(self.stencils, mode=dse)
-
-        self.propagator = Propagator(self.getName(), nt, shape, self.stencils,
+        self.propagator = Propagator(self.getName(), nt, shape, self.stencils, dse=dse,
                                      dtype=dtype, spc_border=spc_border,
                                      time_order=time_order, forward=forward,
                                      space_dims=self.space_dims, compiler=self.compiler,
@@ -133,7 +129,6 @@ class Operator(object):
         for param in self.signature:
             self.propagator.add_devito_param(param)
             self.symbol_to_data[param.name] = param
-        self.propagator.stencils = self.stencils
 
     @property
     def signature(self):

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -112,11 +112,12 @@ class Operator(object):
         self.stencils = [Eq(indexify(eqn.lhs), indexify(eqn.rhs))
                          for eqn in self.stencils]
 
-        # Applies CSE
-        self.stencils = rewrite(self.stencils, mode=dse)
-
         # Apply user-defined subs to stencil
         self.stencils = [eqn.subs(subs[0]) for eqn in self.stencils]
+
+        # Use the Devito Symbolic Engine to reduce the operation count
+        self.stencils = rewrite(self.stencils, mode=dse)
+
         self.propagator = Propagator(self.getName(), nt, shape, self.stencils,
                                      dtype=dtype, spc_border=spc_border,
                                      time_order=time_order, forward=forward,

--- a/devito/profiler.py
+++ b/devito/profiler.py
@@ -22,8 +22,6 @@ class Profiler(object):
 
         self._C_timings = None
 
-        self.num_flops = {}
-
     def add_profiling(self, code, name, omp_flag=None, to_ignore=None):
         """Function to add profiling code to the given :class:`cgen.Block`.
 
@@ -47,9 +45,6 @@ class Profiler(object):
         omp_flag = omp_flag or []
 
         self.t_fields.append((name, c_double))
-
-        self.num_flops[name] = FlopsCounter(code, name, self.openmp,
-                                            self.float_size, to_ignore or []).run()
 
         init = [
             Statement("struct timeval start_%s, end_%s" % (name, name))
@@ -124,136 +119,3 @@ class Profiler(object):
                     for field, _ in self._C_timings._fields_}
         else:
             return {}
-
-    @property
-    def gflops(self):
-        """GFlops per loop iteration, keyed by code section."""
-        return self.num_flops
-
-
-class FlopsCounter(object):
-
-    """Compute the operational intensity of a stencil."""
-
-    def __init__(self, code, name, openmp, float_size, to_ignore):
-        self.code = code
-        self.name = name
-        self.openmp = openmp
-        self.float_size = float_size
-
-        self.to_ignore = [
-            "int",
-            "float",
-            "double",
-            "F",
-            "e",
-            "fabsf",
-            "powf",
-            "floor",
-            "ceil",
-            "temp",
-            "i",
-            "t",
-            "p",  # This one shouldn't be here.
-                  # It should be passed in by an Iteration object.
-                  # Added only because tti_example uses it.
-        ] + to_ignore
-        self.seen = set()
-
-    def run(self):
-        """
-        Calculates the total operation intensity of the code provided.
-        If needed, lets the C code calculate it.
-        """
-        num_flops = 0
-
-        for elem in self.code:
-            if isinstance(elem, Assign):
-                num_flops += self._handle_assign(elem)
-            elif isinstance(elem, For):
-                num_flops += self._handle_for(elem)
-            elif isinstance(elem, Block):
-                num_flops += self._handle_block(elem)[0]
-            else:
-                # no op
-                pass
-
-        return num_flops
-
-    def _handle_for(self, loop):
-        loop_flops = 0
-        loop_oi_f = 0
-
-        if isinstance(loop.body, Assign):
-            loop_flops = self._handle_assign(loop.body)
-            loop_oi_f = loop_flops
-        elif isinstance(loop.body, Block):
-            loop_oi_f, loop_flops = self._handle_block(loop.body)
-        elif isinstance(loop.body, For):
-            loop_oi_f = self._handle_for(loop.body)
-        else:
-            # no op
-            pass
-
-        old_body = loop.body
-
-        while isinstance(old_body, Block) and isinstance(old_body.contents[0], Statement):
-            old_body = old_body.contents[1]
-
-        if loop_flops == 0:
-            if old_body in self.seen:
-                return 0
-
-            self.seen.add(old_body)
-
-            return loop_oi_f
-
-        if old_body in self.seen:
-            return 0
-
-        self.seen.add(old_body)
-        return loop_oi_f
-
-    def _handle_block(self, block):
-        block_flops = 0
-        block_oi = 0
-
-        for elem in block.contents:
-            if isinstance(elem, Assign):
-                a_flops = self._handle_assign(elem)
-                block_flops += a_flops
-                block_oi += a_flops
-            elif isinstance(elem, Block):
-                nblock_oi, nblock_flops = self._handle_block(elem)
-                block_oi += nblock_oi
-                block_flops += nblock_flops
-            elif isinstance(elem, For):
-                block_oi += self._handle_for(elem)
-            else:
-                # no op
-                pass
-
-        return block_oi, block_flops
-
-    def _handle_assign(self, assign):
-        flops = 0
-
-        # removing casting statements and function calls to floor
-        # that can confuse the parser
-        string = assign.lvalue + " " + assign.rvalue
-
-        brackets = 0
-        for idx in range(len(string)):
-            c = string[idx]
-
-            # We skip index operations. The third check works because in the
-            # generated code constants always precede variables in operations
-            # and is needed because Sympy prints fractions like this: 1.0F/4.0F
-            if brackets == 0 and c in "*/-+" and not string[idx+1].isdigit():
-                flops += 1
-            elif c == "[":
-                brackets += 1
-            elif c == "]":
-                brackets -= 1
-
-        return flops

--- a/devito/profiler.py
+++ b/devito/profiler.py
@@ -2,7 +2,7 @@ from ctypes import Structure, byref, c_double
 
 import numpy as np
 
-from devito.cgen_wrapper import Assign, Block, For, Statement, Struct, Value
+from devito.cgen_wrapper import Block, Statement, Struct, Value
 
 
 class Profiler(object):

--- a/devito/propagator.py
+++ b/devito/propagator.py
@@ -251,7 +251,8 @@ class Propagator(object):
             niters_per_section[key] = with_time_loop(niters)
 
         key = LOOP_BODY.name
-        niters = reduce(operator.mul, self.shape)
+        niters = reduce(operator.mul,
+                        [j - i for i, j in self._space_loop_limits.values()])
         niters_per_section[key] = with_time_loop(niters)
 
         for i, subsection in enumerate(self.time_loop_stencils_a):

--- a/devito/propagator.py
+++ b/devito/propagator.py
@@ -551,6 +551,10 @@ class Propagator(object):
         else:
             header = []
 
+        # Avoid denormal numbers
+        extra = [cgen.Line('_MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_ON);'),
+                 cgen.Line('_MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);')]
+
         # Statements to be inserted into the time loop before the spatial loop
         pre_stencils = [self.time_substitutions(x)
                         for x in self.time_loop_stencils_b]
@@ -597,7 +601,8 @@ class Propagator(object):
         # Code to declare the time stepping variables (outside the time loop)
         def_time_step = [cgen.Value("int", t_var_def.name)
                          for t_var_def in self.time_steppers]
-        body = cgen.Block(time_invariants + def_time_step + omp_parallel + [loop_body])
+        body = cgen.Block(extra + time_invariants + def_time_step +
+                          omp_parallel + [loop_body])
 
         return header + [body]
 

--- a/devito/propagator.py
+++ b/devito/propagator.py
@@ -1,7 +1,7 @@
 from __future__ import absolute_import
 
 import operator
-from collections import Iterable, defaultdict
+from collections import Iterable, OrderedDict, defaultdict
 from functools import reduce
 from hashlib import sha1
 from os import path
@@ -17,7 +17,7 @@ from devito.compiler import (IntelMICCompiler, get_compiler_from_env,
                              get_tmp_dir, jit_compile_and_load)
 from devito.dimension import t, x, y, z
 from devito.dse.inspection import retrieve_dtype
-from devito.dse.symbolics import _temp_prefix
+from devito.dse.symbolics import _temp_prefix, rewrite
 from devito.expression import Expression
 from devito.function_manager import FunctionDescriptor, FunctionManager
 from devito.iteration import Iteration
@@ -51,6 +51,8 @@ class Propagator(object):
                      If not provided, the compiler will be inferred from the
                      environment variable DEVITO_ARCH, or default to GNUCompiler
     :param profile: Flag to enable performance profiling
+    :param dse: Set of transformations applied by the Devito Symbolic Engine.
+                Available: [None, 'basic', 'advanced' (default)]
     :param cache_blocking: Block sizes used for cache clocking. Can be either a single
                            number used for all dimensions except inner most or a list
                            explicitly stating block sizes for each dimension
@@ -59,7 +61,7 @@ class Propagator(object):
                            tune block sizes
     """
 
-    def __init__(self, name, nt, shape, stencils, spc_border=0, time_order=0,
+    def __init__(self, name, nt, shape, stencils, dse=None, spc_border=0, time_order=0,
                  time_dim=None, space_dims=None, dtype=np.float32, forward=True,
                  compiler=None, profile=False, cache_blocking=None):
         self.stencils = stencils
@@ -80,6 +82,7 @@ class Propagator(object):
         self.time_steppers = []
         self.time_order = time_order
         self.nt = nt
+        self.time_invariants = []
         self.time_loop_stencils_b = []
         self.time_loop_stencils_a = []
 
@@ -111,6 +114,11 @@ class Propagator(object):
         self.profile = profile
         # Profiler needs to know whether openmp is set
         self.profiler = Profiler(self.compiler.openmp, self.dtype)
+
+        # Performance data
+        self._dse = dse
+        self._ops = {}
+        self._memory = {}
 
         # Cache blocking and block sizes
         self.cache_blocking = cache_blocking
@@ -182,8 +190,12 @@ class Propagator(object):
         if self._ccode is None:
             manager = FunctionManager([self.fd], mic_flag=self.mic_flag,
                                       openmp=self.compiler.openmp)
-            # For some reason we need this call to trigger fd.body
-            self.get_fd()
+
+            # Go through the Devito Symbolic Engine to generate optimized code
+            self._optimize()
+
+            # Perform code generation
+            self._get_fd()
 
             if self.profile:
                 manager.add_struct_definition(self.profiler.as_cgen_struct(Profiler.TIME))
@@ -220,20 +232,18 @@ class Propagator(object):
     def oi(self):
         """Summary of operational intensities, by code section."""
 
-        gflops_per_section = self.gflops
-        bytes_per_section = self.traffic()
         oi_per_section = {}
 
         for i, subsection in enumerate(self.time_loop_stencils_b):
             key = "%s%d" % (PRE_STENCILS.name, i)
-            oi_per_section[key] = 1.0*gflops_per_section[key]/bytes_per_section[key]
+            oi_per_section[key] = 1.0*self.gflops[key]/self.traffic[key]
 
         key = LOOP_BODY.name
-        oi_per_section[key] = 1.0*gflops_per_section[key]/bytes_per_section[key]
+        oi_per_section[key] = 1.0*self.gflops[key]/self.traffic[key]
 
         for i, subsection in enumerate(self.time_loop_stencils_a):
             key = "%s%d" % (POST_STENCILS.name, i)
-            oi_per_section[key] = 1.0*gflops_per_section[key]/bytes_per_section[key]
+            oi_per_section[key] = 1.0*self.gflops[key]/self.traffic[key]
 
         return oi_per_section
 
@@ -250,10 +260,10 @@ class Propagator(object):
             niters = subsection.limits[1] if isinstance(subsection, Iteration) else 1
             niters_per_section[key] = with_time_loop(niters)
 
-        key = LOOP_BODY.name
         niters = reduce(operator.mul,
                         [j - i for i, j in self._space_loop_limits.values()])
-        niters_per_section[key] = with_time_loop(niters)
+        niters_per_section[TIME_INVARIANTS.name] = niters
+        niters_per_section[LOOP_BODY.name] = with_time_loop(niters)
 
         for i, subsection in enumerate(self.time_loop_stencils_a):
             key = "%s%d" % (POST_STENCILS.name, i)
@@ -262,89 +272,37 @@ class Propagator(object):
 
         return niters_per_section
 
-    def traffic(self, mode='realistic'):
+    @property
+    def dataspace(self):
+        """Summary of data items accessed, by code section."""
+        handle = self.niters
+        handle[LOOP_BODY.name] = reduce(operator.mul, (self.nt,) + self.shape)
+        return handle
+
+    @property
+    def traffic(self):
         """Summary of Bytes moved between CPU (last level cache) and DRAM,
-        by code section.
-
-        :param mode: Several estimates are possible: ::
-
-            * ideal: also known as "compulsory traffic", which is the minimum
-                number of bytes to be moved (ie, models an infinite cache)
-            * ideal_with_stores: like ideal, but a data item which is both read
-                and written is counted twice (load + store)
-            * realistic: assume that all datasets, even those that do not depend
-                on time, need to be re-loaded at each time iteration
-        """
-
-        assert mode in ['ideal', 'ideal_with_stores', 'realistic']
-
-        def access(symbol):
-            assert isinstance(symbol, Indexed)
-            # Irregular accesses (eg A[B[i]]) are counted as compulsory traffic
-            if any(i.atoms(Indexed) for i in symbol.indices):
-                return symbol
-            else:
-                return symbol.base
-
-        def count(self, expressions):
-            if mode in ['ideal', 'ideal_with_stores']:
-                filter = lambda s: self.time_dim in s.atoms()
-            else:
-                filter = lambda s: s
-            reads = set(flatten([e.rhs.atoms(Indexed) for e in expressions]))
-            writes = set(flatten([e.lhs.atoms(Indexed) for e in expressions]))
-            reads = set([access(s) for s in reads if filter(s)])
-            writes = set([access(s) for s in writes if filter(s)])
-            if mode == 'ideal':
-                return len(set(reads) | set(writes))
-            else:
-                return len(reads) + len(writes)
-
-        niters = self.niters
+        by code section."""
         dsize = np.dtype(self.dtype).itemsize
-
-        bytes_per_section = {}
-
-        for i, subsection in enumerate(self.time_loop_stencils_b):
-            key = "%s%d" % (PRE_STENCILS.name, i)
-            if isinstance(subsection, Iteration):
-                expressions = [e.stencil for e in subsection.expressions]
-            else:
-                expressions = subsection.stencil
-            bytes_per_section[key] = dsize*count(self, expressions)*niters[key]
-
-        key = LOOP_BODY.name
-        bytes_per_section[key] = dsize*count(self, self.stencils)*niters[key]
-
-        for i, subsection in enumerate(self.time_loop_stencils_a):
-            key = "%s%d" % (POST_STENCILS.name, i)
-            if isinstance(subsection, Iteration):
-                expressions = [e.stencil for e in subsection.expressions]
-            else:
-                expressions = subsection.stencil
-            bytes_per_section[key] = dsize*count(self, expressions)*niters[key]
-
-        return bytes_per_section
+        return {k: dsize*self.dataspace[k]*v for k, v in self._memory.items()}
 
     @property
     def gflops(self):
         """Summary of GFlops performed, by code section."""
 
         niters = self.niters
-
-        gflops_per_iteration = self.profiler.gflops
         gflops_per_section = {}
 
         for i, subsection in enumerate(self.time_loop_stencils_b):
             key = "%s%d" % (PRE_STENCILS.name, i)
-            gflops_per_section[key] = gflops_per_iteration[key]*niters[key]
+            gflops_per_section[key] = self._ops[key]*niters[key]
 
         key = LOOP_BODY.name
-        gflops_per_section[key] = gflops_per_iteration[key]*niters[key]
+        gflops_per_section[key] = self._ops[key]*niters[key]
 
         for i, subsection in enumerate(self.time_loop_stencils_a):
             key = "%s%d" % (POST_STENCILS.name, i)
-            gflops_per_section[key] = gflops_per_iteration[key]*niters[key]
+            gflops_per_section[key] = self._ops[key]*niters[key]
 
         return gflops_per_section
 
@@ -476,6 +434,36 @@ class Propagator(object):
                                               ", ".join([str(i) for i in array_names])
                                               ))
 
+    def _optimize(self):
+        """
+        Use the Devito Symbolic Engine to reduce the operation count of stencils
+        and any other expressions appearing in the kernel.
+        """
+
+        handle = rewrite(self.stencils, mode=self._dse)
+
+        self.stencils = handle.time_varying
+        self._ops[LOOP_BODY.name] = handle.ops_time_varying
+        self._memory[LOOP_BODY.name] = handle.memory_time_varying
+
+        self.time_invariants.extend(handle.time_invariants)
+        self._ops[TIME_INVARIANTS.name] = handle.ops_time_invariants
+        self._memory[TIME_INVARIANTS.name] = handle.memory_time_invariants
+
+        sections = OrderedDict()
+        sections[PRE_STENCILS.name] = self.time_loop_stencils_b
+        sections[POST_STENCILS.name] = self.time_loop_stencils_a
+        for k, section in sections.items():
+            for i, subsection in enumerate(section):
+                if isinstance(subsection, Iteration):
+                    exprs = [e.stencil for e in subsection.expressions]
+                else:
+                    exprs = subsection.stencil
+                handle = rewrite(exprs, mode='noop')
+                key = "%s%d" % (k, i)
+                self._ops[key] = handle.ops_time_varying
+                self._memory[key] = handle.memory_time_varying
+
     def generate_loops(self):
         """Assuming that the variable order defined in init (#var_order) is the
         order the corresponding dimensions are layout in memory, the last variable
@@ -491,10 +479,8 @@ class Propagator(object):
             time_invariants = []
             loop_body = self.loop_body
         elif self.time_order:
-            time_invariants = [i for i in self.stencils if isinstance(i.lhs, Indexed)
-                               and i.lhs.indices == self.space_dims]
-            loop_body = [i for i in self.stencils if i not in time_invariants]
-            loop_body = self.sympy_to_cgen(loop_body)
+            time_invariants = self.time_invariants
+            loop_body = self.sympy_to_cgen(self.stencils)
         else:
             time_invariants = []
             loop_body = self.sympy_to_cgen(self.stencils)
@@ -847,7 +833,7 @@ class Propagator(object):
 
         return symbols(name)
 
-    def get_fd(self):
+    def _get_fd(self):
         """Get a FunctionDescriptor that describes the code represented by this Propagator
         in the format that FunctionManager and JitManager can deal with it.
         Before calling, make sure you have either called set_jit_params


### PR DESCRIPTION
This PR makes a step forward towards Devito 2.0

The obsolete, hacky, and bug-prone profiler.py module is drastically trimmed, and its key functionality of "counting flops in the generated code" is moved to the DSE. It is indeed possible to count the number of operations by applying the DSE function ``estimate_cost``, which in turn wraps Sympy's  ``count_ops``, to any Sympy expression.

The operation of counting the memory accesses performed by a Sympy expression is also moved to the DSE (from Propagator).

Summing up, now the DSE returns a data structure containing:
- the transformed expressions
- a mapper to identify time-invariant expressions, out of the transformed expressions
- operations count
- memory accesses count

This PR depends on #170 