### PR TITLE
FindSymbols: Filter symbol names and sort them

### DIFF
--- a/devito/tools.py
+++ b/devito/tools.py
@@ -48,6 +48,11 @@ def filter_ordered(elements, key=None):
     return [e for e in elements if not (key(e) in seen or seen.add(key(e)))]
 
 
+def filter_sorted(elements, key=None):
+    """Filter elements in a list and sort them by key"""
+    return sorted(filter_ordered(elements, key=key), key=key)
+
+
 def convert_dtype_to_ctype(dtype):
     """Maps numpy types to C types.
 

--- a/devito/visitors.py
+++ b/devito/visitors.py
@@ -15,7 +15,7 @@ from sympy import Symbol
 
 from devito.dse import estimate_cost, estimate_memory
 from devito.nodes import Block, IterationBound
-from devito.tools import filter_ordered, flatten
+from devito.tools import filter_sorted, flatten
 
 __all__ = ["EstimateCost", "FindSections", "FindSymbols", "IsPerfectIteration",
            "SubstituteExpression", "ResolveIterationVariable"]
@@ -215,16 +215,16 @@ class FindSymbols(Visitor):
 
     def visit_tuple(self, o):
         symbols = flatten([self.visit(i) for i in o])
-        return filter_ordered(symbols, key=attrgetter('name'))
+        return filter_sorted(symbols, key=attrgetter('name'))
 
     def visit_Iteration(self, o):
         symbols = flatten([self.visit(i) for i in o.children])
         if isinstance(o.limits[1], IterationBound):
             symbols += [o.dim]
-        return filter_ordered(symbols, key=attrgetter('name'))
+        return filter_sorted(symbols, key=attrgetter('name'))
 
     def visit_Expression(self, o):
-        return filter_ordered([f for f in self.rule(o)], key=attrgetter('name'))
+        return filter_sorted([f for f in self.rule(o)], key=attrgetter('name'))
 
 
 class IsPerfectIteration(Visitor):

--- a/tests/test_dle.py
+++ b/tests/test_dle.py
@@ -102,17 +102,17 @@ def test_create_elemental_functions_simple(simple_function):
   {
     for (int j0 = 0 + 0; j0 < 5 - 0; j0 += 1)
     {
-      f_0_0(a_vec,b_vec,d_vec,c_vec,i0,j0);
+      f_0_0(a_vec,b_vec,c_vec,d_vec,i0,j0);
     }
   }
 }
-void f_0_0(float *a_vec, float *b_vec, float *d_vec, float *c_vec,"""
+void f_0_0(float *a_vec, float *b_vec, float *c_vec, float *d_vec,"""
          """ const int i0, const int j0)
 {
   float (*a) = (float (*)) a_vec;
   float (*b) = (float (*)) b_vec;
-  float (*d)[5][7] = (float (*)[5][7]) d_vec;
   float (*c)[5] = (float (*)[5]) c_vec;
+  float (*d)[5][7] = (float (*)[5][7]) d_vec;
   for (int k0 = 0 + 0; k0 < 7 - 0; k0 += 1)
   {
     a[i0] = a[i0] + b[i0] + 5.0F;
@@ -136,7 +136,7 @@ def test_create_elemental_functions_complex(complex_function):
     f_0_0(a_vec,b_vec,i1);
     for (int j1 = 0 + 0; j1 < 5 - 0; j1 += 1)
     {
-      f_0_1(a_vec,b_vec,c_vec,d_vec,j1,i1);
+      f_0_1(a_vec,b_vec,c_vec,d_vec,i1,j1);
     }
     f_0_2(a_vec,b_vec,i1);
   }
@@ -151,7 +151,7 @@ void f_0_0(float *a_vec, float *b_vec, const int i1)
   }
 }
 void f_0_1(float *a_vec, float *b_vec, float *c_vec, float *d_vec,"""
-         """ const int j1, const int i1)
+         """ const int i1, const int j1)
 {
   float (*a) = (float (*)) a_vec;
   float (*b) = (float (*)) b_vec;


### PR DESCRIPTION
This merge should fix the spurious breakages in current master. 
It adds a new utility routine `filter_sorted()` that behaves like
`filter_ordered` but also enforces sorting according to a key.