### PR TITLE
DLE: OpenMP and SIMD

### DIFF
--- a/devito/dle/inspection.py
+++ b/devito/dle/inspection.py
@@ -21,4 +21,4 @@ def retrieve_iteration_tree(node):
         [(Iteration i, Iteration j, Iteration k), (Iteration i, Iteration p)]
     """
 
-    return FindSections().visit(node).keys()
+    return [i for i in FindSections().visit(node).keys() if i]

--- a/devito/dle/transformer.py
+++ b/devito/dle/transformer.py
@@ -95,8 +95,7 @@ def dle_transformation(func):
             state.update(**func(self, state))
             toc = time()
 
-            key = '%s%d' % (func.__name__, len(self.timings))
-            self.timings[key] = toc - tic
+            self.timings[func.__name__] = toc - tic
 
     return wrapper
 

--- a/devito/dle/transformer.py
+++ b/devito/dle/transformer.py
@@ -252,11 +252,13 @@ class Rewriter(object):
                     break
 
             # Track parallelism in the Iteration/Expression tree
+            mapper = {i: ('parallel',) for i in tree[is_OSIP:-1]}
+            mapper[tree[-1]] = ('parallel', 'vector-dim')
             for i in tree[is_OSIP:]:
                 args = i.args
-                properties = as_tuple(args.pop('properties')) + ('parallel',)
-                transformer = Transformer({i: Iteration(properties=properties, **args)})
-                nodes = transformer.visit(nodes)
+                properties = as_tuple(args.pop('properties')) + mapper[i]
+                propertized = Iteration(properties=properties, **args)
+                nodes = Transformer({i: propertized}).visit(nodes)
 
         state.update(nodes=nodes)
 

--- a/devito/dle/transformer.py
+++ b/devito/dle/transformer.py
@@ -380,7 +380,8 @@ class Rewriter(object):
 
                     start = i.limits[0] - i.offsets[0]
                     finish = iter_size - ((iter_size - i.offsets[1]) % block_size)
-                    inter_block = Iteration([], dim, [start, finish, block_size])
+                    inter_block = Iteration([], dim, [start, finish, block_size],
+                                            properties=('parallel', 'blocked'))
 
                     # Build Iteration within a block
                     dim = dims.setdefault((i.dim, 'intra-block'),
@@ -388,7 +389,8 @@ class Rewriter(object):
 
                     start = inter_block.dim
                     finish = start + block_size
-                    intra_block = Iteration([], dim, [start, finish, 1], i.index)
+                    intra_block = Iteration([], dim, [start, finish, 1], i.index,
+                                            properties=('parallel',))
 
                     blocked_iterations.append((inter_block, intra_block))
 
@@ -397,14 +399,16 @@ class Rewriter(object):
                     # non-blocked ("remainder") iterations.
                     start = inter_block.limits[0]
                     finish = inter_block.limits[1]
-                    main = Iteration([], i.dim, [start, finish, 1], i.index)
+                    main = Iteration([], i.dim, [start, finish, 1], i.index,
+                                     properties=('parallel',))
 
                     # Build unitary-increment Iteration over the 'leftover' region:
                     # again as above, this may be necessary when the dimension size
                     # is not a multiple of the block size.
                     start = inter_block.limits[1]
                     finish = iter_size - i.offsets[1]
-                    leftover = Iteration([], i.dim, [start, finish, 1], i.index)
+                    leftover = Iteration([], i.dim, [start, finish, 1], i.index,
+                                         properties=('parallel',))
 
                     regions[i] = Region(main, leftover)
 

--- a/devito/dle/transformer.py
+++ b/devito/dle/transformer.py
@@ -257,7 +257,7 @@ class Rewriter(object):
 
             # Track parallelism in the Iteration/Expression tree
             mapper = {i: ('parallel',) for i in tree[is_OSIP:-1]}
-            mapper[tree[-1]] = ('parallel', 'vector-dim')
+            mapper[tree[-1]] = ('vector-dim',)
             for i in tree[is_OSIP:]:
                 args = i.args
                 properties = as_tuple(args.pop('properties')) + mapper[i]

--- a/devito/nodes.py
+++ b/devito/nodes.py
@@ -92,7 +92,7 @@ class Block(Node):
     @property
     def ccode(self):
         body = tuple(s.ccode for s in self.body)
-        return self._wrapper(self.header + body + self.footer)
+        return c.Module(self.header + (self._wrapper(body),) + self.footer)
 
     @property
     def children(self):
@@ -419,11 +419,11 @@ class Denormals(Block):
 
     """Macros to make sure denormal numbers are flushed in hardware."""
 
-    def __init__(self, **kwargs):
+    def __init__(self, header=None, body=None, footer=None):
         b = [Element(c.Comment('Flush denormal numbers to zero in hardware')),
              Element(c.Statement('_MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_ON)')),
              Element(c.Statement('_MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON)'))]
-        super(Denormals, self).__init__(body=b)
+        super(Denormals, self).__init__(header, b, footer)
 
     def __repr__(self):
         return "<DenormalsMacro>"

--- a/devito/nodes.py
+++ b/devito/nodes.py
@@ -429,7 +429,6 @@ class Denormals(Block):
         return "<DenormalsMacro>"
 
 
-
 class IterationBound(object):
     """Utility class to encapsulate variable loop bounds and link them
     back to the respective :class:`Dimension` object.

