### PR TITLE
Allow pragma to be set by env variable

### DIFF
--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -192,7 +192,7 @@ class CustomCompiler(Compiler):
         default = '-O3 -g -march=native -fPIC -mno-avx -Wall -std=c99'
         self.cflags = environ.get('CFLAGS', default).split(' ')
         self.ldflags = environ.get('LDFLAGS', '-shared').split(' ')
-        self.pragma_ivdep = [Pragma(environ.get('DEVITO_PRAGMA', 'GCC ivdep'))]
+        self.pragma_ivdep = [Pragma(environ.get('DEVITO_IVDEP', 'GCC ivdep'))]
         if self.openmp:
             self.ldflags += environ.get('OMP_LDFLAGS', '-fopenmp').split(' ')
 

--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -192,7 +192,7 @@ class CustomCompiler(Compiler):
         default = '-O3 -g -march=native -fPIC -mno-avx -Wall -std=c99'
         self.cflags = environ.get('CFLAGS', default).split(' ')
         self.ldflags = environ.get('LDFLAGS', '-shared').split(' ')
-
+        self.pragma_ivdep = [Pragma(environ.get('DEVITO_PRAGMA', 'GCC ivdep'))]
         if self.openmp:
             self.ldflags += environ.get('OMP_LDFLAGS', '-fopenmp').split(' ')
 


### PR DESCRIPTION
When using the `CustomCompiler`, the pragma used for ignoring vector dependencies is the one for the intel compiler. This change allows the pragma to be set with an environment variable.
This continues the thought behind having a compiler completely configurable by environment variables. 