### PR TITLE
Tweaks, hacks and fixes to make Acoustic-Forward run with Devito-3.0

### DIFF
--- a/devito/dimension.py
+++ b/devito/dimension.py
@@ -27,12 +27,6 @@ class Dimension(Symbol):
     def __str__(self):
         return self.name
 
-    def get_varname(self):
-        """Generates a new variables name based on an internal counter"""
-        name = "%s%d" % (self.name, self._count)
-        self._count += 1
-        return name
-
     @property
     def symbolic_size(self):
         """The symbolic size of this dimension."""

--- a/devito/interfaces.py
+++ b/devito/interfaces.py
@@ -591,8 +591,8 @@ class PointData(DenseData):
         :param shape: Shape of the spatial data
         :return: indices used for axis.
         """
-        _indices = [t, p]
-        return _indices
+        dimensions = kwargs.get('dimensions', None)
+        return dimensions or [t, p]
 
 
 class IndexedData(IndexedBase):

--- a/devito/interfaces.py
+++ b/devito/interfaces.py
@@ -538,8 +538,8 @@ class CoordinateData(TensorData):
         :param shape: Shape of the spatial data
         :return: indices used for axis.
         """
-        _indices = [p, d]
-        return _indices
+        dimensions = kwargs.get('dimensions', None)
+        return dimensions or [p, d]
 
     @property
     def indexed(self):
@@ -573,6 +573,7 @@ class PointData(DenseData):
             super(PointData, self).__init__(self, *args, **kwargs)
             coordinates = kwargs.get('coordinates')
             self.coordinates = CoordinateData(name='%s_coords' % self.name,
+                                              dimensions=[self.indices[1], d],
                                               data=coordinates, ndim=ndim,
                                               nt=self.nt, npoint=self.npoint)
             self.coordinates.data[:] = kwargs.get('coordinates')[:]

--- a/devito/memory.py
+++ b/devito/memory.py
@@ -8,6 +8,7 @@ from operator import mul
 import numpy as np
 from sympy import Eq
 
+from devito.dimension import t
 from devito.logger import error
 from devito.tools import convert_dtype_to_ctype
 
@@ -77,6 +78,7 @@ def first_touch(array):
 
     exp_init = [Eq(array.indexed[array.indices], 0)]
     it_init = []
+    time_dim = t
     if isinstance(array, TimeData):
         shape = array.shape
         time_steps = shape[0]
@@ -88,6 +90,7 @@ def first_touch(array):
                                  limits=array.shape[1])]
             exp_init = []
             time_steps = array.shape[0]
+            time_dim = array.indices[0]
             shape = []
             space_dims = []
         else:
@@ -95,7 +98,8 @@ def first_touch(array):
             time_steps = 1
             space_dims = array.indices
     prop = Propagator(name="init", nt=time_steps, shape=shape,
-                      stencils=exp_init, space_dims=space_dims)
+                      stencils=exp_init, space_dims=space_dims,
+                      time_dim=time_dim)
     prop.add_devito_param(array)
     prop.save_vars[array.name] = True
     prop.time_loop_stencils_a = it_init

--- a/devito/memory.py
+++ b/devito/memory.py
@@ -8,7 +8,6 @@ from operator import mul
 import numpy as np
 from sympy import Eq
 
-from devito.dimension import p
 from devito.logger import error
 from devito.tools import convert_dtype_to_ctype
 
@@ -85,7 +84,8 @@ def first_touch(array):
         space_dims = array.indices[1:]
     else:
         if isinstance(array, PointData):
-            it_init = [Iteration(exp_init, dimension=p, limits=array.shape[1])]
+            it_init = [Iteration(exp_init, dimension=array.indices[1],
+                                 limits=array.shape[1])]
             exp_init = []
             time_steps = array.shape[0]
             shape = []

--- a/devito/nodes.py
+++ b/devito/nodes.py
@@ -271,7 +271,8 @@ class Iteration(Node):
         if self.limits[1] is None:
             # FIXME: Add dimension size as variable bound.
             # Needs further generalisation to support loop blocking.
-            self.limits[1] = IterationBound("%s_size" % self.dim.name, self.dim)
+            dim = self.dim.parent if self.dim.is_Buffered else self.dim
+            self.limits[1] = IterationBound("%s_size" % dim.name, self.dim)
 
         # Record offsets to later adjust loop limits accordingly
         self.offsets = [0, 0]

