### PR TITLE
all orders second derivative

### DIFF
--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -261,7 +261,12 @@ def load(basename, compiler=GNUCompiler):
     Note: If the provided compiler is of type `IntelMICCompiler`
     we utilise the `pymic` package to manage device streams.
     """
-    lib_file = "%s.%s" % (basename, compiler.lib_ext)
+    if platform == "linux" or platform == "linux2":
+        lib_file = "%s.so" % basename
+    elif platform == "darwin":
+        lib_file = "%s.dylib" % basename
+    elif platform == "win32" or platform == "win64":
+        lib_file = "%s.dll" % basename
 
     if isinstance(compiler, IntelMICCompiler):
         compiler._device = compiler._mic.devices[0]

--- a/devito/finite_difference.py
+++ b/devito/finite_difference.py
@@ -55,7 +55,7 @@ def second_derivative(*args, **kwargs):
     ind = [(dim + i * diff) for i in range(-int(order / 2),
                                            int(order / 2) + 1)]
 
-    coeffs = finite_diff_weights(1, ind, dim)[-1][-1]
+    coeffs = finite_diff_weights(2, ind, dim)[-1][-1]
     deriv = 0
 
     for i in range(0, len(ind)):

--- a/devito/finite_difference.py
+++ b/devito/finite_difference.py
@@ -10,23 +10,6 @@ from devito.dimension import x, y
 __all__ = ['first_derivative', 'second_derivative', 'cross_derivative',
            'left', 'right', 'centered']
 
-
-# Explicitly derived Finite Difference coefficients for
-# symmetric derivative stencils.
-fd_coefficients = {
-    16: [-3.054844, 1.777778, -0.311111, 0.075421, -0.017677, 0.003481, -0.000518,
-         0.000051, -0.000002],
-    14: [-3.023594, 1.750000, -0.291667, 0.064815, -0.013258, 0.002121, -0.000227,
-         0.000012],
-    12: [-2.982778, 1.714286, -0.267857, 0.052910, -0.008929, 0.001039, -0.000060],
-    10: [-2.927222, 1.666667, -0.238095, 0.039683, -0.004960, 0.000317],
-    8: [-2.847222, 1.600000, -0.200000, 0.025397, -0.001786],
-    6: [-2.722222, 1.500000, -0.150000, 0.01111],
-    4: [-2.500000, 1.333333, -0.08333],
-    2: [-2., 1.],
-}
-
-
 # Default spacing symbol
 h = symbols('h')
 
@@ -69,17 +52,16 @@ def second_derivative(*args, **kwargs):
     dim = kwargs.get('dim', x)
     diff = kwargs.get('diff', h)
 
-    assert(order in fd_coefficients)
+    ind = [(dim + i * diff) for i in range(-int(order / 2),
+                                           int(order / 2) + 1)]
 
-    coeffs = fd_coefficients[order]
-    deriv = coeffs[0] * reduce(mul, args, 1)
+    coeffs = finite_diff_weights(1, ind, dim)[-1][-1]
+    deriv = 0
 
-    for i in range(1, int(order / 2) + 1):
-        aux1 = [a.subs(dim, dim + i * diff) for a in args]
-        aux2 = [a.subs(dim, dim - i * diff) for a in args]
-        deriv += coeffs[i] * (reduce(mul, aux1, 1) + reduce(mul, aux2, 1))
-
-    return (1 / diff**2) * deriv
+    for i in range(0, len(ind)):
+            var = [a.subs({dim: ind[i]}) for a in args]
+            deriv += coeffs[i] * reduce(mul, var, 1)
+    return deriv
 
 
 def cross_derivative(*args, **kwargs):
@@ -173,7 +155,7 @@ def first_derivative(*args, **kwargs):
     c = finite_diff_weights(1, ind, dim)
     c = c[-1][-1]
 
-    # Diagonal elements
+    # Loop through positions
     for i in range(0, len(ind)):
             var = [a.subs({dim: ind[i]}) for a in args]
             deriv += c[i] * reduce(mul, var, 1)


### PR DESCRIPTION
Small PR that allow any order for the second derivative while the old version had hard-codded order [2,4,6,8,10,12,14,16] only.