### PR TITLE
Allow symbol data to be substituted at the time of applying the Operator

### DIFF
--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -260,14 +260,14 @@ def load(basename, compiler=GNUCompiler):
 
     Note: If the provided compiler is of type `IntelMICCompiler`
     we utilise the `pymic` package to manage device streams.
-    """ 
+    """
     if isinstance(compiler, IntelMICCompiler):
         compiler._device = compiler._mic.devices[0]
         compiler._stream = compiler._device.get_default_stream()
         # The name with the extension is only used for MIC
         lib_file = "%s.%s" % (basename, compiler.lib_ext)
         return compiler._device.load_library(lib_file)
-    
+
     return npct.load_library(basename, '.')
 
 

--- a/devito/exceptions.py
+++ b/devito/exceptions.py
@@ -1,0 +1,2 @@
+class InvalidArgument(Exception):
+    pass

--- a/devito/stencilkernel.py
+++ b/devito/stencilkernel.py
@@ -130,9 +130,8 @@ class OperatorBasic(Function):
 
         # Have we been provided substitutes for symbol data?
         # Only SymbolicData can be overridden with this route
-        r_args = [f_n for f_n, f in arguments.iteritems()
-                  if isinstance(f, SymbolicData)]
-        o_vals = OrderedDict([arg for arg in kwargs.iteritems() if arg[0] in r_args])
+        r_args = [f_n for f_n, f in arguments.items() if isinstance(f, SymbolicData)]
+        o_vals = OrderedDict([arg for arg in kwargs.items() if arg[0] in r_args])
 
         # Replace the over-ridden values with the provided ones
         for argname in o_vals.keys():

--- a/devito/stencilkernel.py
+++ b/devito/stencilkernel.py
@@ -24,6 +24,7 @@ from devito.tools import (SetOrderedDict, as_tuple, filter_ordered, filter_sorte
 from devito.visitors import (FindNodes, FindSections, FindSymbols, FindScopes,
                              IsPerfectIteration, MergeOuterIterations,
                              ResolveIterationVariable, SubstituteExpression, Transformer)
+from devito.exceptions import InvalidArgument
 
 __all__ = ['StencilKernel']
 
@@ -127,10 +128,23 @@ class OperatorBasic(Function):
         arguments = OrderedDict([(arg.name, arg) for arg in self.parameters])
         dim_sizes = {}
 
+        # Have we been provided substitutes for symbol data?
+        # Only SymbolicData can be overridden with this route
+        r_args = [f_n for f_n, f in arguments.iteritems()
+                  if isinstance(f, SymbolicData)]
+        o_vals = OrderedDict([arg for arg in kwargs.iteritems() if arg[0] in r_args])
+
+        # Replace the over-ridden values with the provided ones
+        for argname in o_vals.keys():
+            if not arguments[argname].shape == o_vals[argname].shape:
+                raise InvalidArgument("Shapes must match")
+
+            arguments[argname] = o_vals[argname]
+
         # Traverse positional args and infer loop sizes for open dimensions
         f_args = [f for f in arguments.values() if isinstance(f, SymbolicData)]
         for f, arg in zip(f_args, args):
-            arguments[f.name] = self._arg_data(f)
+            arguments[arg.name] = self._arg_data(f)
             shape = self._arg_shape(f)
 
             # Ensure data dimensions match symbol dimensions

--- a/tests/test_stencil_arithmetic.py
+++ b/tests/test_stencil_arithmetic.py
@@ -140,3 +140,24 @@ def test_arithmetic_indexed_open_loops(i, j, k, l, expr, result):
     eqn = eval(expr)
     StencilKernel(eqn)(fa)
     assert np.allclose(fa.data[1, 1:-1, 1:-1], result[1:-1, 1:-1], rtol=1e-12)
+
+
+def test_override(i, j, k, l):
+    """Test that the call-time overriding of Operator arguments works"""
+    a = symbol(name='a', dimensions=(i, j, k, l), value=2., mode='indexed').base.function
+    a1 = symbol(name='a', dimensions=(i, j, k, l), value=3., mode='indexed').base.function
+    a2 = symbol(name='b', dimensions=(i, j, k, l), value=4., mode='indexed').base.function
+    eqn = Eq(a, a+3)
+    op = StencilKernel(eqn)
+    op()
+    op(a=a1)
+    op(a=a2)
+    shape = [d.size for d in [i, j, k, l]]
+
+    assert(np.allclose(a.data, np.zeros(shape) + 5))
+    assert(np.allclose(a1.data, np.zeros(shape) + 6))
+    assert(np.allclose(a2.data, np.zeros(shape) + 7))
+
+
+if __name__ == "__main__":
+    test_override(i(), j(), k(), l())

--- a/tests/test_stencil_arithmetic.py
+++ b/tests/test_stencil_arithmetic.py
@@ -157,7 +157,3 @@ def test_override(i, j, k, l):
     assert(np.allclose(a.data, np.zeros(shape) + 5))
     assert(np.allclose(a1.data, np.zeros(shape) + 6))
     assert(np.allclose(a2.data, np.zeros(shape) + 7))
-
-
-if __name__ == "__main__":
-    test_override(i(), j(), k(), l())


### PR DESCRIPTION
In response to #220 
This PR adds:
- The ability to do `op.apply(m=m1)`
- A test for this

There is one tiny caveat in this implementation though. In order to do `op.apply(m=m1)`, both `m` and `m1` need to have the same `name` property. In case this is not true, the expected syntax is `op.apply(m=m1.data)`. 
Edit: Never mind, the above has been fixed as well. `op.apply(m=m1)` would work regardless of the symbol names. 