### PR TITLE
Outer iteration merge and other niceties

### DIFF
--- a/devito/dimension.py
+++ b/devito/dimension.py
@@ -3,8 +3,7 @@ import cgen
 import numpy as np
 from sympy import Symbol
 
-
-__all__ = ['Dimension', 'x', 'y', 'z', 't', 'p']
+__all__ = ['Dimension', 'x', 'y', 'z', 't', 'p', 'r']
 
 
 class Dimension(Symbol):
@@ -54,3 +53,4 @@ y = Dimension('y')
 z = Dimension('z')
 t = Dimension('t')
 p = Dimension('p')
+r = Dimension('r')

--- a/devito/interfaces.py
+++ b/devito/interfaces.py
@@ -4,7 +4,7 @@ import numpy as np
 from sympy import Function, IndexedBase, as_finite_diff, symbols
 from sympy.abc import h, s
 
-from devito.dimension import p, t, x, y, z
+from devito.dimension import p, r, t, x, y, z
 from devito.finite_difference import (centered, cross_derivative,
                                       first_derivative, left, right,
                                       second_derivative)
@@ -538,7 +538,7 @@ class CoordinateData(TensorData):
         :param shape: Shape of the spatial data
         :return: indices used for axis.
         """
-        _indices = [p, s]
+        _indices = [p, r]
         return _indices
 
     @property

--- a/devito/nodes.py
+++ b/devito/nodes.py
@@ -85,10 +85,8 @@ class Block(Node):
         self.footer = as_tuple(footer)
 
     def __repr__(self):
-        header = "".join([str(s) for s in self.header])
-        body = "\n\t".join([str(s) for s in self.body])
-        footer = "".join([str(s) for s in self.footer])
-        return "%s::\n\t%s" % (self.__class__.__name__, header + body + footer)
+        return "<%s (%d, %d, %d)>" % (self.__class__.__name__, len(self.header),
+                                      len(self.body), len(self.footer))
 
     @property
     def ccode(self):
@@ -155,7 +153,7 @@ class Expression(Node):
         self.functions = filter_ordered(self.functions)
 
     def __repr__(self):
-        return "Expression<%s = %s>" % (self.stencil.lhs, self.stencil.rhs)
+        return "<Expression::%s>" % filter_ordered([f.func for f in self.functions])
 
     def substitute(self, substitutions):
         """Apply substitutions to the expression stencil
@@ -242,9 +240,7 @@ class Iteration(Node):
             self.offsets[1] = max(self.offsets[1], int(off))
 
     def __repr__(self):
-        str_expr = "\n\t".join([str(s) for s in self.nodes])
-        return "Iteration<%s; %s>::\n\t%s" % (self.index, self.limits,
-                                              str_expr)
+        return "<Iteration %s; %s>" % (self.index, self.limits)
 
     @property
     def ccode(self):

--- a/devito/nodes.py
+++ b/devito/nodes.py
@@ -171,21 +171,28 @@ class Expression(Node):
 
     @property
     def index_offsets(self):
-        """Collect all non-zero offsets used with each index in a map
+        """Mapping of :class:`Dimension` symbols to each integer
+        stencil offset used with it in this expression.
+
+        This also include zero offsets, so that the keys of this map
+        may be used as the set of :class:`Dimension` symbols used in
+        this expression.
 
         Note: This assumes we have indexified the stencil expression."""
-        offsets = defaultdict(list)
+        offsets = defaultdict(set)
         for e in terminals(self.stencil):
             for a in e.indices:
+                if isinstance(a, Dimension):
+                    offsets[a].update([0])
                 d = None
                 off = []
                 for idx in a.args:
                     if isinstance(idx, Dimension):
                         d = idx
-                    else:
+                    elif idx.is_integer:
                         off += [idx]
                 if d is not None:
-                    offsets[d] += off
+                    offsets[d].update(off)
         return offsets
 
 

--- a/devito/nodes.py
+++ b/devito/nodes.py
@@ -391,6 +391,9 @@ class IterationBound(object):
     def __repr__(self):
         return self.name
 
+    def __eq__(self, bound):
+        return self.name == bound.name and self.dim == bound.dim
+
     @property
     def ccode(self):
         """C code for the variable declaration within a kernel signature"""

--- a/devito/stencilkernel.py
+++ b/devito/stencilkernel.py
@@ -21,7 +21,8 @@ from devito.nodes import Block, Expression, Function, Iteration, TimedList
 from devito.profiler import Profiler
 from devito.visitors import (EstimateCost, FindSections, FindSymbols,
                              IsPerfectIteration, ResolveIterationVariable,
-                             SubstituteExpression, Transformer)
+                             SubstituteExpression, Transformer, printAST)
+
 
 __all__ = ['StencilKernel']
 
@@ -236,8 +237,8 @@ class StencilKernel(Function):
 
         :returns: The basename path as a string
         """
