### PR TITLE
Toward Devito 3.0: extended StencilKernel, introduce DLE

### DIFF
--- a/devito/dimension.py
+++ b/devito/dimension.py
@@ -1,5 +1,8 @@
 import cgen
+
+import numpy as np
 from sympy import Symbol
+
 
 __all__ = ['Dimension', 'x', 'y', 'z', 't', 'p']
 
@@ -38,6 +41,11 @@ class Dimension(Symbol):
     def decl(self):
         """Variable declaration for C-level kernel headers"""
         return cgen.Value("const int", self.ccode)
+
+    @property
+    def dtype(self):
+        """The data type of the iteration variable"""
+        return np.int32
 
 
 # Set of default dimensions for space and time

--- a/devito/dle/__init__.py
+++ b/devito/dle/__init__.py
@@ -1,0 +1,1 @@
+from devito.dle.transformer import transform

--- a/devito/dle/__init__.py
+++ b/devito/dle/__init__.py
@@ -1,1 +1,2 @@
 from devito.dle.transformer import transform
+from devito.dle.inspection import *

--- a/devito/dle/__init__.py
+++ b/devito/dle/__init__.py
@@ -1,2 +1,2 @@
-from devito.dle.transformer import transform
-from devito.dle.inspection import *
+from devito.dle.transformer import transform  # noqa
+from devito.dle.inspection import *  # noqa

--- a/devito/dle/inspection.py
+++ b/devito/dle/inspection.py
@@ -1,0 +1,26 @@
+from collections import OrderedDict
+
+from devito.visitors import FindSections
+
+__all__ = ['retrieve_iteration_tree']
+
+
+def retrieve_iteration_tree(node):
+    """Return a list of all :class:`Iteration` sub-trees rooted in ``node``.
+    For example, given the Iteration tree:
+
+        .. code-block::
+           Iteration i
+             expr0
+             Iteration j
+               Iteraion k
+                 expr1
+             Iteration p
+               expr2
+
+    Return the list: ::
+
+        [(Iteration i, Iteration j, Iteration k), (Iteration i, Iteration p)]
+    """
+
+    return FindSections().visit(node).keys()

--- a/devito/dle/inspection.py
+++ b/devito/dle/inspection.py
@@ -1,5 +1,3 @@
-from collections import OrderedDict
-
 from devito.visitors import FindSections
 
 __all__ = ['retrieve_iteration_tree']

--- a/devito/dle/transformer.py
+++ b/devito/dle/transformer.py
@@ -115,6 +115,7 @@ class Rewriter(object):
         functions = []
         processed = []
         for i, node in enumerate(state.nodes):
+            mapper = {}
             for j, subtree in enumerate(retrieve_iteration_tree(node)):
                 if len(subtree) <= 1:
                     continue
@@ -147,13 +148,15 @@ class Rewriter(object):
 
                 root = candidate[0]
 
-                # Transform the main tree
+                # Track info to transform the main tree
                 call = '%s(%s)' % (name, ','.join(call))
-                mapper = {root: Element(c.Statement(call))}
-                processed.append(Transformer(mapper).visit(node))
+                mapper[root] = Element(c.Statement(call))
 
-                # Produce the new functions
+                # Produce the new function
                 functions.append(Function(name, root, 'void', parameters, ('static',)))
+
+            # Transform the main tree
+            processed.append(Transformer(mapper).visit(node))
 
         return {'nodes': processed, 'elemental_functions': functions}
 

