### PR TITLE
Compiler: Adding `march=native` to `GNU/CustomCompiler` to enable SSE

### DIFF
--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -75,7 +75,7 @@ class GNUCompiler(Compiler):
         self.version = kwargs.get('version', None)
         self.cc = 'gcc' if self.version is None else 'gcc-%s' % self.version
         self.ld = 'gcc' if self.version is None else 'gcc-%s' % self.version
-        self.cflags = ['-O3', '-g', '-fPIC', '-Wall', '-std=c99']
+        self.cflags = ['-O3', '-g', '-march=native', '-fPIC', '-Wall', '-std=c99']
         self.ldflags = ['-shared']
 
         if self.openmp:
@@ -173,7 +173,8 @@ class CustomCompiler(Compiler):
         super(CustomCompiler, self).__init__(*args, **kwargs)
         self.cc = environ.get('CC', 'gcc')
         self.ld = environ.get('LD', 'gcc')
-        self.cflags = environ.get('CFLAGS', '-O3 -g -fPIC -Wall -std=c99').split(' ')
+        default = '-O3 -g -march=native -fPIC -Wall -std=c99'
+        self.cflags = environ.get('CFLAGS', default).split(' ')
         self.ldflags = environ.get('LDFLAGS', '-shared').split(' ')
 
         if self.openmp:


### PR DESCRIPTION
On GCC version 4.8.4 our compiles otherwise fail with the recent denormals fix due to SSE not being enabled.