### PR TITLE
Reverse time interface for 3.0

### DIFF
--- a/devito/dimension.py
+++ b/devito/dimension.py
@@ -3,7 +3,7 @@ import cgen
 import numpy as np
 from sympy import Symbol
 
-__all__ = ['Dimension', 'x', 'y', 'z', 't', 'p', 'd']
+__all__ = ['Dimension', 'x', 'y', 'z', 't', 'p', 'd', 'time']
 
 
 class Dimension(Symbol):
@@ -14,6 +14,7 @@ class Dimension(Symbol):
     defines a potential iteration space.
 
     :param size: Optional, size of the array dimension.
+    :param reverse: Traverse dimension in reverse order (default False)
     :param buffered: Optional, boolean flag indicating whether to
                      buffer variables when iterating this dimension.
     """
@@ -22,6 +23,7 @@ class Dimension(Symbol):
         newobj = Symbol.__new__(cls, name)
         newobj.size = kwargs.get('size', None)
         newobj._count = 0
+        newobj.reverse = kwargs.get('reverse', False)
         return newobj
 
     def __str__(self):
@@ -68,6 +70,10 @@ class BufferedDimension(Dimension):
     @property
     def size(self):
         return self.parent.size
+
+    @property
+    def reverse(self):
+        return self.parent.reverse
 
 
 # Default dimensions for time

--- a/devito/dse/symbolics.py
+++ b/devito/dse/symbolics.py
@@ -97,6 +97,7 @@ class State(object):
     def __init__(self, exprs):
         self.exprs = exprs
         self.mapper = OrderedDict()
+        self.input = exprs
 
     def update(self, exprs=None, mapper=None):
         self.exprs = exprs or self.exprs

--- a/devito/interfaces.py
+++ b/devito/interfaces.py
@@ -4,7 +4,7 @@ import numpy as np
 from sympy import Function, IndexedBase, Symbol, as_finite_diff, symbols
 from sympy.abc import h, s
 
-from devito.dimension import d, p, t, x, y, z
+from devito.dimension import d, p, t, x, y, z, time
 from devito.finite_difference import (centered, cross_derivative,
                                       first_derivative, left, right,
                                       second_derivative)
@@ -515,7 +515,9 @@ class TimeData(DenseData):
         dimensions = kwargs.get('dimensions', None)
         if dimensions is None:
             # Infer dimensions from default and data shape
-            _indices = [t, x, y, z]
+            save = kwargs.get('save', None)
+            tidx = time if save else t
+            _indices = [tidx, x, y, z]
             shape = kwargs.get('shape')
             dimensions = _indices[:len(shape) + 1]
         return dimensions
@@ -538,15 +540,17 @@ class TimeData(DenseData):
     def forward(self):
         """Symbol for the time-forward state of the function"""
         i = int(self.time_order / 2) if self.time_order >= 2 else 1
+        _t = self.indices[0]
 
-        return self.subs(t, t + i * s)
+        return self.subs(_t, _t + i * s)
 
     @property
     def backward(self):
         """Symbol for the time-backward state of the function"""
         i = int(self.time_order / 2) if self.time_order >= 2 else 1
+        _t = self.indices[0]
 
-        return self.subs(t, t - i * s)
+        return self.subs(_t, _t - i * s)
 
     @property
     def dt(self):

--- a/devito/interfaces.py
+++ b/devito/interfaces.py
@@ -555,22 +555,24 @@ class TimeData(DenseData):
     @property
     def dt(self):
         """Symbol for the first derivative wrt the time dimension"""
+        _t = self.indices[0]
         if self.time_order == 1:
             # This hack is needed for the first-order diffusion test
-            indices = [t, t + s]
+            indices = [_t, _t + s]
         else:
             width = int(self.time_order / 2)
-            indices = [(t + i * s) for i in range(-width, width + 1)]
+            indices = [(_t + i * s) for i in range(-width, width + 1)]
 
-        return as_finite_diff(self.diff(t), indices)
+        return as_finite_diff(self.diff(_t), indices)
 
     @property
     def dt2(self):
         """Symbol for the second derivative wrt the t dimension"""
-        width_t = int(self.time_order/2)
-        indt = [(t + i * s) for i in range(-width_t, width_t + 1)]
+        _t = self.indices[0]
+        width_t = int(self.time_order / 2)
+        indt = [(_t + i * s) for i in range(-width_t, width_t + 1)]
 
-        return as_finite_diff(self.diff(t, t), indt)
+        return as_finite_diff(self.diff(_t, _t), indt)
 
 
 class CoordinateData(SymbolicData):

--- a/devito/interfaces.py
+++ b/devito/interfaces.py
@@ -12,13 +12,35 @@ from devito.logger import debug, error
 from devito.memmap_manager import MemmapManager
 from devito.memory import CMemory, first_touch
 
-__all__ = ['DenseData', 'TimeData', 'PointData']
+__all__ = ['DenseData', 'TimeData', 'PointData', 'Forward', 'Backward']
 
 
 # This cache stores a reference to each created data object
 # so that we may re-create equivalent symbols during symbolic
 # manipulation with the correct shapes, pointers, etc.
 _SymbolCache = {}
+
+
+class TimeAxis(object):
+    """Direction in which to advance the time index on
+    :class:`TimeData` objects.
+
+    :param axis: Either 'Forward' or 'Backward'
+    """
+
+    def __init__(self, axis):
+        assert axis in ['Forward', 'Backward']
+        self._axis = {'Forward': 1, 'Backward': -1}[axis]
+
+    def __eq__(self, other):
+        return self._axis == other._axis
+
+    def __repr__(self):
+        return {-1: 'Backward', 1: 'Forward'}[self._axis]
+
+
+Forward = TimeAxis('Forward')
+Backward = TimeAxis('Backward')
 
 
 class CachedSymbol(object):

--- a/devito/nodes.py
+++ b/devito/nodes.py
@@ -365,7 +365,8 @@ class Iteration(Node):
 
         # For reverse dimensions flip loop bounds
         if self.dim.reverse:
-            loop_init = c.InlineInitializer(c.Value("int", self.index), ccode(end))
+            loop_init = c.InlineInitializer(c.Value("int", self.index),
+                                            ccode('%s - 1' % end))
             loop_cond = '%s >= %s' % (self.index, ccode(start))
             loop_inc = '%s -= %s' % (self.index, self.limits[2])
         else:

--- a/devito/nodes.py
+++ b/devito/nodes.py
@@ -345,28 +345,33 @@ class Iteration(Node):
 
         # Start
         if offsets[0] != 0:
-            val = "%s + %s" % (self.limits[0], -offsets[0])
+            start = "%s + %s" % (self.limits[0], -offsets[0])
             try:
-                val = eval(val)
+                start = eval(start)
             except (NameError, TypeError):
                 pass
         else:
-            val = self.limits[0]
-        loop_init = c.InlineInitializer(c.Value("int", self.index), ccode(val))
+            start = self.limits[0]
 
         # Bound
         if offsets[1] != 0:
-            val = "%s - %s" % (self.limits[1], offsets[1])
+            end = "%s - %s" % (self.limits[1], offsets[1])
             try:
-                val = eval(val)
+                end = eval(end)
             except (NameError, TypeError):
                 pass
         else:
-            val = self.limits[1]
-        loop_cond = '%s < %s' % (self.index, ccode(val))
+            end = self.limits[1]
 
-        # Increment
-        loop_inc = '%s += %s' % (self.index, self.limits[2])
+        # For reverse dimensions flip loop bounds
+        if self.dim.reverse:
+            loop_init = c.InlineInitializer(c.Value("int", self.index), ccode(end))
+            loop_cond = '%s >= %s' % (self.index, ccode(start))
+            loop_inc = '%s -= %s' % (self.index, self.limits[2])
+        else:
+            loop_init = c.InlineInitializer(c.Value("int", self.index), ccode(start))
+            loop_cond = '%s < %s' % (self.index, ccode(end))
+            loop_inc = '%s += %s' % (self.index, self.limits[2])
 
         return c.For(loop_init, loop_cond, loop_inc, c.Block(loop_body))
 

--- a/devito/stencilkernel.py
+++ b/devito/stencilkernel.py
@@ -357,6 +357,8 @@ class StencilKernel(Function):
         """Wrap :class:`Expression` objects within suitable hierarchies of
         :class:`Iteration` according to dimensions.
         """
+        functions = flatten(Expression(i).functions for i in dse_state.input)
+        ordering = partial_order([i.indices for i in functions])
 
         processed = []
         for cluster in dse_state.clusters:
@@ -370,8 +372,6 @@ class StencilKernel(Function):
             dimensions = filter_ordered(list(offsets.keys()), key=key)
 
             # Determine a total ordering for the dimensions
-            functions = flatten(i.functions for i in body)
-            ordering = partial_order([i.indices for i in functions])
             dimensions = filter_sorted(dimensions, key=lambda d: ordering.index(d))
             for d in reversed(dimensions):
                 body = Iteration(body, dimension=d, limits=d.size, offsets=offsets[d])

--- a/devito/stencilkernel.py
+++ b/devito/stencilkernel.py
@@ -156,7 +156,7 @@ class StencilKernel(Function):
                     if dim in dim_sizes:
                         # Ensure size matches previously defined size
                         if not dim.is_Buffered:
-                            assert dim_sizes[dim] == data.shape[i]
+                            assert dim_sizes[dim] <= data.shape[i]
                     else:
                         # Derive size from grid data shape and store
                         dim_sizes[dim] = data.shape[i]

--- a/devito/tools.py
+++ b/devito/tools.py
@@ -104,22 +104,19 @@ def partial_order(elements):
     roots = OrderedDict([(k, v) for k, v in mapper.items()
                          if k not in flatten(mapper.values())])
 
-    # Compute the partial orders
+    # Start by queuing up roots
     ordering = []
+    queue = []
     for k, v in roots.items():
-        pos = 0
         ordering.append(k)
-        queue = [(i, k) for i in v]
-        while queue:
-            item, prev = queue.pop(0)
-            pos = ordering.index(prev) + 1
-            ordering.insert(pos, item)
-            for i in mapper[item]:
-                if i in ordering:
-                    if any(i == j for j in ordering[:pos]):
-                        return []
-                else:
-                    queue.append((i, item))
+        queue += [(i, k) for i in v]
+
+    # Compute the partial orders from roots
+    while queue:
+        item, prev = queue.pop(0)
+        if item not in ordering:
+            ordering += [item]
+        queue += [(i, item) for i in mapper[item]]
 
     return ordering
 

--- a/tests/test_timestepping.py
+++ b/tests/test_timestepping.py
@@ -53,3 +53,15 @@ def test_forward_unroll(a, c, nt=5):
     StencilKernel([eqn_c, eqn_a], dle=None, dse=None)(time=nt)
     for i in range(nt):
         assert np.allclose(a.data[i, :], 1. + i, rtol=1.e-12)
+
+
+def test_forward_backward(a, b, nt=5):
+    a.data[0, :] = 1.
+    b.data[0, :] = 1.
+    eqn_a = Eq(a.forward, a + 1.)
+    StencilKernel(eqn_a, dle=None, dse=None, time_axis=Forward)(time=nt)
+
+    eqn_b = Eq(b, a + 1.)
+    StencilKernel(eqn_b, dle=None, dse=None, time_axis=Backward)(time=nt)
+    for i in range(nt):
+        assert np.allclose(b.data[i, :], 2. + i, rtol=1.e-12)

--- a/tests/test_timestepping.py
+++ b/tests/test_timestepping.py
@@ -21,6 +21,13 @@ def b(shape=(11, 11)):
                     time_dim=6, save=True)
 
 
+@pytest.fixture
+def c(shape=(11, 11)):
+    """Forward time data object, buffered (save=False)"""
+    return TimeData(name='c', shape=shape, time_order=1,
+                    save=False, time_axis=Forward)
+
+
 def test_forward(a, nt=5):
     a.data[0, :] = 1.
     eqn = Eq(a.forward, a + 1.)
@@ -35,3 +42,14 @@ def test_backward(b, nt=5):
     StencilKernel(eqn, dle=None, dse=None, time_axis=Backward)(time=nt)
     for i in range(nt + 1):
         assert np.allclose(b.data[i, :], 1. + i, rtol=1.e-12)
+
+
+def test_forward_unroll(a, c, nt=5):
+    """Test forward time marching with a buffered and an unrolled t"""
+    a.data[0, :] = 1.
+    c.data[0, :] = 1.
+    eqn_c = Eq(c.forward, c + 1.)
+    eqn_a = Eq(a.forward, c.forward)
+    StencilKernel([eqn_c, eqn_a], dle=None, dse=None)(time=nt)
+    for i in range(nt):
+        assert np.allclose(a.data[i, :], 1. + i, rtol=1.e-12)

--- a/tests/test_timestepping.py
+++ b/tests/test_timestepping.py
@@ -3,7 +3,7 @@ from sympy import Eq
 
 import pytest
 
-from devito.interfaces import TimeData
+from devito.interfaces import Backward, Forward, TimeData
 from devito.stencilkernel import StencilKernel
 
 
@@ -14,9 +14,24 @@ def a(shape=(11, 11)):
                     time_dim=6, save=True)
 
 
+@pytest.fixture
+def b(shape=(11, 11)):
+    """Backward time data object, unrolled (save=True)"""
+    return TimeData(name='b', shape=shape, time_order=1,
+                    time_dim=6, save=True)
+
+
 def test_forward(a, nt=5):
     a.data[0, :] = 1.
     eqn = Eq(a.forward, a + 1.)
     StencilKernel(eqn, dle=None, dse=None)()
     for i in range(nt):
         assert np.allclose(a.data[i, :], 1. + i, rtol=1.e-12)
+
+
+def test_backward(b, nt=5):
+    b.data[nt, :] = 6.
+    eqn = Eq(b.backward, b - 1.)
+    StencilKernel(eqn, dle=None, dse=None, time_axis=Backward)(time=nt)
+    for i in range(nt + 1):
+        assert np.allclose(b.data[i, :], 1. + i, rtol=1.e-12)

--- a/tests/test_timestepping.py
+++ b/tests/test_timestepping.py
@@ -1,0 +1,22 @@
+import numpy as np
+from sympy import Eq
+
+import pytest
+
+from devito.interfaces import TimeData
+from devito.stencilkernel import StencilKernel
+
+
+@pytest.fixture
+def a(shape=(11, 11)):
+    """Forward time data object, unrolled (save=True)"""
+    return TimeData(name='a', shape=shape, time_order=1,
+                    time_dim=6, save=True)
+
+
+def test_forward(a, nt=5):
+    a.data[0, :] = 1.
+    eqn = Eq(a.forward, a + 1.)
+    StencilKernel(eqn, dle=None, dse=None)()
+    for i in range(nt):
+        assert np.allclose(a.data[i, :], 1. + i, rtol=1.e-12)

--- a/tests/test_timestepping.py
+++ b/tests/test_timestepping.py
@@ -1,5 +1,6 @@
 import numpy as np
 from sympy import Eq
+from sympy.abc import s
 
 import pytest
 
@@ -28,19 +29,26 @@ def c(shape=(11, 11)):
                     save=False, time_axis=Forward)
 
 
-def test_forward(a, nt=5):
+@pytest.fixture
+def d(shape=(11, 11)):
+    """Forward time data object, unrolled (save=True), end order"""
+    return TimeData(name='d', shape=shape, time_order=2,
+                    time_dim=6, save=True)
+
+
+def test_forward(a):
     a.data[0, :] = 1.
     eqn = Eq(a.forward, a + 1.)
     StencilKernel(eqn, dle=None, dse=None)()
-    for i in range(nt):
+    for i in range(a.shape[0]):
         assert np.allclose(a.data[i, :], 1. + i, rtol=1.e-12)
 
 
-def test_backward(b, nt=5):
-    b.data[nt, :] = 6.
+def test_backward(b):
+    b.data[-1, :] = 7.
     eqn = Eq(b.backward, b - 1.)
-    StencilKernel(eqn, dle=None, dse=None, time_axis=Backward)(time=nt)
-    for i in range(nt + 1):
+    StencilKernel(eqn, dle=None, dse=None, time_axis=Backward)()
+    for i in range(b.shape[0]):
         assert np.allclose(b.data[i, :], 1. + i, rtol=1.e-12)
 
 
@@ -65,3 +73,25 @@ def test_forward_backward(a, b, nt=5):
     StencilKernel(eqn_b, dle=None, dse=None, time_axis=Backward)(time=nt)
     for i in range(nt):
         assert np.allclose(b.data[i, :], 2. + i, rtol=1.e-12)
+
+
+def test_loop_bounds_forward(d):
+    """Test the automatic bound detection for forward time loops"""
+    d.data[:] = 1.
+    eqn = Eq(d, 2. + d.dt2)
+    StencilKernel(eqn, dle=None, dse=None, subs={s: 1.}, time_axis=Forward)()
+    assert np.allclose(d.data[0, :], 1., rtol=1.e-12)
+    assert np.allclose(d.data[-1, :], 1., rtol=1.e-12)
+    for i in range(1, d.data.shape[0]-1):
+        assert np.allclose(d.data[i, :], 1. + i, rtol=1.e-12)
+
+
+def test_loop_bounds_backward(d):
+    """Test the automatic bound detection for backward time loops"""
+    d.data[:] = 1.
+    eqn = Eq(d, 2. + d.dt2)
+    StencilKernel(eqn, dle=None, dse=None, subs={s: 1.}, time_axis=Backward)()
+    assert np.allclose(d.data[0, :], 1., rtol=1.e-12)
+    assert np.allclose(d.data[-1, :], 1., rtol=1.e-12)
+    for i in range(1, d.data.shape[0]-1):
+        assert np.allclose(d.data[i, :], d.data.shape[0] - i, rtol=1.e-12)

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,16 @@
+import pytest
+
+from sympy.abc import a, b, c, d, e
+
+from devito.tools import partial_order
+
+
+@pytest.mark.parametrize('elements, expected', [
+    ([[a, b, c], [c, d, e]], [a, b, c, d, e]),
+    ([[e, d, c], [c, b, a]], [e, d, c, b, a]),
+    ([[a, b, c], [b, d, e]], [a, b, c, d, e]),
+    ([[a, b, c], [d, b, c]], [a, d, b, c]),
+])
+def test_partial_order(elements, expected):
+    ordering = partial_order(elements)
+    assert ordering == expected


### PR DESCRIPTION
After long deliberation and experimentation we finally introduce the ability to add reverse-time operators through the new 3.0 API. To the outside this looks pretty similar to the previous approach where an operator argument `StencilKernel, eq, subs=subs, time_axis=Forward/Backward` determines the direction of the time loop.

Under the hood this now behaves slightly different, where the `Dimension.reverse` on the dedicated `time` dimension is set according to the given parameter. This ensures that:
a) We can use the same `time`/`t`symbols in forward and backward runs
b) Custom dimensions may also be inverted if desired

We also introduce a new high-level utility object `TimeAxis` that describes the particular mode of "time" to use in an operator and will hopefully be extended soon.

This change also includes a fix to the `partial_order` utility function that is used to schedule loops according to dimension dependencies in the index signatures. It also forces the `StencilKernel` to create one global partial ordering across encountered clusters to ensure semantic rigour.