### PR TITLE
Tweak TTI to run via Devito3.0

### DIFF
--- a/devito/nodes.py
+++ b/devito/nodes.py
@@ -297,6 +297,10 @@ class Iteration(Node):
         """
         loop_body = [s.ccode for s in self.nodes]
 
+        # Disregard offsets for buffered dimensions
+        if self.dim.is_Buffered:
+            self.offsets = [0, 0]
+
         # Start
         if self.offsets[0] != 0:
             val = "%s + %s" % (self.limits[0], -self.offsets[0])

--- a/devito/nodes.py
+++ b/devito/nodes.py
@@ -298,12 +298,11 @@ class Iteration(Node):
         loop_body = [s.ccode for s in self.nodes]
 
         # Disregard offsets for buffered dimensions
-        if self.dim.is_Buffered:
-            self.offsets = [0, 0]
+        offsets = [0, 0] if self.dim.is_Buffered else self.offsets
 
         # Start
-        if self.offsets[0] != 0:
-            val = "%s + %s" % (self.limits[0], -self.offsets[0])
+        if offsets[0] != 0:
+            val = "%s + %s" % (self.limits[0], -offsets[0])
             try:
                 val = eval(val)
             except (NameError, TypeError):
@@ -313,8 +312,8 @@ class Iteration(Node):
         loop_init = c.InlineInitializer(c.Value("int", self.index), ccode(val))
 
         # Bound
-        if self.offsets[1] != 0:
-            val = "%s - %s" % (self.limits[1], self.offsets[1])
+        if offsets[1] != 0:
+            val = "%s - %s" % (self.limits[1], offsets[1])
             try:
                 val = eval(val)
             except (NameError, TypeError):

--- a/devito/visitors.py
+++ b/devito/visitors.py
@@ -198,7 +198,7 @@ class PrintAST(Visitor):
         body = self.visit(o.children)
         self._depth -= 1
         if self.verbose:
-            detail = '::%s::%s' % (o.index, o.limits)
+            detail = '::%s::%s::%s' % (o.index, o.limits, offsets)
             props = '[%s] ' % ','.join(o.properties) if o.properties else ''
         else:
             detail, props = '', ''
@@ -501,7 +501,8 @@ class MergeOuterIterations(Transformer):
         """
         newexpr = iter1.nodes + iter2.nodes
         return Iteration(newexpr, dimension=iter1.dim,
-                         limits=iter1.limits)
+                         limits=iter1.limits,
+                         offsets=iter1.offsets)
 
     def visit_Iteration(self, o):
         rebuilt = self.visit(o.children)

--- a/devito/visitors.py
+++ b/devito/visitors.py
@@ -198,7 +198,7 @@ class PrintAST(Visitor):
         body = self.visit(o.children)
         self._depth -= 1
         if self.verbose:
-            detail = '::%s::%s::%s' % (o.index, o.limits, offsets)
+            detail = '::%s::%s::%s' % (o.index, o.limits, o.offsets)
             props = '[%s] ' % ','.join(o.properties) if o.properties else ''
         else:
             detail, props = '', ''

--- a/examples/acoustic/Acoustic_codegen.py
+++ b/examples/acoustic/Acoustic_codegen.py
@@ -133,13 +133,13 @@ class Acoustic_cg(object):
                              compiler=compiler, profile=True, u_ini=u_ini,
                              legacy=legacy)
 
-        fw.apply()
-        if isinstance(fw, StencilKernel):
-            # TODO: Hook up DSE/DLE profiling tools
-            return rec.data, u, None, None, None
-        else:
+        if legacy:
+            fw.apply()
             return (rec.data, u, fw.propagator.gflopss,
                     fw.propagator.oi, fw.propagator.timings)
+        else:
+            summary = fw.apply()
+            return rec.data, u, summary.gflopss, summary.oi, summary.timings
 
     def Adjoint(self, rec, cache_blocking=None):
         adj = AdjointOperator(self.model, self.damp, self.data, self.source, rec,

--- a/examples/acoustic/acoustic_example.py
+++ b/examples/acoustic/acoustic_example.py
@@ -25,8 +25,9 @@ def source(t, f0):
 
 
 def run(dimensions=(50, 50, 50), spacing=(20.0, 20.0, 20.0), tn=1000.0,
-        time_order=2, space_order=2, nbpml=40, dse='advanced', auto_tuning=False,
-        compiler=None, cache_blocking=None, full_run=False):
+        time_order=2, space_order=2, nbpml=40, dse='advanced', dle='advanced',
+        auto_tuning=False, compiler=None, cache_blocking=None, full_run=False,
+        legacy=True):
 
     origin = (0., 0., 0.)
 
@@ -79,12 +80,12 @@ def run(dimensions=(50, 50, 50), spacing=(20.0, 20.0, 20.0), tn=1000.0,
 
     Acoustic = Acoustic_cg(model, data, src, nbpml=nbpml, t_order=time_order,
                            s_order=space_order, auto_tuning=auto_tuning, dse=dse,
-                           compiler=compiler)
+                           dle=dle, compiler=compiler, legacy=legacy)
 
     info("Applying Forward")
     rec, u, gflopss, oi, timings = Acoustic.Forward(
-        cache_blocking=cache_blocking, save=full_run, dse=dse,
-        auto_tuning=auto_tuning, compiler=compiler
+        cache_blocking=cache_blocking, save=full_run, dse=dse, dle=dle,
+        auto_tuning=auto_tuning, compiler=compiler, legacy=legacy,
     )
 
     if not full_run:

--- a/examples/acoustic/fwi_operators.py
+++ b/examples/acoustic/fwi_operators.py
@@ -75,7 +75,7 @@ def ForwardOperator(model, u, src, rec, damp, data, time_order=2, spc_order=6,
 
         # Shift time indices so that LHS writes into t only,
         # eg. u[t+2] = u[t+1] + u[t]  -> u[t] = u[t-1] + u[t-2]
-        stencils = [e.subs(t, t + solve(eqn.lhs.args[0], t)[0])
+        stencils = [e.subs(t, t + solve(e.lhs.args[0], t)[0])
                     if isinstance(e.lhs, TimeData) else e
                     for e in stencils]
         # Apply time substitutions as per legacy approach

--- a/examples/benchmark.py
+++ b/examples/benchmark.py
@@ -65,6 +65,9 @@ if __name__ == "__main__":
                             type=int, help="End time of the simulation in ms")
 
     devito = parser.add_argument_group("Devito")
+    devito.add_argument("--no-legacy", dest="legacy", action="store_false",
+                        help="Pass False to run with the new StencilKernel "
+                             "infrastructure, rather than Operator/Propagator")
     devito.add_argument("-dse", default="advanced", nargs="*",
                         choices=["noop", "basic", "factorize", "approx-trigonometry",
                                  "glicm", "advanced"],
@@ -147,7 +150,6 @@ if __name__ == "__main__":
                                  "speculative"]
 
     if args.execmode == "test":
-        parameters.pop('dle')  # FIXME : 'dle' still unsupported, but not for long
         values_sweep = [v if isinstance(v, list) else [v] for v in parameters.values()]
         params_sweep = [dict(zip(parameters.keys(), values))
                         for values in product(*values_sweep)]

--- a/examples/tti/TTI_codegen.py
+++ b/examples/tti/TTI_codegen.py
@@ -136,9 +136,10 @@ class TTI_cg:
             at.auto_tune_blocks(self.s_order + 1, self.s_order * 4 + 2)
             fw.propagator.cache_blocking = at.block_size
 
-        fw.apply()
         if legacy:
+            fw.apply()
             return (rec.data, u.data, v.data,
                     fw.propagator.gflopss, fw.propagator.oi, fw.propagator.timings)
         else:
-            return (rec.data, u.data, v.data, None, None, None)
+            summary = fw.apply()
+            return rec.data, u.data, v.data, summary.gflopss, summary.oi, summary.timings

--- a/examples/tti/TTI_codegen.py
+++ b/examples/tti/TTI_codegen.py
@@ -4,7 +4,10 @@ from __future__ import print_function
 import numpy as np
 
 from devito.at_controller import AutoTuner
+from devito.dimension import Dimension, time
+from devito.interfaces import TimeData
 from examples.tti.tti_operators import *
+from examples.source_type import SourceLike
 
 
 class TTI_cg:
@@ -16,7 +19,7 @@ class TTI_cg:
         self.t_order = t_order
         self.s_order = s_order
         self.data = data
-        self.src = source
+        self.source = source
         self.dtype = np.float32
         self.dt = model.get_critical_dt()
         self.model.nbpml = nbpml
@@ -50,20 +53,89 @@ class TTI_cg:
 
     def Forward(self, save=False, dse='advanced', auto_tuning=False,
                 cache_blocking=None, compiler=None, u_ini=None):
-        fw = ForwardOperator(self.model, self.src, self.damp, self.data,
+        nt, nrec = self.data.shape
+        nsrc = self.source.shape[1]
+        ndim = len(self.damp.shape)
+        dt = self.dt
+        h = self.model.get_spacing()
+        dtype = self.damp.dtype
+        nbpml = self.model.nbpml
+
+        # uses space_order/2 for the first derivatives to
+        # have spc_order second derivatives for consistency
+        # with the acoustic kernel
+        u = TimeData(name="u", shape=self.model.get_shape_comp(),
+                     time_dim=nt, time_order=self.t_order,
+                     space_order=self.s_order/2,
+                     save=save, dtype=dtype)
+        v = TimeData(name="v", shape=self.model.get_shape_comp(),
+                     time_dim=nt, time_order=self.t_order,
+                     space_order=self.s_order/2,
+                     save=save, dtype=dtype)
+
+        u.pad_time = save
+        v.pad_time = save
+
+        if u_ini is not None:
+            u.data[0:3, :] = u_ini[:]
+            v.data[0:3, :] = u_ini[:]
+
+        # Create source symbol
+        p_src = Dimension('p_src', size=nsrc)
+        src = SourceLike(name="src", dimensions=[time, p_src], npoint=nsrc, nt=nt,
+                         dt=dt, h=h, ndim=ndim, nbpml=nbpml, dtype=dtype,
+                         coordinates=self.source.receiver_coords)
+        src.data[:] = .5 * self.source.traces[:]
+
+        # Create receiver symbol
+        p_rec = Dimension('p_rec', size=nrec)
+        rec = SourceLike(name="rec", dimensions=[time, p_rec], npoint=nrec, nt=nt,
+                         dt=dt, h=h, ndim=ndim, nbpml=nbpml, dtype=dtype,
+                         coordinates=self.data.receiver_coords)
+
+        # Create forward operator
+        fw = ForwardOperator(self.model, u, v, src, rec, self.damp, self.data,
                              time_order=self.t_order, spc_order=self.s_order,
                              profile=True, save=save, cache_blocking=cache_blocking,
                              dse=dse, compiler=compiler, u_ini=u_ini)
 
         if auto_tuning:
-            fw_new = ForwardOperator(self.model, self.src, self.damp, self.data,
-                                     time_order=self.t_order, spc_order=self.s_order,
-                                     profile=True, save=save, dse=dse, compiler=compiler)
+            # uses space_order/2 for the first derivatives to
+            # have spc_order second derivatives for consistency
+            # with the acoustic kernel
+            u = TimeData(name="u", shape=self.model.get_shape_comp(),
+                         time_dim=nt, time_order=self.t_order,
+                         space_order=self.s_order/2,
+                         save=save, dtype=dtype)
+            v = TimeData(name="v", shape=self.model.get_shape_comp(),
+                         time_dim=nt, time_order=self.t_order,
+                         space_order=self.s_order/2,
+                         save=save, dtype=dtype)
+
+            u.pad_time = save
+            v.pad_time = save
+
+            # Create source symbol
+            src_new = SourceLike(name="src", dimensions=[time, p_src], npoint=nsrc, nt=nt,
+                                 dt=dt, h=h, ndim=ndim, nbpml=nbpml, dtype=dtype,
+                                 coordinates=self.source.receiver_coords)
+            src_new.data[:] = .5 * self.source.traces[:]
+
+            # Create receiver symbol
+            rec_new = SourceLike(name="rec", dimensions=[time, p_rec], npoint=nrec, nt=nt,
+                                 dt=dt, h=h, ndim=ndim, nbpml=nbpml, dtype=dtype,
+                                 coordinates=self.data.receiver_coords)
+
+            # Ceate tuning operator
+            fw_new = ForwardOperator(self.model, u, v, src_new, rec_new, self.damp,
+                                     self.data, time_order=self.t_order,
+                                     spc_order=self.s_order, profile=True, save=save,
+                                     dse=dse, compiler=compiler)
 
             at = AutoTuner(fw_new)
             at.auto_tune_blocks(self.s_order + 1, self.s_order * 4 + 2)
             fw.propagator.cache_blocking = at.block_size
 
-        u, v, rec = fw.apply()
+        fw.apply()
         return (rec.data, u.data, v.data,
                 fw.propagator.gflopss, fw.propagator.oi, fw.propagator.timings)

--- a/examples/tti/TTI_codegen.py
+++ b/examples/tti/TTI_codegen.py
@@ -51,7 +51,7 @@ class TTI_cg:
         # Initialize damp by calling the function that can precompute damping
         damp_boundary(self.damp.data, nbpml)
 
-    def Forward(self, save=False, dse='advanced', auto_tuning=False,
+    def Forward(self, save=False, dse='advanced', dle='advanced', auto_tuning=False,
                 cache_blocking=None, compiler=None, u_ini=None, legacy=True):
         nt, nrec = self.data.shape
         nsrc = self.source.shape[1]
@@ -99,7 +99,7 @@ class TTI_cg:
                              profile=True, save=save, cache_blocking=cache_blocking,
                              dse=dse, compiler=compiler, u_ini=u_ini, legacy=legacy)
 
-        if auto_tuning:
+        if auto_tuning and legacy:
             # uses space_order/2 for the first derivatives to
             # have spc_order second derivatives for consistency
             # with the acoustic kernel
@@ -141,5 +141,5 @@ class TTI_cg:
             return (rec.data, u.data, v.data,
                     fw.propagator.gflopss, fw.propagator.oi, fw.propagator.timings)
         else:
-            summary = fw.apply()
+            summary = fw.apply(autotune=auto_tuning)
             return rec.data, u.data, v.data, summary.gflopss, summary.oi, summary.timings

--- a/examples/tti/TTI_codegen.py
+++ b/examples/tti/TTI_codegen.py
@@ -48,11 +48,6 @@ class TTI_cg:
         # Initialize damp by calling the function that can precompute damping
         damp_boundary(self.damp.data, nbpml)
 
-        if len(self.damp.shape) == 2 and self.src.receiver_coords.shape[1] == 3:
-            self.src.receiver_coords = np.delete(self.src.receiver_coords, 1, 1)
-        if len(self.damp.shape) == 2 and self.data.receiver_coords.shape[1] == 3:
-            self.data.receiver_coords = np.delete(self.data.receiver_coords, 1, 1)
-
     def Forward(self, save=False, dse='advanced', auto_tuning=False,
                 cache_blocking=None, compiler=None, u_ini=None):
         fw = ForwardOperator(self.model, self.src, self.damp, self.data,

--- a/examples/tti/TTI_codegen.py
+++ b/examples/tti/TTI_codegen.py
@@ -52,7 +52,7 @@ class TTI_cg:
         damp_boundary(self.damp.data, nbpml)
 
     def Forward(self, save=False, dse='advanced', auto_tuning=False,
-                cache_blocking=None, compiler=None, u_ini=None):
+                cache_blocking=None, compiler=None, u_ini=None, legacy=True):
         nt, nrec = self.data.shape
         nsrc = self.source.shape[1]
         ndim = len(self.damp.shape)
@@ -97,7 +97,7 @@ class TTI_cg:
         fw = ForwardOperator(self.model, u, v, src, rec, self.damp, self.data,
                              time_order=self.t_order, spc_order=self.s_order,
                              profile=True, save=save, cache_blocking=cache_blocking,
-                             dse=dse, compiler=compiler, u_ini=u_ini)
+                             dse=dse, compiler=compiler, u_ini=u_ini, legacy=legacy)
 
         if auto_tuning:
             # uses space_order/2 for the first derivatives to
@@ -137,5 +137,8 @@ class TTI_cg:
             fw.propagator.cache_blocking = at.block_size
 
         fw.apply()
-        return (rec.data, u.data, v.data,
-                fw.propagator.gflopss, fw.propagator.oi, fw.propagator.timings)
+        if legacy:
+            return (rec.data, u.data, v.data,
+                    fw.propagator.gflopss, fw.propagator.oi, fw.propagator.timings)
+        else:
+            return (rec.data, u.data, v.data, None, None, None)

--- a/examples/tti/tti_example.py
+++ b/examples/tti/tti_example.py
@@ -66,17 +66,17 @@ def setup(dimensions=(50, 50, 50), spacing=(20.0, 20.0, 20.0), tn=250.0,
 
 
 def run(dimensions=(50, 50, 50), spacing=(20.0, 20.0, 20.0), tn=250.0,
-        time_order=2, space_order=4, nbpml=10, dse='advanced',
-        auto_tuning=False, compiler=None, cache_blocking=None):
+        time_order=2, space_order=4, nbpml=10, dse='advanced', dle='advanced',
+        auto_tuning=False, compiler=None, cache_blocking=None, legacy=True):
     if auto_tuning:
         cache_blocking = None
 
     TTI = setup(dimensions, spacing, tn, time_order, space_order, nbpml)
 
-    rec, u, v, gflopss, oi, timings = TTI.Forward(dse=dse,
+    rec, u, v, gflopss, oi, timings = TTI.Forward(dse=dse, dle=dle,
                                                   auto_tuning=auto_tuning,
                                                   cache_blocking=cache_blocking,
-                                                  compiler=compiler)
+                                                  compiler=compiler, legacy=legacy)
 
     return gflopss, oi, timings, [rec, u, v]
 

--- a/examples/tti/tti_operators.py
+++ b/examples/tti/tti_operators.py
@@ -1,14 +1,17 @@
 from sympy import *
 
-from devito.dimension import x, y, z
+from devito.dimension import x, y, z, t, time
 from devito.finite_difference import centered, first_derivative, left
-from devito.interfaces import DenseData
+from devito.interfaces import DenseData, TimeData
 from devito.operator import Operator
+from devito.stencilkernel import StencilKernel
 
 
-class ForwardOperator(Operator):
+def ForwardOperator(model, u, v, src, rec, damp, data, time_order=2,
+                    spc_order=4, save=False, u_ini=None, legacy=True,
+                    **kwargs):
     """
-    Class to setup the forward modelling operator in an acoustic media
+    Constructor method for the forward modelling operator in an acoustic media
 
     :param model: IGrid() object containing the physical parameters
     :param src: None ot IShot() (not currently supported properly)
@@ -18,156 +21,173 @@ class ForwardOperator(Operator):
     :param: spc_order: Space discretization order
     :param: u_ini : wavefield at the three first time step for non-zero initial condition
     """
-    def __init__(self, model, u, v, src, rec, damp, data, time_order=2, spc_order=4,
-                 save=False, u_ini=None, **kwargs):
-        nt, nrec = data.shape
-        nt, nsrc = src.shape
-        dt = model.get_critical_dt()
+    nt, nrec = data.shape
+    nt, nsrc = src.shape
+    dt = model.get_critical_dt()
 
-        m = DenseData(name="m", shape=model.get_shape_comp(),
-                      dtype=damp.dtype, space_order=spc_order)
-        m.data[:] = model.padm()
+    m = DenseData(name="m", shape=model.get_shape_comp(),
+                  dtype=damp.dtype, space_order=spc_order)
+    m.data[:] = model.padm()
 
-        parm = [m, damp, u, v]
+    parm = [m, damp, u, v]
 
-        if model.epsilon is not None:
-            epsilon = DenseData(name="epsilon", shape=model.get_shape_comp(),
-                                dtype=damp.dtype, space_order=spc_order)
-            epsilon.data[:] = model.pad(model.epsilon)
-            parm += [epsilon]
-        else:
-            epsilon = 1
-
-        if model.delta is not None:
-            delta = DenseData(name="delta", shape=model.get_shape_comp(),
-                              dtype=damp.dtype, space_order=spc_order)
-            delta.data[:] = model.pad(model.delta)
-            parm += [delta]
-        else:
-            delta = 1
-
-        if model.theta is not None:
-            theta = DenseData(name="theta", shape=model.get_shape_comp(),
-                              dtype=damp.dtype, space_order=spc_order)
-            theta.data[:] = model.pad(model.theta)
-            parm += [theta]
-        else:
-            theta = 0
-
-        if model.phi is not None:
-            phi = DenseData(name="phi", shape=model.get_shape_comp(),
+    if model.epsilon is not None:
+        epsilon = DenseData(name="epsilon", shape=model.get_shape_comp(),
                             dtype=damp.dtype, space_order=spc_order)
-            phi.data[:] = model.pad(model.phi)
-            parm += [phi]
-        else:
-            phi = 0
+        epsilon.data[:] = model.pad(model.epsilon)
+        parm += [epsilon]
+    else:
+        epsilon = 1
 
-        s, h = symbols('s h')
+    if model.delta is not None:
+        delta = DenseData(name="delta", shape=model.get_shape_comp(),
+                          dtype=damp.dtype, space_order=spc_order)
+        delta.data[:] = model.pad(model.delta)
+        parm += [delta]
+    else:
+        delta = 1
 
-        spc_brd = spc_order/2
+    if model.theta is not None:
+        theta = DenseData(name="theta", shape=model.get_shape_comp(),
+                          dtype=damp.dtype, space_order=spc_order)
+        theta.data[:] = model.pad(model.theta)
+        parm += [theta]
+    else:
+        theta = 0
 
-        ang0 = cos(theta)
-        ang1 = sin(theta)
-        if len(m.shape) == 3:
-            ang2 = cos(phi)
-            ang3 = sin(phi)
+    if model.phi is not None:
+        phi = DenseData(name="phi", shape=model.get_shape_comp(),
+                        dtype=damp.dtype, space_order=spc_order)
+        phi.data[:] = model.pad(model.phi)
+        parm += [phi]
+    else:
+        phi = 0
 
-            # Derive stencil from symbolic equation
-            Gyp = (ang3 * u.dx - ang2 * u.dyr)
-            Gyy = (-first_derivative(Gyp * ang3,
-                                     dim=x, side=centered, order=spc_brd) -
-                   first_derivative(Gyp * ang2,
-                                    dim=y, side=left, order=spc_brd))
-            Gyp2 = (ang3 * u.dxr - ang2 * u.dy)
-            Gyy2 = (first_derivative(Gyp2 * ang3,
-                                     dim=x, side=left, order=spc_brd) +
-                    first_derivative(Gyp2 * ang2,
-                                     dim=y, side=centered, order=spc_brd))
+    s, h = symbols('s h')
 
-            Gxp = (ang0 * ang2 * u.dx + ang0 * ang3 * u.dyr - ang1 * u.dzr)
-            Gzr = (ang1 * ang2 * v.dx + ang1 * ang3 * v.dyr + ang0 * v.dzr)
-            Gxx = (-first_derivative(Gxp * ang0 * ang2,
-                                     dim=x, side=centered, order=spc_brd) +
-                   first_derivative(Gxp * ang0 * ang3,
-                                    dim=y, side=left, order=spc_brd) -
-                   first_derivative(Gxp * ang1,
-                                    dim=z, side=left, order=spc_brd))
-            Gzz = (-first_derivative(Gzr * ang1 * ang2,
-                                     dim=x, side=centered, order=spc_brd) +
-                   first_derivative(Gzr * ang1 * ang3,
-                                    dim=y, side=left, order=spc_brd) +
-                   first_derivative(Gzr * ang0,
-                                    dim=z, side=left, order=spc_brd))
-            Gxp2 = (ang0 * ang2 * u.dxr + ang0 * ang3 * u.dy - ang1 * u.dz)
-            Gzr2 = (ang1 * ang2 * v.dxr + ang1 * ang3 * v.dy + ang0 * v.dz)
-            Gxx2 = (first_derivative(Gxp2 * ang0 * ang2,
-                                     dim=x, side=left, order=spc_brd) -
-                    first_derivative(Gxp2 * ang0 * ang3,
-                                     dim=y, side=centered, order=spc_brd) +
-                    first_derivative(Gxp2 * ang1,
-                                     dim=z, side=centered, order=spc_brd))
-            Gzz2 = (first_derivative(Gzr2 * ang1 * ang2,
-                                     dim=x, side=left, order=spc_brd) -
-                    first_derivative(Gzr2 * ang1 * ang3,
-                                     dim=y, side=centered, order=spc_brd) -
-                    first_derivative(Gzr2 * ang0,
-                                     dim=z, side=centered, order=spc_brd))
-            Hp = -(.5*Gxx + .5*Gxx2 + .5*Gyy + .5*Gyy2)
-            Hzr = -(.5*Gzz + .5 * Gzz2)
+    spc_brd = spc_order/2
 
-        else:
-            Gx1p = (ang0 * u.dxr - ang1 * u.dy)
-            Gz1r = (ang1 * v.dxr + ang0 * v.dy)
-            Gxx1 = (first_derivative(Gx1p * ang0, dim=x,
-                                     side=left, order=spc_brd) +
-                    first_derivative(Gx1p * ang1, dim=y,
-                                     side=centered, order=spc_brd))
-            Gzz1 = (first_derivative(Gz1r * ang1, dim=x,
-                                     side=left, order=spc_brd) -
-                    first_derivative(Gz1r * ang0, dim=y,
-                                     side=centered, order=spc_brd))
-            Gx2p = (ang0 * u.dx - ang1 * u.dyr)
-            Gz2r = (ang1 * v.dx + ang0 * v.dyr)
-            Gxx2 = (-first_derivative(Gx2p * ang0, dim=x,
-                    side=centered, order=spc_brd) -
-                    first_derivative(Gx2p * ang1, dim=y,
-                    side=left, order=spc_brd))
-            Gzz2 = (-first_derivative(Gz2r * ang1, dim=x,
-                    side=centered, order=spc_brd) +
-                    first_derivative(Gz2r * ang0, dim=y,
-                    side=left, order=spc_brd))
+    ang0 = cos(theta)
+    ang1 = sin(theta)
+    if len(m.shape) == 3:
+        ang2 = cos(phi)
+        ang3 = sin(phi)
 
-            Hp = -(.5 * Gxx1 + .5 * Gxx2)
-            Hzr = -(.5 * Gzz1 + .5 * Gzz2)
+        # Derive stencil from symbolic equation
+        Gyp = (ang3 * u.dx - ang2 * u.dyr)
+        Gyy = (-first_derivative(Gyp * ang3,
+                                 dim=x, side=centered, order=spc_brd) -
+               first_derivative(Gyp * ang2,
+                                dim=y, side=left, order=spc_brd))
+        Gyp2 = (ang3 * u.dxr - ang2 * u.dy)
+        Gyy2 = (first_derivative(Gyp2 * ang3,
+                                 dim=x, side=left, order=spc_brd) +
+                first_derivative(Gyp2 * ang2,
+                                 dim=y, side=centered, order=spc_brd))
 
-        stencilp = 1.0 / (2.0 * m + s * damp) * \
-            (4.0 * m * u + (s * damp - 2.0 * m) *
-             u.backward + 2.0 * s**2 * (epsilon * Hp + delta * Hzr))
-        stencilr = 1.0 / (2.0 * m + s * damp) * \
-            (4.0 * m * v + (s * damp - 2.0 * m) *
-             v.backward + 2.0 * s**2 * (delta * Hp + Hzr))
+        Gxp = (ang0 * ang2 * u.dx + ang0 * ang3 * u.dyr - ang1 * u.dzr)
+        Gzr = (ang1 * ang2 * v.dx + ang1 * ang3 * v.dyr + ang0 * v.dzr)
+        Gxx = (-first_derivative(Gxp * ang0 * ang2,
+                                 dim=x, side=centered, order=spc_brd) +
+               first_derivative(Gxp * ang0 * ang3,
+                                dim=y, side=left, order=spc_brd) -
+               first_derivative(Gxp * ang1,
+                                dim=z, side=left, order=spc_brd))
+        Gzz = (-first_derivative(Gzr * ang1 * ang2,
+                                 dim=x, side=centered, order=spc_brd) +
+               first_derivative(Gzr * ang1 * ang3,
+                                dim=y, side=left, order=spc_brd) +
+               first_derivative(Gzr * ang0,
+                                dim=z, side=left, order=spc_brd))
+        Gxp2 = (ang0 * ang2 * u.dxr + ang0 * ang3 * u.dy - ang1 * u.dz)
+        Gzr2 = (ang1 * ang2 * v.dxr + ang1 * ang3 * v.dy + ang0 * v.dz)
+        Gxx2 = (first_derivative(Gxp2 * ang0 * ang2,
+                                 dim=x, side=left, order=spc_brd) -
+                first_derivative(Gxp2 * ang0 * ang3,
+                                 dim=y, side=centered, order=spc_brd) +
+                first_derivative(Gxp2 * ang1,
+                                 dim=z, side=centered, order=spc_brd))
+        Gzz2 = (first_derivative(Gzr2 * ang1 * ang2,
+                                 dim=x, side=left, order=spc_brd) -
+                first_derivative(Gzr2 * ang1 * ang3,
+                                 dim=y, side=centered, order=spc_brd) -
+                first_derivative(Gzr2 * ang0,
+                                 dim=z, side=centered, order=spc_brd))
+        Hp = -(.5*Gxx + .5*Gxx2 + .5*Gyy + .5*Gyy2)
+        Hzr = -(.5*Gzz + .5 * Gzz2)
 
-        # Add substitutions for spacing (temporal and spatial)
-        subs = [{s: dt, h: model.get_spacing()}, {s: dt, h: model.get_spacing()}]
-        first_stencil = Eq(u.forward, stencilp)
-        second_stencil = Eq(v.forward, stencilr)
-        stencils = [first_stencil, second_stencil]
-        super(ForwardOperator, self).__init__(nt, m.shape,
-                                              stencils=stencils,
-                                              subs=subs,
-                                              spc_border=spc_order,
-                                              time_order=time_order,
-                                              forward=True,
-                                              dtype=m.dtype,
-                                              input_params=parm,
-                                              **kwargs)
+    else:
+        Gx1p = (ang0 * u.dxr - ang1 * u.dy)
+        Gz1r = (ang1 * v.dxr + ang0 * v.dy)
+        Gxx1 = (first_derivative(Gx1p * ang0, dim=x,
+                                 side=left, order=spc_brd) +
+                first_derivative(Gx1p * ang1, dim=y,
+                                 side=centered, order=spc_brd))
+        Gzz1 = (first_derivative(Gz1r * ang1, dim=x,
+                                 side=left, order=spc_brd) -
+                first_derivative(Gz1r * ang0, dim=y,
+                                 side=centered, order=spc_brd))
+        Gx2p = (ang0 * u.dx - ang1 * u.dyr)
+        Gz2r = (ang1 * v.dx + ang0 * v.dyr)
+        Gxx2 = (-first_derivative(Gx2p * ang0, dim=x,
+                                  side=centered, order=spc_brd) -
+                first_derivative(Gx2p * ang1, dim=y,
+                                 side=left, order=spc_brd))
+        Gzz2 = (-first_derivative(Gz2r * ang1, dim=x,
+                                  side=centered, order=spc_brd) +
+                first_derivative(Gz2r * ang0, dim=y,
+                                 side=left, order=spc_brd))
+
+        Hp = -(.5 * Gxx1 + .5 * Gxx2)
+        Hzr = -(.5 * Gzz1 + .5 * Gzz2)
+
+    stencilp = 1.0 / (2.0 * m + s * damp) * \
+        (4.0 * m * u + (s * damp - 2.0 * m) *
+         u.backward + 2.0 * s**2 * (epsilon * Hp + delta * Hzr))
+    stencilr = 1.0 / (2.0 * m + s * damp) * \
+        (4.0 * m * v + (s * damp - 2.0 * m) *
+         v.backward + 2.0 * s**2 * (delta * Hp + Hzr))
+
+    # Add substitutions for spacing (temporal and spatial)
+    subs = {s: dt, h: model.get_spacing()}
+    first_stencil = Eq(u.forward, stencilp)
+    second_stencil = Eq(v.forward, stencilr)
+    stencils = [first_stencil, second_stencil]
+
+    if legacy:
+        op = Operator(nt, m.shape, stencils=stencils, subs=[subs, subs],
+                      spc_border=spc_order, time_order=time_order,
+                      forward=True, dtype=m.dtype, input_params=parm,
+                      **kwargs)
 
         # Insert source and receiver terms post-hoc
-        self.input_params += [src, src.coordinates, rec, rec.coordinates]
-        self.output_params += [v, rec]
-        self.propagator.time_loop_stencils_a = (src.add(m, u) + src.add(m, v) +
-                                                rec.read2(u, v))
-        self.propagator.add_devito_param(src)
-        self.propagator.add_devito_param(src.coordinates)
-        self.propagator.add_devito_param(rec)
-        self.propagator.add_devito_param(rec.coordinates)
+        op.input_params += [src, src.coordinates, rec, rec.coordinates]
+        op.output_params += [v, rec]
+        op.propagator.time_loop_stencils_a = (src.add(m, u) + src.add(m, v) +
+                                              rec.read2(u, v))
+        op.propagator.add_devito_param(src)
+        op.propagator.add_devito_param(src.coordinates)
+        op.propagator.add_devito_param(rec)
+        op.propagator.add_devito_param(rec.coordinates)
+
+    else:
+        stencils += src.point2grid(u, m, u_t=t, p_t=time)
+        stencils += src.point2grid(v, m, u_t=t, p_t=time)
+        stencils += [Eq(rec, rec.grid2point(u) + rec.grid2point(v))]
+
+        # TODO: The following time-index hackery is a legacy hangover
+        # from the Operator/Propagator structure and is used here for
+        # backward compatibiliy. We need re-examine this apporach carefully!
+
+        # Shift time indices so that LHS writes into t only,
+        # eg. u[t+2] = u[t+1] + u[t]  -> u[t] = u[t-1] + u[t-2]
+        stencils = [e.subs(t, t + solve(e.lhs.args[0], t)[0])
+                    if isinstance(e.lhs, TimeData) else e
+                    for e in stencils]
+        # Apply time substitutions as per legacy approach
+        time_subs = {t + 2: t + 1, t: t + 2, t - 2: t, t - 1: t + 1, t + 1: t}
+        subs.update(time_subs)
+
+        op = StencilKernel(stencils=stencils, subs=subs, dse=None, dle=None)
+
+    return op

--- a/examples/tti/tti_operators.py
+++ b/examples/tti/tti_operators.py
@@ -156,7 +156,7 @@ def ForwardOperator(model, u, v, src, rec, damp, data, time_order=2,
 
     if legacy:
         op = Operator(nt, m.shape, stencils=stencils, subs=[subs, subs],
-                      spc_border=spc_order, time_order=time_order,
+                      spc_border=spc_order/2, time_order=time_order,
                       forward=True, dtype=m.dtype, input_params=parm,
                       **kwargs)
 

--- a/examples/tti/tti_operators.py
+++ b/examples/tti/tti_operators.py
@@ -155,6 +155,8 @@ def ForwardOperator(model, u, v, src, rec, damp, data, time_order=2,
     stencils = [first_stencil, second_stencil]
 
     if legacy:
+        kwargs.pop('dle', None)
+
         op = Operator(nt, m.shape, stencils=stencils, subs=[subs, subs],
                       spc_border=spc_order/2, time_order=time_order,
                       forward=True, dtype=m.dtype, input_params=parm,
@@ -171,6 +173,10 @@ def ForwardOperator(model, u, v, src, rec, damp, data, time_order=2,
         op.propagator.add_devito_param(rec.coordinates)
 
     else:
+        dse = kwargs.get('dse', 'advanced')
+        dle = kwargs.get('dle', 'advanced')
+        compiler = kwargs.get('compiler', None)
+
         stencils += src.point2grid(u, m, u_t=t, p_t=time)
         stencils += src.point2grid(v, m, u_t=t, p_t=time)
         stencils += [Eq(rec, rec.grid2point(u) + rec.grid2point(v))]
@@ -188,6 +194,7 @@ def ForwardOperator(model, u, v, src, rec, damp, data, time_order=2,
         time_subs = {t + 2: t + 1, t: t + 2, t - 2: t, t - 1: t + 1, t + 1: t}
         subs.update(time_subs)
 
-        op = StencilKernel(stencils=stencils, subs=subs, dse=None, dle=None)
+        op = StencilKernel(stencils=stencils, subs=subs, dse=dse, dle=dle,
+                           compiler=compiler)
 
     return op

--- a/tests/test_tti.py
+++ b/tests/test_tti.py
@@ -105,7 +105,8 @@ def test_tti(dimensions, space_order):
                       nbpml=nbpml)
 
     rec, u, _, _, _ = wave_acou.Forward(save=False, u_ini=u1.data)
-    rec_tti, u_tti, v_tti, _, _, _ = wave_tti.Forward(save=False, u_ini=u1.data)
+    rec_tti, u_tti, v_tti, _, _, _ = wave_tti.Forward(save=False, u_ini=u1.data,
+                                                      legacy=True)
 
     res = linalg.norm(u.data.reshape(-1) -
                       .5 * u_tti.reshape(-1) - .5 * v_tti.reshape(-1))

--- a/tests/test_tti.py
+++ b/tests/test_tti.py
@@ -11,9 +11,41 @@ from examples.tti.TTI_codegen import TTI_cg
 @pytest.mark.parametrize('dimensions', [(120, 140), (120, 140, 150)])
 @pytest.mark.parametrize('space_order', [4, 8])
 def test_tti(dimensions, space_order):
-    # dimensions are (x,z) and (x, y, z)
-    origin = tuple([0.0]*len(dimensions))
-    spacing = tuple([15.0]*len(dimensions))
+    nbpml = 10
+
+    if len(dimensions) == 2:
+        # Dimensions in 2D are (x, z)
+        origin = (0., 0.)
+        spacing = (15., 15.)
+
+        # Source location
+        location = np.zeros((1, 2))
+        location[0, 0] = origin[0] + dimensions[0] * spacing[0] * 0.5
+        location[0, 1] = origin[1] + dimensions[1] * spacing[1] * 0.5
+
+        # Receiver coordinates
+        receiver_coords = np.zeros((101, 2))
+        receiver_coords[:, 0] = np.linspace(0, origin[0] +
+                                            dimensions[0] * spacing[0], num=101)
+        receiver_coords[:, 1] = origin[1] + 50 * spacing[1]
+
+    elif len(dimensions) == 3:
+        # Dimensions in 3D are (x, y, z)
+        origin = (0., 0., 0.)
+        spacing = (15., 15., 15.)
+
+        # Source location
+        location = np.zeros((1, 3))
+        location[0, 0] = origin[0] + dimensions[0] * spacing[0] * 0.5
+        location[0, 1] = origin[1] + dimensions[1] * spacing[1] * 0.5
+        location[0, 2] = origin[2] + dimensions[2] * spacing[2] * 0.5
+
+        # Receiver coordinates
+        receiver_coords = np.zeros((101, 3))
+        receiver_coords[:, 0] = np.linspace(0, origin[0] +
+                                            dimensions[0] * spacing[0], num=101)
+        receiver_coords[:, 1] = origin[1] + dimensions[1] * spacing[1] * 0.5
+        receiver_coords[:, 2] = origin[2] + 50 * spacing[2]
 
     # True velocity
     true_vp = np.ones(dimensions) + .5
@@ -45,30 +77,16 @@ def test_tti(dimensions, space_order):
     # Source geometry
     time_series = np.zeros((nt, 1))
     time_series[:, 0] = source(np.linspace(t0, tn, nt), f0)
-
-    location = np.zeros((1, len(dimensions)))
-    location[0, 0] = origin[0] + dimensions[0] * spacing[0] * 0.5
-    location[0, 1] = origin[1] + dimensions[1] * spacing[1] * 0.5
-    if len(dimensions) == 3:
-        location[0, 1] = origin[1] + dimensions[1] * spacing[1] * 0.5
-        location[0, 2] = origin[2] + dimensions[2] * spacing[2] * 0.5
     src.set_receiver_pos(location)
     src.set_shape(nt, 1)
     src.set_traces(time_series)
 
-    receiver_coords = np.zeros((101, len(dimensions)))
-    receiver_coords[:, 0] = np.linspace(0, origin[0] +
-                                        dimensions[0] * spacing[0], num=101)
-    receiver_coords[:, 1] = origin[1] + 50 * spacing[1]
-    if len(dimensions) == 3:
-        receiver_coords[:, 1] = origin[1] + dimensions[1] * spacing[1] * 0.5
-        receiver_coords[:, 2] = origin[2] + 50 * spacing[2]
     data.set_receiver_pos(receiver_coords)
     data.set_shape(nt, 101)
 
     # Adjoint test
     wave_acou = Acoustic_cg(model, data, src, t_order=2, s_order=space_order,
-                            nbpml=10)
+                            nbpml=nbpml)
     rec, u1, _, _, _ = wave_acou.Forward(save=False)
 
     tn = 50.0
@@ -81,10 +99,10 @@ def test_tti(dimensions, space_order):
     data.set_shape(nt, 101)
 
     wave_acou = Acoustic_cg(model, data, src, t_order=2, s_order=space_order,
-                            nbpml=10)
+                            nbpml=nbpml)
 
     wave_tti = TTI_cg(model, data, src, t_order=2, s_order=space_order,
-                      nbpml=10)
+                      nbpml=nbpml)
 
     rec, u, _, _, _ = wave_acou.Forward(save=False, u_ini=u1.data)
     rec_tti, u_tti, v_tti, _, _, _ = wave_tti.Forward(save=False, u_ini=u1.data)

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -74,31 +74,31 @@ def block3(exprs, iters):
 def test_printAST(block1, block2, block3):
     str1 = printAST(block1)
     assert str1 in """
-<Iteration i::i::[0, 3, 1]>
-  <Iteration j::j::[0, 5, 1]>
-    <Iteration k::k::[0, 7, 1]>
+<Iteration i::i::[0, 3, 1]::[0, 0]>
+  <Iteration j::j::[0, 5, 1]::[0, 0]>
+    <Iteration k::k::[0, 7, 1]::[0, 0]>
       <Expression a[i] = a[i] + b[i] + 5.0>
 """
 
     str2 = printAST(block2)
     assert str2 in """
-<Iteration i::i::[0, 3, 1]>
+<Iteration i::i::[0, 3, 1]::[0, 0]>
   <Expression a[i] = a[i] + b[i] + 5.0>
-  <Iteration j::j::[0, 5, 1]>
-    <Iteration k::k::[0, 7, 1]>
+  <Iteration j::j::[0, 5, 1]::[0, 0]>
+    <Iteration k::k::[0, 7, 1]::[0, 0]>
       <Expression a[i] = -a[i] + b[i]>
 """
 
     str3 = printAST(block3)
     assert str3 in """
-<Iteration i::i::[0, 3, 1]>
-  <Iteration s::s::[0, 4, 1]>
+<Iteration i::i::[0, 3, 1]::[0, 0]>
+  <Iteration s::s::[0, 4, 1]::[0, 0]>
     <Expression a[i] = a[i] + b[i] + 5.0>
-  <Iteration j::j::[0, 5, 1]>
-    <Iteration k::k::[0, 7, 1]>
+  <Iteration j::j::[0, 5, 1]::[0, 0]>
+    <Iteration k::k::[0, 7, 1]::[0, 0]>
       <Expression a[i] = -a[i] + b[i]>
       <Expression a[i] = 4*a[i]*b[i]>
-  <Iteration p::p::[0, 4, 1]>
+  <Iteration p::p::[0, 4, 1]::[0, 0]>
     <Expression a[i] = 8.0*a[i] + 6.0/b[i]>
 """
 
@@ -253,10 +253,10 @@ def test_merge_iterations_flat(exprs, iters):
              iters[0](iters[2](exprs[1]))]
     newblock = MergeOuterIterations().visit(block)
     newstr = printAST(newblock)
-    assert newstr == """<Iteration i::i::[0, 3, 1]>
-  <Iteration j::j::[0, 5, 1]>
+    assert newstr == """<Iteration i::i::[0, 3, 1]::[0, 0]>
+  <Iteration j::j::[0, 5, 1]::[0, 0]>
     <Expression a[i] = a[i] + b[i] + 5.0>
-  <Iteration k::k::[0, 7, 1]>
+  <Iteration k::k::[0, 7, 1]::[0, 0]>
     <Expression a[i] = -a[i] + b[i]>"""
 
 
@@ -276,10 +276,10 @@ def test_merge_iterations_deep(exprs, iters):
              iters[0]([iters[2](exprs[0]), iters[2](exprs[1])])]
     newblock = MergeOuterIterations().visit(block)
     newstr = printAST(newblock)
-    assert newstr == """<Iteration i::i::[0, 3, 1]>
-  <Iteration j::j::[0, 5, 1]>
+    assert newstr == """<Iteration i::i::[0, 3, 1]::[0, 0]>
+  <Iteration j::j::[0, 5, 1]::[0, 0]>
     <Expression a[i] = a[i] + b[i] + 5.0>
-  <Iteration k::k::[0, 7, 1]>
+  <Iteration k::k::[0, 7, 1]::[0, 0]>
     <Expression a[i] = a[i] + b[i] + 5.0>
     <Expression a[i] = -a[i] + b[i]>"""
 
@@ -301,9 +301,9 @@ def test_merge_iterations_nested(exprs, iters):
              iters[0]([iters[1](exprs[1]), iters[2](exprs[1])])]
     newblock = MergeOuterIterations().visit(block)
     newstr = printAST(newblock)
-    assert newstr == """<Iteration i::i::[0, 3, 1]>
-  <Iteration j::j::[0, 5, 1]>
+    assert newstr == """<Iteration i::i::[0, 3, 1]::[0, 0]>
+  <Iteration j::j::[0, 5, 1]::[0, 0]>
     <Expression a[i] = a[i] + b[i] + 5.0>
     <Expression a[i] = -a[i] + b[i]>
-  <Iteration k::k::[0, 7, 1]>
+  <Iteration k::k::[0, 7, 1]::[0, 0]>
     <Expression a[i] = -a[i] + b[i]>"""


### PR DESCRIPTION
This merge applies the same type of trickery to allow TTI to be run through the new `StencilKernel` interface, hidden behind a `legacy` flag for now. It comes with a small set of bug fixes and the necessary test modifications and also hooks up profiling information for the acoustic and TTI wrappers for the new API.

Travis does not test the new code path yet due to the heavy nature of all tests involving TTI, but I have verified correctness of the relevant tests locally. This merge is intended to allow us to like-for-like test the current with the 3.0 API and gather performance data ahead of the switch. Support for 3.0 on acoustic and TTI is currently still on a "best effort" basis, until we have a better handle on some of the outstanding issues. 