-        expr_string = "\n".join([str(e) for e in self.body])
-        expr_string += "\n".join([str(e) for e in self.elemental_functions])
+        expr_string = printAST(self.body, verbose=True)
+        expr_string += printAST(self.elemental_functions, verbose=True)
         hash_key = sha1(expr_string.encode()).hexdigest()
 
         return path.join(get_tmp_dir(), hash_key)

--- a/devito/stencilkernel.py
+++ b/devito/stencilkernel.py
@@ -91,7 +91,7 @@ class StencilKernel(Function):
                     if IsPerfectIteration().visit(j) and j not in mapper:
                         # Insert `TimedList` block. This should come from
                         # the profiler, but we do this manually for now.
-                        lname = 'loop_%s' % j.index
+                        lname = 'loop_%s_%d' % (j.index, i)
                         mapper[j] = TimedList(gname=self.profiler.t_name,
                                               lname=lname, body=j)
                         self.profiler.t_fields += [(lname, c_double)]

--- a/devito/stencilkernel.py
+++ b/devito/stencilkernel.py
@@ -20,8 +20,9 @@ from devito.logger import error, info
 from devito.nodes import Block, Expression, Function, Iteration, TimedList
 from devito.profiler import Profiler
 from devito.visitors import (EstimateCost, FindSections, FindSymbols,
-                             IsPerfectIteration, ResolveIterationVariable,
-                             SubstituteExpression, Transformer, printAST)
+                             IsPerfectIteration, MergeOuterIterations,
+                             ResolveIterationVariable, SubstituteExpression,
+                             Transformer, printAST)
 
 
 __all__ = ['StencilKernel']
@@ -83,7 +84,8 @@ class StencilKernel(Function):
                                     limits=d.size, offsets=offsets[d])
             nodes[i] = newexpr
 
-        # TODO: Merge Iterations iff outermost variables agree
+        # Merge Iterations iff outermost iterations agree
+        nodes = MergeOuterIterations().visit(nodes)
 
         # Introduce profiling infrastructure
         mapper = {}

--- a/devito/stencilkernel.py
+++ b/devito/stencilkernel.py
@@ -72,10 +72,12 @@ class StencilKernel(Function):
         nodes = [Expression(s) for s in stencils]
 
         # Wrap expressions with Iterations according to dimensions
+        # TODO: This should probably be done more safely in a visitor
+        # that tracks free and bound loop variables in the AST.
         for i, expr in enumerate(nodes):
             newexpr = expr
             offsets = newexpr.index_offsets
-            for d in reversed(expr.dimensions):
+            for d in reversed(list(offsets.keys())):
                 newexpr = Iteration(newexpr, dimension=d,
                                     limits=d.size, offsets=offsets[d])
             nodes[i] = newexpr

--- a/devito/tools.py
+++ b/devito/tools.py
@@ -1,5 +1,5 @@
 import ctypes
-from collections import Iterable
+from collections import Callable, Iterable, OrderedDict
 
 import numpy as np
 from sympy import symbols
@@ -112,3 +112,38 @@ def aligned(a, alignment=16):
     assert (aa.ctypes.data % alignment) == 0
 
     return aa
+
+
+class DefaultOrderedDict(OrderedDict):
+    # Source: http://stackoverflow.com/a/6190500/562769
+    def __init__(self, default_factory=None, *a, **kw):
+        if (default_factory is not None and
+           not isinstance(default_factory, Callable)):
+            raise TypeError('first argument must be callable')
+        OrderedDict.__init__(self, *a, **kw)
+        self.default_factory = default_factory
+
+    def __getitem__(self, key):
+        try:
+            return OrderedDict.__getitem__(self, key)
+        except KeyError:
+            return self.__missing__(key)
+
+    def __missing__(self, key):
+        if self.default_factory is None:
+            raise KeyError(key)
+        self[key] = value = self.default_factory()
+        return value
+
+    def __reduce__(self):
+        if self.default_factory is None:
+            args = tuple()
+        else:
+            args = self.default_factory,
+        return type(self), args, None, None, self.items()
+
+    def copy(self):
+        return self.__copy__()
+
+    def __copy__(self):
+        return type(self)(self.default_factory, self)