--- a/devito/visitors.py
+++ b/devito/visitors.py
@@ -441,14 +441,17 @@ class ResolveIterationVariable(Transformer):
           int t1 = (t + 1) % 2;
     """
 
-    def visit_Iteration(self, o, subs={}, offsets=defaultdict(set)):
-        nodes = self.visit(o.children, subs=subs, offsets=offsets)
+    def visit_Iteration(self, o, subs={}, offsets=defaultdict(set),
+                        variable_map=defaultdict(int)):
+        nodes = self.visit(o.children, subs=subs, offsets=offsets,
+                           variable_map=variable_map)
         if o.dim.is_Buffered:
             # For buffered dimensions insert the explicit
             # definition of buffere variables, eg. t+1 => t1
             init = []
             for off in filter_ordered(offsets[o.dim]):
-                vname = o.dim.get_varname()
+                vname = "%s%d" % (o.dim.name, variable_map[o.dim])
+                variable_map[o.dim] += 1  # Increase variable count
                 value = o.dim.parent + off
                 modulo = o.dim.modulo
                 init += [c.Initializer(c.Value('int', vname),
@@ -460,11 +463,13 @@ class ResolveIterationVariable(Transformer):
             newnodes = (List(header=init, body=nodes[0]), )
             return o._rebuild(newnodes, index=o.dim.parent.name)
         else:
-            vname = o.dim.get_varname()
+            vname = "%s%d" % (o.dim.name, variable_map[o.dim])
+            variable_map[o.dim] += 1  # Increase variable count
             subs[o.dim] = Symbol(vname)
             return o._rebuild(*nodes, index=vname)
 
-    def visit_Expression(self, o, subs={}, offsets=defaultdict(set)):
+    def visit_Expression(self, o, subs={}, offsets=defaultdict(set),
+                         variable_map=defaultdict(int)):
         """Collect all offsets used with a dimension"""
         for dim, offs in o.index_offsets.items():
             offsets[dim].update(offs)

--- a/devito/visitors.py
+++ b/devito/visitors.py
@@ -14,7 +14,7 @@ import cgen as c
 from sympy import Symbol
 
 from devito.dse import estimate_cost, estimate_memory
-from devito.nodes import Iteration, IterationBound, List
+from devito.nodes import Iteration, List
 from devito.tools import as_tuple, filter_ordered, filter_sorted, flatten
 
 
@@ -275,7 +275,8 @@ class FindSymbols(Visitor):
 
     rules = {
         'with-data': lambda e: e.functions,
-        'free-symbols': lambda e: e.stencil.free_symbols
+        'free-symbols': lambda e: e.stencil.free_symbols,
+        'dimensions': lambda e: e.dimensions,
     }
 
     def __init__(self, mode='with-data'):
@@ -288,8 +289,6 @@ class FindSymbols(Visitor):
 
     def visit_Iteration(self, o):
         symbols = flatten([self.visit(i) for i in o.children])
-        if isinstance(o.limits[1], IterationBound):
-            symbols += [o.dim]
         return filter_sorted(symbols, key=attrgetter('name'))
 
     def visit_Expression(self, o):

--- a/devito/visitors.py
+++ b/devito/visitors.py
@@ -13,9 +13,8 @@ from operator import attrgetter
 import cgen as c
 from sympy import Symbol
 
-from devito.dimension import BufferedDimension
 from devito.dse import estimate_cost, estimate_memory
-from devito.nodes import Block, Iteration, IterationBound
+from devito.nodes import Iteration, IterationBound, List
 from devito.tools import as_tuple, filter_ordered, filter_sorted, flatten
 
 
@@ -444,13 +443,13 @@ class ResolveIterationVariable(Transformer):
 
     def visit_Iteration(self, o, subs={}, offsets=defaultdict(set)):
         nodes = self.visit(o.children, subs=subs, offsets=offsets)
-        if isinstance(o.dim, BufferedDimension):
+        if o.dim.is_Buffered:
             # For buffered dimensions insert the explicit
             # definition of buffere variables, eg. t+1 => t1
             init = []
             for off in filter_ordered(offsets[o.dim]):
                 vname = o.dim.get_varname()
-                value = o.dim + off
+                value = o.dim.parent + off
                 modulo = o.dim.modulo
                 init += [c.Initializer(c.Value('int', vname),
                                        "(%s) %% %d" % (value, modulo))]
@@ -458,8 +457,8 @@ class ResolveIterationVariable(Transformer):
             # Always lower to symbol
             subs[o.dim.parent] = Symbol(o.dim.parent.name)
             # Insert block with modulo initialisations
-            newnodes = (Block(header=init, body=nodes[0]), )
-            return o._rebuild(newnodes)
+            newnodes = (List(header=init, body=nodes[0]), )
+            return o._rebuild(newnodes, index=o.dim.parent.name)
         else:
             vname = o.dim.get_varname()
             subs[o.dim] = Symbol(vname)

--- a/examples/acoustic/Acoustic_codegen.py
+++ b/examples/acoustic/Acoustic_codegen.py
@@ -77,8 +77,13 @@ class Acoustic_cg(object):
                              save=save, cache_blocking=cache_blocking, dse=dse,
                              compiler=compiler, profile=True, u_ini=u_ini)
 
-        u, rec = fw.apply()
-        return rec.data, u, fw.propagator.gflopss, fw.propagator.oi, fw.propagator.timings
+        if isinstance(fw, StencilKernel):
+            fw.apply()
+            return None, None, None, None, None
+        else:
+            u, rec = fw.apply()
+            return (rec.data, u, fw.propagator.gflopss,
+                    fw.propagator.oi, fw.propagator.timings)
 
     def Adjoint(self, rec, cache_blocking=None):
         adj = AdjointOperator(self.model, self.damp, self.data, self.src, rec,

--- a/examples/acoustic/Acoustic_codegen.py
+++ b/examples/acoustic/Acoustic_codegen.py
@@ -55,11 +55,6 @@ class Acoustic_cg(object):
         # Initialize damp by calling the function that can precompute damping
         damp_boundary(self.damp.data, nbpml)
 
-        if len(self.damp.shape) == 2 and self.src.receiver_coords.shape[1] == 3:
-            self.src.receiver_coords = np.delete(self.src.receiver_coords, 1, 1)
-        if len(self.damp.shape) == 2 and self.data.receiver_coords.shape[1] == 3:
-            self.data.receiver_coords = np.delete(self.data.receiver_coords, 1, 1)
-
         if auto_tuning:  # auto tuning with dummy forward operator
             fw = ForwardOperator(self.model, self.src, self.damp, self.data,
                                  time_order=self.t_order, spc_order=self.s_order,

--- a/examples/acoustic/Acoustic_codegen.py
+++ b/examples/acoustic/Acoustic_codegen.py
@@ -90,8 +90,8 @@ class Acoustic_cg(object):
             self.at = AutoTuner(fw)
             self.at.auto_tune_blocks(self.s_order + 1, self.s_order * 4 + 2)
 
-    def Forward(self, save=False, cache_blocking=None,
-                auto_tuning=False, dse='advanced', compiler=None, u_ini=None):
+    def Forward(self, save=False, cache_blocking=None, auto_tuning=False,
+                dse='advanced', compiler=None, u_ini=None, legacy=True):
         nt, nrec = self.data.shape
         nsrc = self.source.shape[1]
         ndim = len(self.damp.shape)
@@ -130,10 +130,12 @@ class Acoustic_cg(object):
         fw = ForwardOperator(self.model, u, src, rec, self.damp, self.data,
                              time_order=self.t_order, spc_order=self.s_order,
                              save=save, cache_blocking=cache_blocking, dse=dse,
-                             compiler=compiler, profile=True, u_ini=u_ini)
+                             compiler=compiler, profile=True, u_ini=u_ini,
+                             legacy=legacy)
 
         fw.apply()
         if isinstance(fw, StencilKernel):
+            # TODO: Hook up DSE/DLE profiling tools
             return rec.data, u, None, None, None
         else:
             return (rec.data, u, fw.propagator.gflopss,

--- a/examples/acoustic/fwi_operators.py
+++ b/examples/acoustic/fwi_operators.py
@@ -71,7 +71,7 @@ def ForwardOperator(model, u, src, rec, damp, data, time_order=2, spc_order=6,
     else:
         # Create stencil expressions for operator, source and receivers
         eqn = Eq(u.forward, stencil)
-        src_add = src.point2grid(u, m, t)
+        src_add = src.point2grid(u, m, u_t=t, p_t=time)
         rec_read = Eq(rec, rec.grid2point(u))
         stencils = [eqn] + src_add + [rec_read]
 
@@ -237,7 +237,7 @@ class GradientOperator(Operator):
         # Insert receiver term post-hoc
         self.input_params += [grad, rec, rec.coordinates]
         self.output_params = [grad]
-        self.propagator.time_loop_stencils_b = rec.add(m, v, t + 1)
+        self.propagator.time_loop_stencils_b = rec.add(m, v, u_t=t + 1, p_t=t + 1)
         self.propagator.add_devito_param(rec)
         self.propagator.add_devito_param(rec.coordinates)
 
@@ -319,7 +319,7 @@ class BornOperator(Operator):
         # Insert source and receiver terms post-hoc
         self.input_params += [dm, source, source.coordinates, rec, rec.coordinates, U]
         self.output_params = [rec]
-        self.propagator.time_loop_stencils_b = source.add(m, u, t - 1)
+        self.propagator.time_loop_stencils_b = source.add(m, u, u_t=t - 1, p_t=t - 1)
         self.propagator.time_loop_stencils_a = rec.read(U)
         self.propagator.add_devito_param(dm)
         self.propagator.add_devito_param(source)

--- a/examples/acoustic/fwi_operators.py
+++ b/examples/acoustic/fwi_operators.py
@@ -76,7 +76,7 @@ def ForwardOperator(model, source, damp, data, time_order=2, spc_order=6,
 
     if legacy:
         op = Operator(nt, m.shape, stencils=Eq(u.forward, stencil), subs=subs,
-                      spc_border=max(spc_order, 2), time_order=2, forward=True,
+                      spc_border=max(spc_order / 2, 2), time_order=2, forward=True,
                       dtype=m.dtype, **kwargs)
 
         # Insert source and receiver terms post-hoc
@@ -155,7 +155,7 @@ class AdjointOperator(Operator):
         super(AdjointOperator, self).__init__(nt, m.shape,
                                               stencils=Eq(v.backward, stencil),
                                               subs=subs,
-                                              spc_border=max(spc_order, 2),
+                                              spc_border=max(spc_order / 2, 2),
                                               time_order=2,
                                               forward=False,
                                               dtype=m.dtype,

--- a/examples/acoustic/fwi_operators.py
+++ b/examples/acoustic/fwi_operators.py
@@ -7,7 +7,7 @@ from devito.stencilkernel import StencilKernel
 from examples.source_type import SourceLike
 
 
-def ForwardOperator(model, src, rec, damp, data, time_order=2, spc_order=6,
+def ForwardOperator(model, u, src, rec, damp, data, time_order=2, spc_order=6,
                     save=False, u_ini=None, legacy=True, **kwargs):
     """
     Constructor method for the forward modelling operator in an acoustic media
