### PR TITLE
Change the type of block sizes to np.int32

### DIFF
--- a/devito/propagator.py
+++ b/devito/propagator.py
@@ -739,7 +739,7 @@ class Propagator(object):
 
         for i, j in zip(self.block_sizes, self.space_dims):
             if i is not None:
-                self.fd.add_value_param("%sblock" % self._mapper[j], np.int64)
+                self.fd.add_value_param("%sblock" % self._mapper[j], np.int32)
 
     def add_inner_most_dim_pragma(self, inner_most_dim, space_dims, loop_body):
         """


### PR DESCRIPTION
- They don't need to be that big
- Breaks `cgen` on 32 bit machines

This is expected to fix #213 