--- a/devito/visitors.py
+++ b/devito/visitors.py
@@ -348,7 +348,7 @@ class ResolveIterationVariable(Transformer):
             # For buffered dimensions insert the explicit
             # definition of buffere variables, eg. t+1 => t1
             init = []
-            for off in [0] + offsets[o.dim]:
+            for off in filter_ordered(offsets[o.dim]):
                 vname = o.dim.get_varname()
                 value = o.dim + off
                 modulo = o.dim.buffered

--- a/devito/visitors.py
+++ b/devito/visitors.py
@@ -190,12 +190,12 @@ class PrintAST(Visitor):
 
     def visit_Block(self, o):
         self._depth += 1
-        header = self.visit(o.header)
-        body = self.visit(o.body)
-        footer = self.visit(o.footer)
+        if self.verbose:
+            body = [self.visit(o.header), self.visit(o.body), self.visit(o.footer)]
+        else:
+            body = [self.visit(o.body)]
         self._depth -= 1
-        return self.indent + "<%s>\n%s" % (o.__class__.__name__,
-                                           '\n'.join([header, body, footer]))
+        return self.indent + "<%s>\n%s" % (o.__class__.__name__, '\n'.join(body))
 
     def visit_Iteration(self, o):
         self._depth += 1

--- a/devito/visitors.py
+++ b/devito/visitors.py
@@ -436,12 +436,20 @@ class MergeOuterIterations(Transformer):
     """
 
     def is_mergable(self, iter1, iter2):
+        """Defines if two :class:`Iteration` objects are mergeable.
+
+        Note: This currently does not(!) consider data dependencies
+        between the loops. A deeper analysis is required for this that
+        will be added soon.
+        """
         return (iter1.dim == iter2.dim and
                 iter1.index == iter2.index and
                 iter1.limits == iter2.limits)
 
     def merge(self, iter1, iter2):
-        # Create a new merged loop
+        """Creates a new merged :class:`Iteration` object from two
+        loops along the same dimension.
+        """
         newexpr = iter1.nodes + iter2.nodes
         return Iteration(newexpr, dimension=iter1.dim,
                          limits=iter1.limits)

--- a/devito/visitors.py
+++ b/devito/visitors.py
@@ -22,8 +22,8 @@ __all__ = ['EstimateCost', 'FindSections', 'FindSymbols',
            'ResolveIterationVariable', 'Transformer', 'printAST']
 
 
-def printAST(node):
-    return PrintAST().visit(node)
+def printAST(node, verbose=True):
+    return PrintAST(verbose=verbose).visit(node)
 
 
 class Visitor(object):
@@ -151,6 +151,10 @@ class Visitor(object):
 class PrintAST(Visitor):
 
     _depth = 0
+
+    def __init__(self, verbose=True):
+        super(PrintAST, self).__init__()
+        self.verbose = verbose
 
     @classmethod
     def default_retval(cls):

--- a/devito/visitors.py
+++ b/devito/visitors.py
@@ -165,6 +165,13 @@ class PrintAST(Visitor):
     def indent(self):
         return '  ' * self._depth
 
+    def visit_Node(self, o):
+        return self.indent + '<%s>' % o.__class__.__name__
+
+    def visit_Generable(self, o):
+        body = ' %s' % str(o) if self.verbose else ''
+        return self.indent + '<C.%s%s>' % (o.__class__.__name__, body)
+
     def visit_list(self, o):
         return ('\n').join([self.visit(i) for i in o])
 
@@ -177,7 +184,8 @@ class PrintAST(Visitor):
         body = self.visit(o.body)
         footer = self.visit(o.footer)
         self._depth -= 1
-        return self.indent + "<Block>\n%s" % header + body + footer
+        return self.indent + "<%s>\n%s" % (o.__class__.__name__,
+                                           '\n'.join([header, body, footer]))
 
     def visit_Iteration(self, o):
         self._depth += 1

--- a/devito/visitors.py
+++ b/devito/visitors.py
@@ -183,7 +183,8 @@ class PrintAST(Visitor):
         self._depth += 1
         body = self.visit(o.children)
         self._depth -= 1
-        return self.indent + "<Iteration %s>\n%s" % (o.dim.name, body)
+        detail = '::%s::%s' % (o.index, o.limits) if self.verbose else ''
+        return self.indent + "<Iteration %s%s>\n%s" % (o.dim.name, detail, body)
 
     def visit_Expression(self, o):
         if self.verbose:

--- a/devito/visitors.py
+++ b/devito/visitors.py
@@ -7,7 +7,7 @@ The main Visitor class is extracted from https://github.com/coneoproject/COFFEE.
 from __future__ import absolute_import
 
 import inspect
-from collections import OrderedDict, namedtuple
+from collections import OrderedDict, defaultdict, namedtuple
 from operator import attrgetter
 
 import cgen as c
@@ -393,7 +393,7 @@ class ResolveIterationVariable(Transformer):
           int t1 = (t + 1) % 2;
     """
 