--- a/devito/nodes.py
+++ b/devito/nodes.py
@@ -118,7 +118,7 @@ class Element(Node):
     is_Element = True
 
     def __init__(self, element):
-        assert isinstance(element, c.Statement)
+        assert isinstance(element, (c.Comment, c.Statement))
         self.element = element
 
     def __repr__(self):

--- a/devito/nodes.py
+++ b/devito/nodes.py
@@ -415,6 +415,21 @@ class TimedList(List):
         return self._name
 
 
+class Denormals(Block):
+
+    """Macros to make sure denormal numbers are flushed in hardware."""
+
+    def __init__(self, **kwargs):
+        b = [Element(c.Comment('Flush denormal numbers to zero in hardware')),
+             Element(c.Statement('_MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_ON)')),
+             Element(c.Statement('_MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON)'))]
+        super(Denormals, self).__init__(body=b)
+
+    def __repr__(self):
+        return "<DenormalsMacro>"
+
+
+
 class IterationBound(object):
     """Utility class to encapsulate variable loop bounds and link them
     back to the respective :class:`Dimension` object.

--- a/devito/stencilkernel.py
+++ b/devito/stencilkernel.py
@@ -19,11 +19,11 @@ from devito.interfaces import SymbolicData
 from devito.logger import error, info
 from devito.nodes import Block, Expression, Function, Iteration, TimedList
 from devito.profiler import Profiler
+from devito.tools import as_tuple
 from devito.visitors import (EstimateCost, FindSections, FindSymbols,
                              IsPerfectIteration, MergeOuterIterations,
                              ResolveIterationVariable, SubstituteExpression,
                              Transformer, printAST)
-from devito.tools import as_tuple
 
 __all__ = ['StencilKernel']
 

--- a/devito/stencilkernel.py
+++ b/devito/stencilkernel.py
@@ -114,7 +114,8 @@ class StencilKernel(Function):
         nodes = SubstituteExpression(subs=subs).visit(nodes)
 
         # Apply the Devito Loop Engine for loop optimization and finalize instantiation
-        dle_state = transform(nodes, mode=set_dle_mode(dle, self.compiler))
+        dle_state = transform(nodes, mode=set_dle_mode(dle, self.compiler),
+                              compiler=self.compiler)
         body = dle_state.nodes
         parameters = FindSymbols().visit(nodes)
         parameters += [i.argument for i in dle_state.arguments]

--- a/devito/stencilkernel.py
+++ b/devito/stencilkernel.py
@@ -30,9 +30,6 @@ __all__ = ['StencilKernel']
 
 class StencilKernel(Function):
 
-    _includes = ['stdlib.h', 'math.h', 'sys/time.h',
-                 'xmmintrin.h', 'pmmintrin.h']
-
     """A special :class:`Function` to evaluate stencils through just-in-time
     compilation of C code.
 