--- a/devito/dle/transformer.py
+++ b/devito/dle/transformer.py
@@ -1,0 +1,105 @@
+from collections import OrderedDict, Sequence
+
+from time import time
+
+from devito.logger import dle, dle_warning
+from devito.visitors import FindSections, FunctionBuilder
+
+
+def transform(node, mode='basic'):
+    """
+    Transform Iteration/Expression trees to generate highly optimized C code.
+
+    :param node: The Iteration/Expression tree to be transformed, or an iterable
+                 of Iteration/Expression trees.
+    :param mode: Drive the tree transformation. Currently, only the default
+                 'basic' option is available.
+    """
+
+    if isinstance(node, Sequence):
+        assert all(n.is_Node for n in node)
+        node = list(node)
+    elif node.is_Node:
+        node = [node]
+    else:
+        raise ValueError("Got illegal node of type %s." % type(node))
+
+    if not mode:
+        return State(node)
+    elif isinstance(mode, str):
+        mode = set([mode])
+    else:
+        try:
+            mode = set(mode)
+        except TypeError:
+            dle_warning("Arg mode must be str or tuple (got %s)" % type(mode))
+            return State(node)
+    if mode.isdisjoint({'noop', 'basic'}):
+        dle_warning("Unknown transformer mode(s) %s" % str(mode))
+        return State(node)
+    else:
+        return Transformer(node).run(mode)
+
+    return Transformer(node).run(mode)
+
+
+def dle_transformation(func):
+
+    def wrapper(self, state, **kwargs):
+        if kwargs['mode'].intersection(set(self.triggers[func.__name__])):
+            tic = time()
+            state.update(**func(self, state))
+            toc = time()
+
+            key = '%s%d' % (func.__name__, len(self.timings))
+            self.timings[key] = toc - tic
+
+    return wrapper
+
+
+class State(object):
+
+    def __init__(self, nodes):
+        self.nodes = nodes
+
+    def update(self, nodes=None):
+        self.nodes = nodes or self.nodes
+
+
+class Transformer(object):
+
+    triggers = {
+        '_extract_loops': ('basic',)
+    }
+
+    def __init__(self, nodes):
+        self.nodes = nodes
+
+        self.timings = OrderedDict()
+
+    def run(self, mode):
+        state = State(self.nodes)
+
+        self._extract_loops(state, mode=mode)
+
+        self._summary(mode)
+
+        return state
+
+    @dle_transformation
+    def _extract_loops(self, state, **kwargs):
+        """
+        Move inner loops to separate functions.
+        """
+
+        return {'nodes': state.nodes}
+
+    def _summary(self, mode):
+        """
+        Print a summary of the DLE transformations
+        """
+
+        if mode.intersection({'basic'}):
+            steps = " --> ".join("(%s)" % i for i in self.timings.keys())
+            elapsed = sum(self.timings.values())
+            dle("%s [%.2f s]" % (steps, elapsed))

--- a/devito/dle/transformer.py
+++ b/devito/dle/transformer.py
@@ -116,13 +116,16 @@ class Rewriter(object):
         processed = []
         for i, node in enumerate(state.nodes):
             for j, subtree in enumerate(retrieve_iteration_tree(node)):
+                if len(subtree) <= 1:
+                    continue
+
                 name = "f_%d_%d" % (i, j)
 
                 candidate = rule(subtree)
                 leftover = tuple(k for k in subtree if k not in candidate)
 
                 args = FindSymbols().visit(candidate)
-                args += [k.dim for k in leftover if k not in args]
+                args += [k.dim for k in leftover if k not in args and k.is_Closed]
 
                 known = [k.name for k in args]
                 known += [k.index for k in candidate]
@@ -150,7 +153,7 @@ class Rewriter(object):
                 processed.append(Transformer(mapper).visit(node))
 
                 # Produce the new functions
-                functions.append(Function(name, root, 'void', parameters, ('static')))
+                functions.append(Function(name, root, 'void', parameters, ('static',)))
 
         return {'nodes': processed, 'elemental_functions': functions}
 

--- a/devito/dse/__init__.py
+++ b/devito/dse/__init__.py
@@ -1,2 +1,2 @@
-from devito.dse.inspection import *
-from devito.dse.symbolics import rewrite
+from devito.dse.inspection import *  # noqa
+from devito.dse.symbolics import rewrite  # noqa

--- a/devito/dse/__init__.py
+++ b/devito/dse/__init__.py
@@ -1,0 +1,2 @@
+from devito.dse.inspection import *
+from devito.dse.symbolics import rewrite

--- a/devito/dse/inspection.py
+++ b/devito/dse/inspection.py
@@ -7,8 +7,9 @@ from devito.interfaces import SymbolicData
 from devito.logger import warning
 from devito.tools import flatten
 
-__all__ = ['indexify', 'retrieve_dimensions', 'retrieve_dtype', 'retrieve_symbols',
-           'retrieve_shape', 'terminals', 'tolambda']
+__all__ = ['estimate_cost', 'estimate_memory', 'indexify', 'retrieve_dimensions',
+           'retrieve_dtype', 'retrieve_symbols', 'retrieve_shape', 'terminals',
+           'tolambda']
 
 
 def terminals(expr, discard_indexed=False):

--- a/devito/dse/symbolics.py
+++ b/devito/dse/symbolics.py
@@ -65,7 +65,7 @@ def rewrite(expr, mode='advanced'):
             mode = set(mode)
         except TypeError:
             dse_warning("Arg mode must be str or tuple (got %s)" % type(mode))