-    def visit_Iteration(self, o, subs={}, offsets={}):
+    def visit_Iteration(self, o, subs={}, offsets=defaultdict(set)):
         nodes = self.visit(o.children, subs=subs, offsets=offsets)
         if o.dim.buffered:
             # For buffered dimensions insert the explicit
@@ -414,11 +414,10 @@ class ResolveIterationVariable(Transformer):
             subs[o.dim] = Symbol(vname)
             return o._rebuild(*nodes, index=vname)
 
-    def visit_Expression(self, o, subs={}, offsets={}):
-        # Collect all offsets used with a dimension
-        # TODO: Straight update is not really safe,
-        # since we're mapping into a list...
-        offsets.update(o.index_offsets)
+    def visit_Expression(self, o, subs={}, offsets=defaultdict(set)):
+        """Collect all offsets used with a dimension"""
+        for dim, offs in o.index_offsets.items():
+            offsets[dim].update(offs)
         return o
 
 

--- a/devito/visitors.py
+++ b/devito/visitors.py
@@ -172,6 +172,16 @@ class PrintAST(Visitor):
         body = ' %s' % str(o) if self.verbose else ''
         return self.indent + '<C.%s%s>' % (o.__class__.__name__, body)
 
+    def visit_Element(self, o):
+        body = ' %s' % str(o.element) if self.verbose else ''
+        return self.indent + '<Element%s>' % body
+
+    def visit_Function(self, o):
+        self._depth += 1
+        body = self.visit(o.children)
+        self._depth -= 1
+        return self.indent + '<Function %s>\n%s' % (o.name, body)
+
     def visit_list(self, o):
         return ('\n').join([self.visit(i) for i in o])
 

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -6,7 +6,7 @@ from devito.dimension import Dimension
 from devito.interfaces import DenseData
 from devito.nodes import Block, Expression, Function, Iteration
 from devito.visitors import (FindSections, FindSymbols, IsPerfectIteration,
-                             Transformer)
+                             Transformer, printAST)
 
 
 def _symbol(name, dimensions):
@@ -69,6 +69,38 @@ def block3(exprs, iters):
     return iters[0]([iters[3](exprs[0]),
                      iters[1](iters[2]([exprs[1], exprs[2]])),
                      iters[4](exprs[3])])