@@ -63,6 +60,7 @@ class StencilKernel(Function):
         # Default attributes required for compilation
         self.compiler = compiler or get_compiler_from_env()
         self.profiler = kwargs.get("profiler", Profiler(self.compiler.openmp))
+        self._includes = ['stdlib.h', 'math.h', 'sys/time.h']
         self._lib = None
         self._cfunction = None
 
@@ -121,6 +119,9 @@ class StencilKernel(Function):
         parameters = FindSymbols().visit(nodes)
         parameters += [i.argument for i in dle_state.arguments]
         super(StencilKernel, self).__init__(name, body, 'int', parameters, ())
+
+        # DLE might have introduced additional headers
+        self._includes.extend(list(dle_state.includes))
 
         # Track the DSE and DLE output, as they may be useful later
         self._dse_state = dse_state
@@ -227,14 +228,9 @@ class StencilKernel(Function):
         blankline = c.Line("")
 
         # Generate function body with all the trimmings
-        extra = [c.Comment('Force flushing of denormals to zero in hardware'),
-                 c.Line('_MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_ON);'),
-                 c.Line('_MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);')]
-        denormal = [c.Block(extra)]
         body = [e.ccode for e in self.body]
         ret = [c.Statement("return 0")]
-        kernel = c.FunctionBody(self._ctop,
-                                c.Block(self._ccasts + denormal + body + ret))
+        kernel = c.FunctionBody(self._ctop, c.Block(self._ccasts + body + ret))
 
         # Generate elemental functions produced by the DLE
         elemental_functions = [e.ccode for e in self._dle_state.elemental_functions]

--- a/devito/tools.py
+++ b/devito/tools.py
@@ -2,7 +2,6 @@ import ctypes
 from collections import Callable, Iterable, OrderedDict
 
 import numpy as np
-from sympy import symbols
 
 
 def as_tuple(item, type=None, length=None):
@@ -93,7 +92,7 @@ def pprint(node, verbose=True):
     Shortcut to pretty print Iteration/Expression trees.
     """
     from devito.visitors import printAST
-    print printAST(node, verbose)
+    print(printAST(node, verbose))
 
 
 class DefaultOrderedDict(OrderedDict):

--- a/devito/tools.py
+++ b/devito/tools.py
@@ -14,6 +14,8 @@ def as_tuple(item, type=None, length=None):
     # Empty list if we get passed None
     if item is None:
         t = ()
+    elif isinstance(item, str):
+        t = (item,)
     else:
         # Convert iterable to list...
         try:

--- a/devito/tools.py
+++ b/devito/tools.py
@@ -88,6 +88,14 @@ def aligned(a, alignment=16):
     return aa
 
 
+def pprint(node, verbose=True):
+    """
+    Shortcut to pretty print Iteration/Expression trees.
+    """
+    from devito.visitors import printAST
+    print printAST(node, verbose)
+
+
 class DefaultOrderedDict(OrderedDict):
     # Source: http://stackoverflow.com/a/6190500/562769
     def __init__(self, default_factory=None, *a, **kw):

--- a/devito/tools.py
+++ b/devito/tools.py
@@ -67,34 +67,6 @@ def convert_dtype_to_ctype(dtype):
     return conversion_dict[dtype]
 
 
-def sympy_find(expr, term, repl):
-    """Change all terms from function notation to array notation.
-
-    Finds all terms of the form term(x1, x2, x3)
-    and changes them to repl[x1, x2, x3]. i.e. changes from
-    function notation to array notation. It also reorders the indices
-    x1, x2, x3 so that the time index comes first.
-
-    :param expr: The expression to be processed
-    :param term: The pattern to be replaced
-    :param repl: The replacing pattern
-    :returns: The changed expression
-    """
-
-    t = symbols("t")
-
-    if type(expr) == term:
-        args_wo_t = [x for x in expr.args if x != t and t not in x.args]
-        args_t = [x for x in expr.args if x == t or t in x.args]
-        expr = repl[tuple(args_t + args_wo_t)]
-
-    if hasattr(expr, "args"):
-        for a in expr.args:
-            expr = expr.subs(a, sympy_find(a, term, repl))
-
-    return expr
-
-
 def aligned(a, alignment=16):
     """Function to align the memmory
 