-            return expr
+            return State(expr)
     if mode.isdisjoint({'noop', 'basic', 'factorize', 'approx-trigonometry',
                         'glicm', 'advanced'}):
         dse_warning("Unknown rewrite mode(s) %s" % str(mode))
@@ -398,7 +398,7 @@ class Rewriter(object):
             except ZeroDivisionError:
                 summary = ""
             elapsed = sum(self.timings.values())
-            dse("Rewriter:%s [%.2f s]" % (summary, elapsed))
+            dse("%s [%.2f s]" % (summary, elapsed))
 
 
 def collect_nested(expr):

--- a/devito/logger.py
+++ b/devito/logger.py
@@ -6,7 +6,8 @@ import sys
 __all__ = ('set_log_level', 'set_log_noperf', 'log',
            'DEBUG', 'INFO', 'AUTOTUNER', 'DSE', 'DSE_WARN', 'DLE', 'DLE_WARN',
            'WARNING', 'ERROR', 'CRITICAL',
-           'log', 'warning', 'error', 'info_at', 'dse', 'dse_warning', 'dle', 'dle_warning'
+           'log', 'warning', 'error', 'info_at', 'dse', 'dse_warning', 'dle',
+           'dle_warning',
            'RED', 'GREEN', 'BLUE')
 
 

--- a/devito/logger.py
+++ b/devito/logger.py
@@ -4,9 +4,9 @@ import logging
 import sys
 
 __all__ = ('set_log_level', 'set_log_noperf', 'log',
-           'DEBUG', 'INFO', 'AUTOTUNER', 'DSE', 'DSE_WARN', 'WARNING',
-           'ERROR', 'CRITICAL',
-           'log', 'warning', 'error', 'info_at', 'dse', 'dse_warning',
+           'DEBUG', 'INFO', 'AUTOTUNER', 'DSE', 'DSE_WARN', 'DLE', 'DLE_WARN',
+           'WARNING', 'ERROR', 'CRITICAL',
+           'log', 'warning', 'error', 'info_at', 'dse', 'dse_warning', 'dle', 'dle_warning'
            'RED', 'GREEN', 'BLUE')
 
 
@@ -19,7 +19,9 @@ DEBUG = logging.DEBUG
 INFO = logging.INFO
 AUTOTUNER = 27
 DSE = 28
+DLE = DSE
 DSE_WARN = 29
+DLE_WARN = DSE_WARN
 WARNING = logging.WARNING
 ERROR = logging.ERROR
 CRITICAL = logging.CRITICAL
@@ -27,6 +29,8 @@ CRITICAL = logging.CRITICAL
 logging.addLevelName(AUTOTUNER, "AUTOTUNER")
 logging.addLevelName(DSE, "DSE")
 logging.addLevelName(DSE_WARN, "DSE_WARN")
+logging.addLevelName(DSE, "DLE")
+logging.addLevelName(DSE_WARN, "DLE_WARN")
 
 logger.setLevel(INFO)
 