@@ -24,14 +24,8 @@ def ForwardOperator(model, src, rec, damp, data, time_order=2, spc_order=6,
     """
     nt = data.shape[0]
     s, h = symbols('s h')
-    u = TimeData(name="u", shape=model.get_shape_comp(), time_dim=nt,
-                 time_order=2, space_order=spc_order, save=save,
-                 dtype=damp.dtype)
-    if u_ini is not None:
-        u.data[0:3, :] = u_ini[:]
     m = DenseData(name="m", shape=model.get_shape_comp(), dtype=damp.dtype)
     m.data[:] = model.padm()
-    u.pad_time = save
     # Derive stencil from symbolic equation
     if time_order == 2:
         laplacian = u.laplace

--- a/examples/acoustic/fwi_operators.py
+++ b/examples/acoustic/fwi_operators.py
@@ -1,6 +1,6 @@
 from sympy import Eq, solve, symbols
 
-from devito.dimension import d, t, time
+from devito.dimension import t, time
 from devito.interfaces import DenseData, TimeData
 from devito.operator import *
 from devito.stencilkernel import StencilKernel
@@ -47,12 +47,6 @@ def ForwardOperator(model, u, src, rec, damp, data, time_order=2, spc_order=6,
         2 * s**2 * (laplacian + s**2 / 12 * biharmonic))
     # Add substitutions for spacing (temporal and spatial)
     subs = {s: dt, h: model.get_spacing()}
-
-    # Define dimensions and fix loop sizes
-    time.size = nt
-    d.size = len(damp.shape)
-    for dim, s in zip(damp.indices, damp.shape):
-        dim.size = s
 
     if legacy:
         op = Operator(nt, m.shape, stencils=Eq(u.forward, stencil), subs=subs,

--- a/examples/source_type.py
+++ b/examples/source_type.py
@@ -63,7 +63,8 @@ class SourceLike(PointData):
     @property
     def sym_coordinates(self):
         """Symbol representing the coordinate values in each dimension"""
-        return tuple([self.coordinates.indexed[p, i]
+        p_dim = self.indices[1]
+        return tuple([self.coordinates.indexed[p_dim, i]
                       for i in range(self.ndim)])
 
     @property
@@ -87,7 +88,7 @@ class SourceLike(PointData):
                                in zip(inc, self.sym_coord_indices)])
                         for inc in self.increments]
         eqns = [Eq(u.indexed[(t, ) + idx], u.indexed[(t, ) + idx]
-                   + self.indexed[t, p] * dt * dt / m.indexed[idx] * b.subs(subs))
+                   + self.indexed[self.indices] * dt * dt / m.indexed[idx] * b.subs(subs))
                 for idx, b in zip(index_matrix, self.bs)]
         return eqns
 

--- a/tests/test_adjointA.py
+++ b/tests/test_adjointA.py
@@ -97,7 +97,7 @@ def test_acoustic(dimensions, time_order, space_order):
     srca = acoustic.Adjoint(rec)
 
     # Actual adjoint test
-    term1 = np.dot(srca.reshape(-1), acoustic.src.traces)
+    term1 = np.dot(srca.reshape(-1), time_series)
     term2 = linalg.norm(rec)**2
     print(term1, term2, term1 - term2, term1 / term2)
     assert np.isclose(term1 / term2, 1.0, atol=0.001)

--- a/tests/test_adjointA.py
+++ b/tests/test_adjointA.py
@@ -8,7 +8,7 @@ from examples.acoustic.Acoustic_codegen import Acoustic_cg
 from examples.containers import IGrid, IShot
 
 
-@pytest.mark.parametrize('space_order', [4, 8, 10])
+@pytest.mark.parametrize('space_order', [4, 8, 12])
 @pytest.mark.parametrize('time_order', [2, 4])
 @pytest.mark.parametrize('dimensions', [(60, 70), (60, 70, 80)])
 def test_acoustic(dimensions, time_order, space_order):

--- a/tests/test_adjointA.py
+++ b/tests/test_adjointA.py
@@ -93,7 +93,7 @@ def test_acoustic(dimensions, time_order, space_order):
     # Adjoint test
     acoustic = Acoustic_cg(model, data, src, t_order=time_order,
                            s_order=space_order, nbpml=nbpml)
-    rec, _, _, _, _ = acoustic.Forward(save=False)
+    rec, _, _, _, _ = acoustic.Forward(save=False, legacy=True)
     srca = acoustic.Adjoint(rec)
 
     # Actual adjoint test

--- a/tests/test_adjointA.py
+++ b/tests/test_adjointA.py
@@ -8,120 +8,100 @@ from examples.acoustic.Acoustic_codegen import Acoustic_cg
 from examples.containers import IGrid, IShot
 
 
-class TestAdjointA(object):
-    @pytest.fixture(params=[(60, 70), (60, 70, 80)])
-    def acoustic(self, request, time_order, space_order):
-        dimensions = request.param
+@pytest.mark.parametrize('space_order', [4, 8, 10])
+@pytest.mark.parametrize('time_order', [2, 4])
+@pytest.mark.parametrize('dimensions', [(60, 70), (60, 70, 80)])
+def test_acoustic(dimensions, time_order, space_order):
+    nbpml = 10
 
-        if len(dimensions) == 2:
-            # Dimensions in 2D are (x, z)
-            origin = (0., 0.)
-            spacing = (15., 15.)
+    if len(dimensions) == 2:
+        # Dimensions in 2D are (x, z)
+        origin = (0., 0.)
+        spacing = (15., 15.)
 
-            # True velocity
-            true_vp = np.ones(dimensions) + .5
-            true_vp[:, int(dimensions[0] / 3):dimensions[0]] = 2.5
+        # True velocity
+        true_vp = np.ones(dimensions) + .5
+        true_vp[:, int(dimensions[0] / 3):dimensions[0]] = 2.5
 
-            # Source location
-            location = np.zeros((1, 2))
-            location[0, 0] = origin[0] + dimensions[0] * spacing[0] * 0.5
-            location[0, 1] = origin[1] + 2 * spacing[1]
+        # Source location
+        location = np.zeros((1, 2))
+        location[0, 0] = origin[0] + dimensions[0] * spacing[0] * 0.5
+        location[0, 1] = origin[1] + 2 * spacing[1]
 
-            # Receiver coordinates
-            receiver_coords = np.zeros((101, 2))
-            receiver_coords[:, 0] = np.linspace(0, origin[0] +
-                                                dimensions[0] * spacing[0], num=101)
-            receiver_coords[:, 1] = location[0, 1]
+        # Receiver coordinates
+        receiver_coords = np.zeros((101, 2))
+        receiver_coords[:, 0] = np.linspace(0, origin[0] +
+                                            dimensions[0] * spacing[0], num=101)
+        receiver_coords[:, 1] = location[0, 1]
 
-        elif len(dimensions) == 3:
-            # Dimensions in 3D are (x, y, z)
-            origin = (0., 0., 0.)
-            spacing = (15., 15., 15.)
+    elif len(dimensions) == 3:
+        # Dimensions in 3D are (x, y, z)
+        origin = (0., 0., 0.)
+        spacing = (15., 15., 15.)
 
-            # True velocity
-            true_vp = np.ones(dimensions) + .5
-            true_vp[:, :, int(dimensions[0] / 3):dimensions[0]] = 2.5
+        # True velocity
+        true_vp = np.ones(dimensions) + .5
+        true_vp[:, :, int(dimensions[0] / 3):dimensions[0]] = 2.5
 
-            # Source location
-            location = np.zeros((1, 3))
-            location[0, 0] = origin[0] + dimensions[0] * spacing[0] * 0.5
-            location[0, 1] = origin[1] + dimensions[1] * spacing[1] * 0.5
-            location[0, 2] = origin[1] + 2 * spacing[2]
+        # Source location
+        location = np.zeros((1, 3))
+        location[0, 0] = origin[0] + dimensions[0] * spacing[0] * 0.5
+        location[0, 1] = origin[1] + dimensions[1] * spacing[1] * 0.5
+        location[0, 2] = origin[1] + 2 * spacing[2]
 
+        # Receiver coordinates
+        receiver_coords = np.zeros((101, 3))
+        receiver_coords[:, 0] = np.linspace(0, origin[0] +
+                                            dimensions[0] * spacing[0], num=101)
+        receiver_coords[:, 1] = origin[1] + dimensions[1] * spacing[1] * 0.5
+        receiver_coords[:, 2] = location[0, 2]
 
-            # Receiver coordinates
-            receiver_coords = np.zeros((101, 3))
-            receiver_coords[:, 0] = np.linspace(0, origin[0] +
-                                                dimensions[0] * spacing[0], num=101)
-            receiver_coords[:, 1] = origin[1] + dimensions[1] * spacing[1] * 0.5
-            receiver_coords[:, 2] = location[0, 2]
+    else:
+        error("Unknown dimension size. `dimensions` parameter"
+              "must be a tuple of either size 2 or 3.")
 
-        else:
-            error("Unknown dimension size. `dimensions` parameter"
-                  "must be a tuple of either size 2 or 3.")
+    model = IGrid(origin, spacing, true_vp)
+    # Define seismic data.
+    data = IShot()
+    src = IShot()
 
-        model = IGrid(origin, spacing, true_vp)
-        # Define seismic data.
-        data = IShot()
-        src = IShot()
+    f0 = .010
+    if time_order == 4:
+        dt = 1.73 * model.get_critical_dt()
+    else:
+        dt = model.get_critical_dt()
+    t0 = 0.0
+    tn = 500.0
+    nt = int(1+(tn-t0)/dt)
 
-        f0 = .010
-        if time_order == 4:
-            dt = 1.73 * model.get_critical_dt()
-        else:
-            dt = model.get_critical_dt()
-        t0 = 0.0
-        tn = 500.0
-        nt = int(1+(tn-t0)/dt)
+    # Set up the source as Ricker wavelet for f0
+    def source(t, f0):
+        r = (np.pi * f0 * (t - 1./f0))
+        return (1-2.*r**2)*np.exp(-r**2)
 
-        # Set up the source as Ricker wavelet for f0
-        def source(t, f0):
-            r = (np.pi * f0 * (t - 1./f0))
-            return (1-2.*r**2)*np.exp(-r**2)
+    # Source geometry
+    time_series = np.zeros((nt, 1))
+    time_series[:, 0] = source(np.linspace(t0, tn, nt), f0)
 
-        # Source geometry
-        time_series = np.zeros((nt, 1))
-        time_series[:, 0] = source(np.linspace(t0, tn, nt), f0)
+    src.set_receiver_pos(location)
+    src.set_shape(nt, 1)
+    src.set_traces(time_series)
 
-        src.set_receiver_pos(location)
-        src.set_shape(nt, 1)
-        src.set_traces(time_series)
+    data.set_receiver_pos(receiver_coords)
+    data.set_shape(nt, 101)
 
-        data.set_receiver_pos(receiver_coords)
-        data.set_shape(nt, 101)
+    # Adjoint test
+    acoustic = Acoustic_cg(model, data, src, t_order=time_order,
+                           s_order=space_order, nbpml=nbpml)
+    rec, _, _, _, _ = acoustic.Forward(save=False)
+    srca = acoustic.Adjoint(rec)
 
-        # Adjoint test
-        wave_true = Acoustic_cg(model, data, src, t_order=time_order, s_order=space_order,
-                                nbpml=10)
-        return wave_true
-
-    @pytest.fixture(params=[2, 4])
-    def time_order(self, request):
-        return request.param
-
-    @pytest.fixture(params=[4, 8, 10])
-    def space_order(self, request):
-        return request.param
-
-    @pytest.fixture
-    def forward(self, acoustic):
-        rec, u, _, _, _ = acoustic.Forward(save=False)
-        return rec
-
-    def test_adjoint(self, acoustic, forward):
-        rec = forward
-        srca = acoustic.Adjoint(rec)
-        # Actual adjoint test
-        term1 = np.dot(srca.reshape(-1), acoustic.src.traces)
-        term2 = linalg.norm(rec)**2
-        print(term1, term2, term1 - term2, term1 / term2)
-        assert np.isclose(term1 / term2, 1.0, atol=0.001)
+    # Actual adjoint test
+    term1 = np.dot(srca.reshape(-1), acoustic.src.traces)
+    term2 = linalg.norm(rec)**2
+    print(term1, term2, term1 - term2, term1 / term2)
+    assert np.isclose(term1 / term2, 1.0, atol=0.001)
 
 
 if __name__ == "__main__":
-    t = TestAdjointA()
-    request = type('', (), {})()
-    request.param = (60, 70)
-    ac = t.acoustic(request, 2, 4)
-    fw = t.forward(ac)
-    t.test_adjoint(ac, fw)
+    test_acoustic(dimensions=(60, 70), time_order=2, space_order=4)

--- a/tests/test_gradient.py
+++ b/tests/test_gradient.py
@@ -2,154 +2,137 @@ import numpy as np
 import pytest
 from numpy import linalg
 
-from devito import clear_cache
 from examples.acoustic.Acoustic_codegen import Acoustic_cg
 from examples.containers import IGrid, IShot
 
 
-class TestGradient(object):
-    @pytest.fixture(params=[(70, 80)])
-    def acoustic(self, request, time_order, space_order):
-        dimensions = request.param
+@pytest.mark.parametrize('space_order', [4])
+@pytest.mark.parametrize('time_order', [2])
+@pytest.mark.parametrize('dimensions', [(70, 80)])
+def test_gradient(dimensions, time_order, space_order):
+    nbpml = 40
 
-        if len(dimensions) == 2:
-            # Dimensions in 2D are (x, z)
-            origin = (0., 0.)
-            spacing = (10., 10.)
+    if len(dimensions) == 2:
+        # Dimensions in 2D are (x, z)
+        origin = (0., 0.)
+        spacing = (10., 10.)
 
-            # True velocity
-            true_vp = np.ones(dimensions) + .5
-            true_vp[:, int(dimensions[1] / 2):] = 2
+        # True velocity
+        true_vp = np.ones(dimensions) + .5
+        true_vp[:, int(dimensions[1] / 2):] = 2
 
-            # Source location
-            location = np.zeros((1, 2))
-            location[0, 0] = origin[0] + dimensions[0] * spacing[0] * 0.5
-            location[0, 1] = origin[1] + 2 * spacing[1]
+        # Source location
+        location = np.zeros((1, 2))
+        location[0, 0] = origin[0] + dimensions[0] * spacing[0] * 0.5
+        location[0, 1] = origin[1] + 2 * spacing[1]
 
-            # Receiver coordinates
-            receiver_coords = np.zeros((101, 2))
-            receiver_coords[:, 0] = np.linspace(0, origin[0] +
+        # Receiver coordinates
+        receiver_coords = np.zeros((101, 2))
+        receiver_coords[:, 0] = np.linspace(0, origin[0] +
                                             dimensions[0] * spacing[0], num=101)
-            receiver_coords[:, 1] = location[0, 1]
+        receiver_coords[:, 1] = location[0, 1]
 
-        elif len(dimensions) == 3:
-            # Dimensions in 3D are (x, y, z)
-            origin = (0., 0., 0.)
-            spacing = (15., 15., 15.)
+    elif len(dimensions) == 3:
+        # Dimensions in 3D are (x, y, z)
+        origin = (0., 0., 0.)
+        spacing = (15., 15., 15.)
 
-            # True velocity
-            true_vp = np.ones(dimensions) + .5
-            true_vp[:, :, int(dimensions[2] / 2):] = 2
+        # True velocity
+        true_vp = np.ones(dimensions) + .5
+        true_vp[:, :, int(dimensions[2] / 2):] = 2
 
-            # Source location
-            location = np.zeros((1, 3))
-            location[0, 0] = origin[0] + dimensions[0] * spacing[0] * 0.5
-            location[0, 1] = origin[1] + dimensions[1] * spacing[1] * 0.5
-            location[0, 2] = origin[1] + 2 * spacing[2]
+        # Source location
+        location = np.zeros((1, 3))
+        location[0, 0] = origin[0] + dimensions[0] * spacing[0] * 0.5
+        location[0, 1] = origin[1] + dimensions[1] * spacing[1] * 0.5
+        location[0, 2] = origin[1] + 2 * spacing[2]
 
-            # Receiver coordinates
-            receiver_coords = np.zeros((101, 3))
-            receiver_coords[:, 0] = np.linspace(0, origin[0] +
+        # Receiver coordinates
+        receiver_coords = np.zeros((101, 3))
+        receiver_coords[:, 0] = np.linspace(0, origin[0] +
                                             dimensions[0] * spacing[0], num=101)
-            receiver_coords[:, 1] = origin[1] + dimensions[1] * spacing[1] * 0.5
-            receiver_coords[:, 2] = location[0, 2]
+        receiver_coords[:, 1] = origin[1] + dimensions[1] * spacing[1] * 0.5
+        receiver_coords[:, 2] = location[0, 2]
 
+    # velocity models
+    def smooth10(vel):
+        out = np.zeros(dimensions)
+        out[:] = vel[:]
+        for a in range(5, dimensions[-1]-6):
+            if len(dimensions) == 2:
+                out[:, a] = np.sum(vel[:, a - 5:a + 5], axis=1) / 10
+            else:
+                out[:, :, a] = np.sum(vel[:, :, a - 5:a + 5], axis=2) / 10
+        return out
 
-        # velocity models
-        def smooth10(vel):
-            out = np.zeros(dimensions)
-            out[:] = vel[:]
-            for a in range(5, dimensions[-1]-6):
-                if len(dimensions) == 2:
-                    out[:, a] = np.sum(vel[:, a - 5:a + 5], axis=1) / 10
-                else:
-                    out[:, :, a] = np.sum(vel[:, :, a - 5:a + 5], axis=2) / 10
-            return out
+    # Smooth velocity
+    initial_vp = smooth10(true_vp)
+    dm = true_vp**-2 - initial_vp**-2
+    model = IGrid(origin, spacing, true_vp)
+    model0 = IGrid(origin, spacing, initial_vp)
+    # Define seismic data.
+    data = IShot()
+    src = IShot()
+    f0 = .010
+    if time_order == 4:
+        dt = 1.73 * model.get_critical_dt()
+    else:
+        dt = model.get_critical_dt()
+    t0 = 0.0
+    tn = 750.0
+    nt = int(1+(tn-t0)/dt)
+    # Set up the source as Ricker wavelet for f0
 
-        # Smooth velocity
-        initial_vp = smooth10(true_vp)
-        dm = true_vp**-2 - initial_vp**-2
-        model = IGrid(origin, spacing, true_vp)
-        model0 = IGrid(origin, spacing, initial_vp)
-        # Define seismic data.
-        data = IShot()
-        src = IShot()
-        f0 = .010
-        if time_order == 4:
-            dt = 1.73 * model.get_critical_dt()
-        else:
-            dt = model.get_critical_dt()
-        t0 = 0.0
-        tn = 750.0
-        nt = int(1+(tn-t0)/dt)
-        # Set up the source as Ricker wavelet for f0
+    def source(t, f0):
+        r = (np.pi * f0 * (t - 1./f0))
+        return (1-2.*r**2)*np.exp(-r**2)
 
-        def source(t, f0):
-            r = (np.pi * f0 * (t - 1./f0))
-            return (1-2.*r**2)*np.exp(-r**2)
+    # Source geometry
+    time_series = np.zeros((nt, 1))
+    time_series[:, 0] = source(np.linspace(t0, tn, nt), f0)
+    src.set_receiver_pos(location)
+    src.set_shape(nt, 1)
+    src.set_traces(time_series)
 
-        # Source geometry
-        time_series = np.zeros((nt, 1))
-        time_series[:, 0] = source(np.linspace(t0, tn, nt), f0)
-        src.set_receiver_pos(location)
-        src.set_shape(nt, 1)
-        src.set_traces(time_series)
+    data.set_receiver_pos(receiver_coords)
+    data.set_shape(nt, 101)
+    # Adjoint test
+    wave_true = Acoustic_cg(model, data, src, t_order=time_order,
+                            s_order=space_order, nbpml=nbpml)
+    wave_0 = Acoustic_cg(model0, data, src, t_order=time_order,
+                         s_order=space_order, nbpml=nbpml)
 
-        data.set_receiver_pos(receiver_coords)
-        data.set_shape(nt, 101)
-        # Adjoint test
-        wave_true = Acoustic_cg(model, data, src, t_order=time_order,
-                                s_order=space_order, nbpml=40)
-        wave_0 = Acoustic_cg(model0, data, src, t_order=time_order,
-                             s_order=space_order, nbpml=40)
-        return wave_true, wave_0, dm, initial_vp
+    rec = wave_true.Forward()[0]
+    rec0, u0, _, _, _ = wave_0.Forward(save=True)
+    F0 = .5*linalg.norm(rec0 - rec)**2
+    gradient = wave_0.Gradient(rec0 - rec, u0)
+    # Actual Gradient test
+    G = np.dot(gradient.reshape(-1), wave_0.model.pad(dm).reshape(-1))
+    # FWI Gradient test
+    H = [0.5, 0.25, .125, 0.0625, 0.0312, 0.015625, 0.0078125]
+    error1 = np.zeros(7)
+    error2 = np.zeros(7)
+    for i in range(0, 7):
+        wave_0.model.set_vp(np.sqrt((initial_vp**-2 + H[i] * dm)**(-1)))
+        d = wave_0.Forward()[0]
+        error1[i] = np.absolute(.5*linalg.norm(d - rec)**2 - F0)
+        error2[i] = np.absolute(.5*linalg.norm(d - rec)**2 - F0 - H[i] * G)
+        # print(F0, .5*linalg.norm(d - rec)**2, error1[i], H[i] *G, error2[i])
+        # print('For h = ', H[i], '\nFirst order errors is : ', error1[i],
+        #       '\nSecond order errors is ', error2[i])
 
-    @pytest.fixture(params=[2])
-    def time_order(self, request):
-        return request.param
+    hh = np.zeros(7)
+    for i in range(0, 7):
+        hh[i] = H[i] * H[i]
 
-    @pytest.fixture(params=[4])
-    def space_order(self, request):
-        return request.param
-
-    def test_grad(self, acoustic):
-        clear_cache()
-        rec = acoustic[0].Forward()[0]
-        rec0, u0, _, _, _ = acoustic[1].Forward(save=True)
-        F0 = .5*linalg.norm(rec0 - rec)**2
-        gradient = acoustic[1].Gradient(rec0 - rec, u0)
-        # Actual Gradient test
-        G = np.dot(gradient.reshape(-1), acoustic[1].model.pad(acoustic[2]).reshape(-1))
-        # FWI Gradient test
-        H = [0.5, 0.25, .125, 0.0625, 0.0312, 0.015625, 0.0078125]
-        error1 = np.zeros(7)
-        error2 = np.zeros(7)
-        for i in range(0, 7):
-            acoustic[1].model.set_vp(np.sqrt((acoustic[3]**-2 + H[i] *
-                                              acoustic[2])**(-1)))
-            d = acoustic[1].Forward()[0]
-            error1[i] = np.absolute(.5*linalg.norm(d - rec)**2 - F0)
-            error2[i] = np.absolute(.5*linalg.norm(d - rec)**2 - F0 - H[i] * G)
-            # print(F0, .5*linalg.norm(d - rec)**2, error1[i], H[i] *G, error2[i])
-            # print('For h = ', H[i], '\nFirst order errors is : ', error1[i],
-            #       '\nSecond order errors is ', error2[i])
-
-        hh = np.zeros(7)
-        for i in range(0, 7):
-            hh[i] = H[i] * H[i]
-
-        # Test slope of the  tests
-        p1 = np.polyfit(np.log10(H), np.log10(error1), 1)
-        p2 = np.polyfit(np.log10(H), np.log10(error2), 1)
-        print(p1)
-        print(p2)
-        assert np.isclose(p1[0], 1.0, rtol=0.1)
-        assert np.isclose(p2[0], 2.0, rtol=0.1)
+    # Test slope of the  tests
+    p1 = np.polyfit(np.log10(H), np.log10(error1), 1)
+    p2 = np.polyfit(np.log10(H), np.log10(error2), 1)
+    print(p1)
+    print(p2)
+    assert np.isclose(p1[0], 1.0, rtol=0.1)
+    assert np.isclose(p2[0], 2.0, rtol=0.1)
 
 
 if __name__ == "__main__":
-    t = TestGradient()
-    request = type('', (), {})()
-    request.param = (60, 70)
-    ac = t.acoustic(request, 2, 4)
-    t.test_grad(ac)
+    test_gradient(dimensions=(60, 70), time_order=2, space_order=4)


### PR DESCRIPTION
**WARNING: This merge contains temporary hacks that are necessary due to legacy restrictions. It also attempts to clean a few things for acoustic test, but it does not attempt a full clean-up of our seismic examples. A full clean-up of the examples and a more rigorous generalisation of the temporary hacks will be attempted soon.**

So, this PR really contains a series of "as-clean-as-currently-possible" changes and fixes to adjust the Acoustic Forward runs to the 3.0 API. It introduces a `legacy` flag on the acoustic examples classes that allows us to switch between the two modes seamlessly and thus compare and contrast. The 3.0 route is not exhaustively tested yet, but it should allow us to run preliminary performance benchmarks to get an overview of how 3.0 will do and fix issues before they arise.

In particular we do:
* New and improved treatment of buffered dimensions (eg. time)
* Lift src/rec and wavefield creation to the `Acoustic_cg` wrappers to avoid call signature clashes
* Minor clean up of `test_adjoint` and `test_gradient`.
* Lift necessary time substitutions to the wrapper layer
* Tweaks to the interpolation symbolics