--- a/devito/visitors.py
+++ b/devito/visitors.py
@@ -197,8 +197,12 @@ class PrintAST(Visitor):
         self._depth += 1
         body = self.visit(o.children)
         self._depth -= 1
-        detail = '::%s::%s' % (o.index, o.limits) if self.verbose else ''
-        return self.indent + "<Iteration %s%s>\n%s" % (o.dim.name, detail, body)
+        if self.verbose:
+            detail = '::%s::%s' % (o.index, o.limits)
+            props = '[%s] ' % ','.join(o.properties) if o.properties else ''
+        else:
+            detail, props = '', ''
+        return self.indent + "<%sIteration %s%s>\n%s" % (props, o.dim.name, detail, body)
 
     def visit_Expression(self, o):
         if self.verbose:

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,5 +5,6 @@ pytest
 flake8>=2.1.0
 isort
 py-cpuinfo
+psutil>=5.1.0
 git+git://github.com/inducer/cgen
 git+git://github.com/inducer/codepy


### PR DESCRIPTION
This PR mainly introduces two transformation steps in the DLE:
- Generation of pragmas for OpenMP parallelism
- Generation of pragmas to trigger compiler auto-vectorization

The OpenMP parallelization looks way simpler than that in the Propagator, but it should be effective in exactly the same way. I talked to @pvelesko , and it turns out the original OpenMPization through the propagator had been done by a number of people, or perhaps mostly by @navjotk ? I'm interested in your thoughts.

Some generated code follows, from our Diffusion example:
```
#include "stdlib.h"
#include "math.h"
#include "sys/time.h"
#include "xmmintrin.h"
#include "pmmintrin.h"

struct profiler
{
  double loop_t_0;
} ;

int Kernel(const int t_size, float *u_vec, const int x_size, const int y_size, struct profiler *timings)
{
  float (*u)[x_size][y_size] = (float (*)[x_size][y_size]) u_vec;
  #pragma omp parallel
  {
    /* Flush denormal numbers to zero in hardware */
    _MM_SET_DENORMALS_ZERO_MODE(_MM_DENORMALS_ZERO_ON);
    _MM_SET_FLUSH_ZERO_MODE(_MM_FLUSH_ZERO_ON);
  }
  {
    struct timeval start_loop_t_0, end_loop_t_0;
    gettimeofday(&start_loop_t_0, NULL);
    for (int t = 0; t < t_size - 1; t += 1)
    {   
      int t0 = (t) % 2;
      int t1 = (t + 1) % 2;
      {   
        #pragma omp parallel for schedule(static)
        for (int x0 = 1; x0 < x_size - 1; x0 += 1)
        {   
          #pragma ivdep
          for (int y0 = 1; y0 < y_size - 1; y0 += 1)
          {   
            u[t1][x0][y0] = 2.5e-1F*(u[t0][x0][y0 - 1] + u[t0][x0][y0 + 1] + u[t0][x0 - 1][y0] + u[t0][x0 + 1][y0]);
          }   
        }
      }
    }
    gettimeofday(&end_loop_t_0, NULL);
    timings->loop_t_0 += (double)(end_loop_t_0.tv_sec-start_loop_t_0.tv_sec)+(double)(end_loop_t_0.tv_usec-start_loop_t_0.tv_usec)/1000000;
  }
  return 0;
}
```

Intel's ``#pragma ivdep`` does suffice to trigger auto-vectorization (it also speeds up compilation time over ``#pragma simd``). If another compiler is used instead, the standard ``#pragma omp simd`` is generated