@@ -41,6 +45,8 @@ COLORS = {
     AUTOTUNER: GREEN,
     DSE: NOCOLOR,
     DSE_WARN: BLUE,
+    DLE: NOCOLOR,
+    DLE_WARN: BLUE,
     WARNING: BLUE,
     ERROR: RED,
     CRITICAL: RED
@@ -52,7 +58,7 @@ def set_log_level(level):
     Set the log level of the Devito logger.
 
     :param level: accepted values are: DEBUG, INFO, AUTOTUNER, DSE, DSE_WARN,
-                  WARNING, ERROR, CRITICAL
+                  DLE, DLE_WARN, WARNING, ERROR, CRITICAL
     """
     logger.setLevel(level)
 
@@ -69,9 +75,9 @@ def log(msg, level=INFO, *args, **kwargs):
 
     :param msg: the message to be printed.
     :param level: accepted values are: DEBUG, INFO, AUTOTUNER, DSE, DSE_WARN,
-                  WARNING, ERROR, CRITICAL
+                  DLE, DLE_WARN, WARNING, ERROR, CRITICAL
     """
-    assert level in [DEBUG, INFO, AUTOTUNER, DSE, DSE_WARN,
+    assert level in [DEBUG, INFO, AUTOTUNER, DSE, DSE_WARN, DLE, DLE_WARN,
                      WARNING, ERROR, CRITICAL]
 
     color = COLORS[level] if sys.stdout.isatty() and sys.stderr.isatty() else '%s'
@@ -104,3 +110,11 @@ def dse(msg, *args, **kwargs):
 
 def dse_warning(msg, *args, **kwargs):
     log(msg, DSE_WARN, *args, **kwargs)
+
+
+def dle(msg, *args, **kwargs):
+    log("DLE: %s" % msg, DLE, *args, **kwargs)
+
+
+def dle_warning(msg, *args, **kwargs):
+    log(msg, DLE_WARN, *args, **kwargs)

--- a/devito/nodes.py
+++ b/devito/nodes.py
@@ -254,6 +254,14 @@ class Iteration(Node):
         return c.For(loop_init, loop_cond, loop_inc, c.Block(loop_body))
 
     @property
+    def is_Open(self):
+        return self.dim.size is not None
+
+    @property
+    def is_Closed(self):
+        return not self.is_Open
+
+    @property
     def children(self):
         """Return the traversable children."""
         return (self.nodes,)

--- a/devito/nodes.py
+++ b/devito/nodes.py
@@ -26,6 +26,7 @@ class Node(object):
     is_Expression = False
     is_Function = False
     is_List = False
+    is_Element = False
 
     """
     :attr:`_traversable`. A list of traversable objects (ie, traversed by
@@ -106,6 +107,27 @@ class List(Block):
     is_List = True
 
     _wrapper = c.Collection
+
+
+class Element(Node):
+
+    """A generic node that is worth identifying in an Iteration/Expression tree.
+
+    It corresponds to a single :class:`cgen.Statement`.
+    """
+
+    is_Element = True
+
+    def __init__(self, element):
+        assert isinstance(element, c.Statement)
+        self.element = element
+
+    def __repr__(self):
+        return "Element::\n\t%s" % (self.element)
+
+    @property
+    def ccode(self):
+        return self.element
 
 
 class Expression(Node):

--- a/devito/nodes.py
+++ b/devito/nodes.py
@@ -43,7 +43,7 @@ class Node(object):
 
     def _rebuild(self, *args, **kwargs):
         """Reconstruct self. None of the embedded Sympy expressions are rebuilt."""
-        handle = self._args  # Original constructor arguments
+        handle = self._args.copy()  # Original constructor arguments
         argnames = [i for i in self._traversable if i not in kwargs]
         handle.update(OrderedDict([(k, v) for k, v in zip(argnames, args)]))
         handle.update(kwargs)

--- a/devito/stencilkernel.py
+++ b/devito/stencilkernel.py
@@ -17,7 +17,7 @@ from devito.dle import transform
 from devito.dse import estimate_cost, estimate_memory, indexify, rewrite
 from devito.interfaces import SymbolicData
 from devito.logger import error, info
-from devito.nodes import Block, Expression, Function, Iteration, Timer
+from devito.nodes import Block, Expression, Function, Iteration, TimedList
 from devito.profiler import Profiler
 from devito.visitors import (FindSections, FindSymbols, IsPerfectIteration,
                              ResolveIterationVariable, SubstituteExpression,
@@ -88,11 +88,11 @@ class StencilKernel(Function):
             for itspace in FindSections().visit(expr).keys():
                 for j in itspace:
                     if IsPerfectIteration().visit(j) and j not in mapper:
-                        # Insert `Timer` block. This should come from
+                        # Insert `TimedList` block. This should come from
                         # the profiler, but we do this manually for now.
                         lname = 'loop_%s' % j.index
-                        mapper[j] = Timer(gname=self.profiler.t_name,
-                                          lname=lname, body=j)
+                        mapper[j] = TimedList(gname=self.profiler.t_name,
+                                              lname=lname, body=j)
                         self.profiler.t_fields += [(lname, c_double)]
                         break
         nodes = [Transformer(mapper).visit(Block(body=nodes))]

--- a/devito/stencilkernel.py
+++ b/devito/stencilkernel.py
@@ -235,6 +235,7 @@ class StencilKernel(Function):
         :returns: The basename path as a string
         """
         expr_string = "\n".join([str(e) for e in self.body])
+        expr_string += "\n".join([str(e) for e in self.elemental_functions])
         hash_key = sha1(expr_string.encode()).hexdigest()
 
         return path.join(get_tmp_dir(), hash_key)

--- a/devito/visitors.py
+++ b/devito/visitors.py
@@ -184,6 +184,8 @@ class FindSections(Visitor):
         ret.setdefault(key, []).append(o)
         return ret
 
+    visit_Element = visit_Expression
+
 
 class FindSymbols(Visitor):
 

--- a/devito/visitors.py
+++ b/devito/visitors.py
@@ -193,9 +193,24 @@ class FindSymbols(Visitor):
     def default_retval(cls):
         return []
 
-    """Find all :class:`SymbolicData` and :class:`IndexedData`
-    instances in an Iteration/Expression tree.
+    """Find symbols in an Iteration/Expression tree.
+
+    :param mode: Drive the search for symbols. Accepted values are: ::
+
+        * 'with-data' (default): all :class:`SymbolicData` and :class:`IndexedData`
+          instances are collected.
+        * 'free-symbols': all free symbols appearing in :class:`Expression` are
+          collected.
     """
+
+    rules = {
+        'with-data': lambda e: e.functions,
+        'free-symbols': lambda e: e.stencil.free_symbols
+    }
+
+    def __init__(self, mode='with-data'):
+        super(FindSymbols, self).__init__()
+        self.rule = self.rules[mode]
 
     def visit_tuple(self, o):
         symbols = flatten([self.visit(i) for i in o])
@@ -208,8 +223,7 @@ class FindSymbols(Visitor):
         return filter_ordered(symbols, key=attrgetter('name'))
 
     def visit_Expression(self, o):
-        return filter_ordered([f for f in o.functions],
-                              key=attrgetter('name'))
+        return filter_ordered([f for f in self.rule(o)], key=attrgetter('name'))
 
 
 class IsPerfectIteration(Visitor):

--- a/devito/visitors.py
+++ b/devito/visitors.py
@@ -248,8 +248,7 @@ class Transformer(Visitor):
     def visit_tuple(self, o, **kwargs):
         return tuple(self.visit(i, **kwargs) for i in o)
 
-    def visit_list(self, o, **kwargs):
-        return tuple(self.visit(i, **kwargs) for i in o)
+    visit_list = visit_tuple
 
     def visit_Node(self, o, **kwargs):
         if o in self.mapper:

--- a/devito/visitors.py
+++ b/devito/visitors.py
@@ -7,16 +7,17 @@ The main Visitor class is extracted from https://github.com/coneoproject/COFFEE.
 from __future__ import absolute_import
 
 import inspect
-from collections import OrderedDict
+from collections import OrderedDict, namedtuple
 from operator import attrgetter
 
 import cgen as c
 from sympy import Symbol
 
+from devito.dse import estimate_cost, estimate_memory
 from devito.nodes import Block, IterationBound
 from devito.tools import filter_ordered, flatten
 
-__all__ = ["FindSections", "FindSymbols", "IsPerfectIteration",
+__all__ = ["EstimateCost", "FindSections", "FindSymbols", "IsPerfectIteration",
            "SubstituteExpression", "ResolveIterationVariable"]
 
 
@@ -246,6 +247,40 @@ class IsPerfectIteration(Visitor):
             return False
         multi = len(o.nodes) > 1
         return all(self.visit(i, found=True, multi=multi) for i in o.children)
+
+
+class EstimateCost(Visitor):
+
+    Cost = namedtuple('Cost', 'ops mem')
+
+    @classmethod
+    def default_retval(cls):
+        return cls.Cost(0, 0)
+
+    """
+    Estimate the number of floating point operations and memory accesses per
+    loop iteration in an Iteration/Expression tree.
+    """
+
+    def visit_object(self, o):
+        return self.default_retval()
+
+    def visit_tuple(self, o):
+        cost = self.default_retval()
+        for i in o:
+            ret = self.visit(i)
+            cost = self.Cost(cost.ops + ret.ops, cost.mem + ret.mem)
+        return cost
+
+    def visit_Node(self, o):
+        cost = self.default_retval()
+        for i in o.children:
+            ret = self.visit(i)
+            cost = self.Cost(cost.ops + ret.ops, cost.mem + ret.mem)
+        return cost
+
+    def visit_Expression(self, o):
+        return self.Cost(estimate_cost(o.stencil), estimate_memory(o.stencil))
 
 
 class Transformer(Visitor):

--- a/devito/visitors.py
+++ b/devito/visitors.py
@@ -162,6 +162,11 @@ class FindSections(Visitor):
             ret = self.visit(i, ret=ret, queue=queue)
         return ret
 
+    def visit_Node(self, o, ret=None, queue=None):
+        for i in o.children:
+            ret = self.visit(i, ret=ret, queue=queue)
+        return ret
+
     def visit_Iteration(self, o, ret=None, queue=None):
         if queue is None:
             queue = [o]

--- a/tests/test_dle.py
+++ b/tests/test_dle.py
@@ -92,7 +92,7 @@ def test_create_elemental_functions_simple(simple_function):
     handle = transform(simple_function, mode=('basic',))
     block = List(body=handle.nodes + handle.elemental_functions)
     assert str(block.ccode) == \
-("""void foo(float *a_vec, float *b_vec, float *c_vec, float *d_vec)
+        ("""void foo(float *a_vec, float *b_vec, float *c_vec, float *d_vec)
 {
   float (*a) = (float (*)) a_vec;
   float (*b) = (float (*)) b_vec;
@@ -107,7 +107,7 @@ def test_create_elemental_functions_simple(simple_function):
   }
 }
 void f_0_0(float *a_vec, float *b_vec, float *d_vec, float *c_vec,"""
-""" const int i0, const int j0)
+         """ const int i0, const int j0)
 {
   float (*a) = (float (*)) a_vec;
   float (*b) = (float (*)) b_vec;
@@ -125,7 +125,7 @@ def test_create_elemental_functions_complex(complex_function):
     handle = transform(complex_function, mode=('basic',))
     block = List(body=handle.nodes + handle.elemental_functions)
     assert str(block.ccode) == \
-("""void foo(float *a_vec, float *b_vec, float *c_vec, float *d_vec)
+        ("""void foo(float *a_vec, float *b_vec, float *c_vec, float *d_vec)
 {
   float (*a) = (float (*)) a_vec;
   float (*b) = (float (*)) b_vec;
@@ -151,7 +151,7 @@ void f_0_0(float *a_vec, float *b_vec, const int i1)
   }
 }
 void f_0_1(float *a_vec, float *b_vec, float *c_vec, float *d_vec,"""
-""" const int j1, const int i1)
+         """ const int j1, const int i1)
 {
   float (*a) = (float (*)) a_vec;
   float (*b) = (float (*)) b_vec;

--- a/tests/test_dle.py
+++ b/tests/test_dle.py
@@ -1,0 +1,174 @@
+import pytest
+from sympy import Eq
+
+from devito.dimension import Dimension
+from devito.dle import transform
+from devito.interfaces import DenseData
+from devito.nodes import Expression, Function, Iteration, List
+from devito.visitors import ResolveIterationVariable, SubstituteExpression
+
+
+def _symbol(name, dimensions):
+    return DenseData(name=name, dimensions=dimensions)
+
+
+@pytest.fixture(scope="session")
+def dims():
+    return {'i': Dimension(name='i', size=3),
+            'j': Dimension(name='j', size=5),
+            'k': Dimension(name='k', size=7),
+            's': Dimension(name='s', size=4),
+            'p': Dimension(name='p', size=4)}
+
+
+@pytest.fixture(scope="session")
+def symbols(dims):
+    a = _symbol(name='a', dimensions=(dims['i'],))
+    b = _symbol(name='b', dimensions=(dims['i'],))
+    c = _symbol(name='c', dimensions=(dims['i'], dims['j']))
+    d = _symbol(name='d', dimensions=(dims['i'], dims['j'], dims['k']))
+    return [a, b, c, d]
+
+
+@pytest.fixture(scope="session")
+def exprs(symbols):
+    a, b, c, d = [i.indexify() for i in symbols]
+    return [Expression(Eq(a, a + b + 5.)),
+            Expression(Eq(a, b*d - a*c)),
+            Expression(Eq(a, a + b*b + 3)),
+            Expression(Eq(a, a*b*d*c)),
+            Expression(Eq(a, 4 * ((b + d) * (a + c)))),
+            Expression(Eq(a, (6. / b) + (8. * a)))]
+
+
+@pytest.fixture(scope="session")
+def iters(dims):
+    return [lambda ex: Iteration(ex, dims['i'], (0, 3, 1)),
+            lambda ex: Iteration(ex, dims['j'], (0, 5, 1)),
+            lambda ex: Iteration(ex, dims['k'], (0, 7, 1)),
+            lambda ex: Iteration(ex, dims['s'], (0, 4, 1)),
+            lambda ex: Iteration(ex, dims['p'], (0, 4, 1))]
+
+
+@pytest.fixture(scope="session")
+def simple_function(symbols, exprs, iters):
+    # void foo(a, b)
+    #   for i
+    #     for j
+    #       for k
+    #         expr0
+    #         expr1
+    body = iters[0](iters[1](iters[2]([exprs[0], exprs[1]])))
+    f = Function('foo', body, 'void', symbols, ())
+    subs = {}
+    f = ResolveIterationVariable().visit(f, subs=subs)
+    f = SubstituteExpression(subs=subs).visit(f)
+    return f
+
+
+@pytest.fixture(scope="session")
+def complex_function(symbols, exprs, iters):
+    # void foo(a, b, c, d)
+    #   for i
+    #     for s
+    #       expr0
+    #     for j
+    #       for k
+    #         expr1
+    #         expr2
+    #     for p
+    #       expr3
+    body = iters[0]([iters[3](exprs[2]),
+                     iters[1](iters[2]([exprs[3], exprs[4]])),
+                     iters[4](exprs[5])])
+    f = Function('foo', body, 'void', symbols, ())
+    subs = {}
+    f = ResolveIterationVariable().visit(f, subs=subs)
+    f = SubstituteExpression(subs=subs).visit(f)
+    return f
+
+
+def test_create_elemental_functions_simple(simple_function):
+    handle = transform(simple_function, mode=('basic',))
+    block = List(body=handle.nodes + handle.elemental_functions)
+    assert str(block.ccode) == \
+("""void foo(float *a_vec, float *b_vec, float *c_vec, float *d_vec)
+{
+  float (*a) = (float (*)) a_vec;
+  float (*b) = (float (*)) b_vec;
+  float (*c)[5] = (float (*)[5]) c_vec;
+  float (*d)[5][7] = (float (*)[5][7]) d_vec;
+  for (int i0 = 0 + 0; i0 < 3 - 0; i0 += 1)
+  {
+    for (int j0 = 0 + 0; j0 < 5 - 0; j0 += 1)
+    {
+      f_0_0(a_vec,b_vec,d_vec,c_vec,i0,j0);
+    }
+  }
+}
+void f_0_0(float *a_vec, float *b_vec, float *d_vec, float *c_vec,"""
+""" const int i0, const int j0)
+{
+  float (*a) = (float (*)) a_vec;
+  float (*b) = (float (*)) b_vec;
+  float (*d)[5][7] = (float (*)[5][7]) d_vec;
+  float (*c)[5] = (float (*)[5]) c_vec;
+  for (int k0 = 0 + 0; k0 < 7 - 0; k0 += 1)
+  {
+    a[i0] = a[i0] + b[i0] + 5.0F;
+    a[i0] = -a[i0]*c[i0][j0] + b[i0]*d[i0][j0][k0];
+  }
+}""")
+
+
+def test_create_elemental_functions_complex(complex_function):
+    handle = transform(complex_function, mode=('basic',))
+    block = List(body=handle.nodes + handle.elemental_functions)
+    assert str(block.ccode) == \
+("""void foo(float *a_vec, float *b_vec, float *c_vec, float *d_vec)
+{
+  float (*a) = (float (*)) a_vec;
+  float (*b) = (float (*)) b_vec;
+  float (*c)[5] = (float (*)[5]) c_vec;
+  float (*d)[5][7] = (float (*)[5][7]) d_vec;
+  for (int i1 = 0 + 0; i1 < 3 - 0; i1 += 1)
+  {
+    f_0_0(a_vec,b_vec,i1);
+    for (int j1 = 0 + 0; j1 < 5 - 0; j1 += 1)
+    {
+      f_0_1(a_vec,b_vec,c_vec,d_vec,j1,i1);
+    }
+    f_0_2(a_vec,b_vec,i1);
+  }
+}
+void f_0_0(float *a_vec, float *b_vec, const int i1)
+{
+  float (*a) = (float (*)) a_vec;
+  float (*b) = (float (*)) b_vec;
+  for (int s0 = 0 + 0; s0 < 4 - 0; s0 += 1)
+  {
+    a[i1] = a[i1] + pow(b[i1], 2) + 3;
+  }
+}
+void f_0_1(float *a_vec, float *b_vec, float *c_vec, float *d_vec,"""
+""" const int j1, const int i1)
+{
+  float (*a) = (float (*)) a_vec;
+  float (*b) = (float (*)) b_vec;
+  float (*c)[5] = (float (*)[5]) c_vec;
+  float (*d)[5][7] = (float (*)[5][7]) d_vec;
+  for (int k1 = 0 + 0; k1 < 7 - 0; k1 += 1)
+  {
+    a[i1] = a[i1]*b[i1]*c[i1][j1]*d[i1][j1][k1];
+    a[i1] = 4*(a[i1] + c[i1][j1])*(b[i1] + d[i1][j1][k1]);
+  }
+}
+void f_0_2(float *a_vec, float *b_vec, const int i1)
+{
+  float (*a) = (float (*)) a_vec;
+  float (*b) = (float (*)) b_vec;
+  for (int p0 = 0 + 0; p0 < 4 - 0; p0 += 1)
+  {
+    a[i1] = 8.0F*a[i1] + 6.0F/b[i1];
+  }
+}""")

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -4,8 +4,8 @@ from sympy import Eq
 
 from devito.dimension import Dimension
 from devito.interfaces import DenseData
-from devito.nodes import Block, Expression, Iteration
-from devito.visitors import FindSections, IsPerfectIteration, Transformer
+from devito.nodes import Block, Expression, Function, Iteration
+from devito.visitors import FindSections, FindSymbols, IsPerfectIteration, Transformer
 
 
 def _symbol(name, dimensions):
@@ -145,6 +145,45 @@ def test_transformer_replace(exprs, block1, block2, block3):
         assert newnumlines >= oldnumlines
         assert line1 in newcode
         assert "a[i0] = a[i0] + b[i0] + 5.0F;" not in newcode
+
+
+def test_transformer_replace_function_body(block1, block2):
+    """Create a Function and replace its body with another."""
+    args = FindSymbols().visit(block1)
+    f = Function('foo', block1, 'void', args)
+    assert str(f.ccode) == """void foo(float *a_vec, float *b_vec)
+{
+  float (*a) = (float (*)) a_vec;
+  float (*b) = (float (*)) b_vec;
+  for (int i = 0 + 0; i < 3 - 0; i += 1)
+  {
+    for (int j = 0 + 0; j < 5 - 0; j += 1)
+    {
+      for (int k = 0 + 0; k < 7 - 0; k += 1)
+      {
+        a[i] = a[i] + b[i] + 5.0F;
+      }
+    }
+  }
+}"""
+
+    f = Transformer({block1: block2}).visit(f)
+    assert str(f.ccode) == """void foo(float *a_vec, float *b_vec)
+{
+  float (*a) = (float (*)) a_vec;
+  float (*b) = (float (*)) b_vec;
+  for (int i = 0 + 0; i < 3 - 0; i += 1)
+  {
+    a[i] = a[i] + b[i] + 5.0F;
+    for (int j = 0 + 0; j < 5 - 0; j += 1)
+    {
+      for (int k = 0 + 0; k < 7 - 0; k += 1)
+      {
+        a[i] = -a[i] + b[i];
+      }
+    }
+  }
+}"""
 
 
 def test_transformer_add_replace(exprs, block2, block3):

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -5,7 +5,8 @@ from sympy import Eq
 from devito.dimension import Dimension
 from devito.interfaces import DenseData
 from devito.nodes import Block, Expression, Function, Iteration
-from devito.visitors import FindSections, FindSymbols, IsPerfectIteration, Transformer
+from devito.visitors import (FindSections, FindSymbols, IsPerfectIteration,
+                             Transformer)
 
 
 def _symbol(name, dimensions):

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -1,9 +1,10 @@
+import cgen as c
 import pytest
 from sympy import Eq
 
-import cgen as c
-
-from devito import Block, DenseData, Dimension, Expression, Function, Iteration
+from devito.dimension import Dimension
+from devito.interfaces import DenseData
+from devito.nodes import Block, Expression, Function, Iteration
 from devito.visitors import FindSections, FindSymbols, IsPerfectIteration, Transformer
 
 

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -1,10 +1,9 @@
-import cgen as c
 import pytest
 from sympy import Eq
 
-from devito.dimension import Dimension
-from devito.interfaces import DenseData
-from devito.nodes import Block, Expression, Function, Iteration
+import cgen as c
+
+from devito import Block, DenseData, Dimension, Expression, Function, Iteration
 from devito.visitors import FindSections, FindSymbols, IsPerfectIteration, Transformer
 
 


### PR DESCRIPTION
*** Note ***
This PR has been opened to promote discussion, but it still lacks:
- flake8 fixes, isort fixes
- a full run of the test suite (let's see what Travis says...)
- more tests (either tomorrow or Monday)
*************

*** EDIT 1 ***
- passing all tests
- added some DLE tests
*************

Now ``StencilKernel`` is a very special node in an Iteration/Expression tree -- a node that can be JIT-compiled and that is allowed to call the optimization engines. As part of this generalization, more nodes and visitors have been introduced. Further, some performance information is now emitted.

Moreover, the PR introduces the DLE -- Devito Loop Engine. This is an analogous of DSE, but for loop optimization (eg, tiling, parallelization). Only one transformation step is at this stage applied, called ``create_elemental_functions``. This basically can move inner loops into separate functions. This, *for example*, will be essential when applying loop tiling to TTI, as the presence of a deep loop nest (body + reminder loops) including a huge number of stencil statements make the compilation time simply blow up. 

Creating "elemental functions" may also be useful to retain some data alignment (stay tuned for more details) 