+
+
+def test_printAST(block1, block2, block3):
+    str1 = printAST(block1)
+    assert str1 in """
+<Iteration i>
+  <Iteration j>
+    <Iteration k>
+      <Expression a[i] = a[i] + b[i] + 5.0>
+"""
+
+    str2 = printAST(block2)
+    assert str2 in """
+<Iteration i>
+  <Expression a[i] = a[i] + b[i] + 5.0>
+  <Iteration j>
+    <Iteration k>
+      <Expression a[i] = -a[i] + b[i]>
+"""
+
+    str3 = printAST(block3)
+    assert str3 in """
+<Iteration i>
+  <Iteration s>
+    <Expression a[i] = a[i] + b[i] + 5.0>
+  <Iteration j>
+    <Iteration k>
+      <Expression a[i] = -a[i] + b[i]>
+      <Expression a[i] = 4*a[i]*b[i]>
+  <Iteration p>
+    <Expression a[i] = 8.0*a[i] + 6.0/b[i]>
+"""
 
 
 def test_find_sections(exprs, block1, block2, block3):

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -74,31 +74,31 @@ def block3(exprs, iters):
 def test_printAST(block1, block2, block3):
     str1 = printAST(block1)
     assert str1 in """
-<Iteration i>
-  <Iteration j>
-    <Iteration k>
+<Iteration i::i::[0, 3, 1]>
+  <Iteration j::j::[0, 5, 1]>
+    <Iteration k::k::[0, 7, 1]>
       <Expression a[i] = a[i] + b[i] + 5.0>
 """
 
     str2 = printAST(block2)
     assert str2 in """
-<Iteration i>
+<Iteration i::i::[0, 3, 1]>
   <Expression a[i] = a[i] + b[i] + 5.0>
-  <Iteration j>
-    <Iteration k>
+  <Iteration j::j::[0, 5, 1]>
+    <Iteration k::k::[0, 7, 1]>
       <Expression a[i] = -a[i] + b[i]>
 """
 
     str3 = printAST(block3)
     assert str3 in """
-<Iteration i>
-  <Iteration s>
+<Iteration i::i::[0, 3, 1]>
+  <Iteration s::s::[0, 4, 1]>
     <Expression a[i] = a[i] + b[i] + 5.0>
-  <Iteration j>
-    <Iteration k>
+  <Iteration j::j::[0, 5, 1]>
+    <Iteration k::k::[0, 7, 1]>
       <Expression a[i] = -a[i] + b[i]>
       <Expression a[i] = 4*a[i]*b[i]>
-  <Iteration p>
+  <Iteration p::p::[0, 4, 1]>
     <Expression a[i] = 8.0*a[i] + 6.0/b[i]>
 """
 
@@ -253,10 +253,10 @@ def test_merge_iterations_flat(exprs, iters):
              iters[0](iters[2](exprs[1]))]
     newblock = MergeOuterIterations().visit(block)
     newstr = printAST(newblock)
-    assert newstr == """<Iteration i>
-  <Iteration j>
+    assert newstr == """<Iteration i::i::[0, 3, 1]>
+  <Iteration j::j::[0, 5, 1]>
     <Expression a[i] = a[i] + b[i] + 5.0>
-  <Iteration k>
+  <Iteration k::k::[0, 7, 1]>
     <Expression a[i] = -a[i] + b[i]>"""
 
 
@@ -276,10 +276,10 @@ def test_merge_iterations_deep(exprs, iters):
              iters[0]([iters[2](exprs[0]), iters[2](exprs[1])])]
     newblock = MergeOuterIterations().visit(block)
     newstr = printAST(newblock)
-    assert newstr == """<Iteration i>
-  <Iteration j>
+    assert newstr == """<Iteration i::i::[0, 3, 1]>
+  <Iteration j::j::[0, 5, 1]>
     <Expression a[i] = a[i] + b[i] + 5.0>
-  <Iteration k>
+  <Iteration k::k::[0, 7, 1]>
     <Expression a[i] = a[i] + b[i] + 5.0>
     <Expression a[i] = -a[i] + b[i]>"""
 
@@ -301,9 +301,9 @@ def test_merge_iterations_nested(exprs, iters):
              iters[0]([iters[1](exprs[1]), iters[2](exprs[1])])]
     newblock = MergeOuterIterations().visit(block)
     newstr = printAST(newblock)
-    assert newstr == """<Iteration i>
-  <Iteration j>
+    assert newstr == """<Iteration i::i::[0, 3, 1]>
+  <Iteration j::j::[0, 5, 1]>
     <Expression a[i] = a[i] + b[i] + 5.0>
     <Expression a[i] = -a[i] + b[i]>
-  <Iteration k>
+  <Iteration k::k::[0, 7, 1]>
     <Expression a[i] = -a[i] + b[i]>"""


### PR DESCRIPTION
This merge includes a set of utility routines and visitors for the `StencilKernel` that bring us closer to being able to handle the FWI examples. Most notably it includes:
* Pretty-print an AST with a custom visitor. This visitor has a `verbose` mode that:
  * If `False` returns a nicely indented short description string of the loop structure.
  * If `True` incorporates all relevant meta-information about the core node types, allowing us to use it as the base of the kernel hash key.
* A new `MergeOuterIteration` transformer that recursively merges matching `Dimension`s so that we can group expressions under them. This is very useful for source terms.
* Fix to include the zero-offset for each `Dimension` in `Expression.index_offset`, which allows us determine "dimensions used in an expression" for loop insertion.
* As mentioned above, build the hash key from the verbose AST pretty-string.
* Add utility dimension `r` to indicate depth of spatial dimension for point source coordinate fields. 