### PR TITLE
Fix wrong library extension

### DIFF
--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -260,14 +260,14 @@ def load(basename, compiler=GNUCompiler):
 
     Note: If the provided compiler is of type `IntelMICCompiler`
     we utilise the `pymic` package to manage device streams.
-    """ 
+    """
     if isinstance(compiler, IntelMICCompiler):
         compiler._device = compiler._mic.devices[0]
         compiler._stream = compiler._device.get_default_stream()
         # The name with the extension is only used for MIC
         lib_file = "%s.%s" % (basename, compiler.lib_ext)
         return compiler._device.load_library(lib_file)
-    
+
     return npct.load_library(basename, '.')
 
 

--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -260,16 +260,15 @@ def load(basename, compiler=GNUCompiler):
 
     Note: If the provided compiler is of type `IntelMICCompiler`
     we utilise the `pymic` package to manage device streams.
-    """
-    lib_file = "%s.%s" % (basename, compiler.lib_ext)
-
+    """ 
     if isinstance(compiler, IntelMICCompiler):
         compiler._device = compiler._mic.devices[0]
         compiler._stream = compiler._device.get_default_stream()
-
+        # The name with the extension is only used for MIC
+        lib_file = "%s.%s" % (basename, compiler.lib_ext)
         return compiler._device.load_library(lib_file)
-
-    return npct.load_library(lib_file, '.')
+    
+    return npct.load_library(basename, '.')
 
 
 def jit_compile(ccode, compiler=GNUCompiler):


### PR DESCRIPTION
In its current state, master is broken on my machine - OSX 10.11.6 with python 2.7.
This is the stack trace: 
```
Traceback (most recent call last):
  File "examples/acoustic/acoustic_example.py", line 103, in <module>
    run(full_run=True, auto_tuning=False, space_order=6, time_order=2)
  File "examples/acoustic/acoustic_example.py", line 88, in run
    auto_tuning=auto_tuning, compiler=compiler, legacy=legacy,
  File "/Users/navjotkukreja/Work/ipcc/devito/examples/acoustic/Acoustic_codegen.py", line 103, in Forward
    fw.apply()
  File "/Users/navjotkukreja/Work/ipcc/devito/devito/operator.py", line 155, in apply
    self.propagator.run(self.get_args())
  File "/Users/navjotkukreja/Work/ipcc/devito/devito/propagator.py", line 134, in run
    f = self.cfunction
  File "/Users/navjotkukreja/Work/ipcc/devito/devito/propagator.py", line 201, in cfunction
    self._lib = load(basename, self.compiler)
  File "/Users/navjotkukreja/Work/ipcc/devito/devito/compiler.py", line 272, in load
    return npct.load_library(lib_file, '.')
  File "/Users/navjotkukreja/Documents/Work/Envs/devito/lib/python2.7/site-packages/numpy/ctypeslib.py", line 155, in load_library
    raise OSError("no file with expected extension")
OSError: no file with expected extension
```

The [documentation](https://docs.scipy.org/doc/numpy/reference/routines.ctypeslib.html) for `numpy.ctypeslib.load_library` clearly states that the name of the library is to be provided without the extension. For some reason in the last PR the extension was added here which broke things since the extension for a shared library in use on my machine is `.dylib`. 

This PR should make this compatible with all platforms again. I don't know how this passed OSX tests on travis though. 