### PR TITLE
`PointData` generalisation

### DIFF
--- a/devito/__init__.py
+++ b/devito/__init__.py
@@ -9,6 +9,7 @@ from devito.operator import *  # noqa
 from devito.interfaces import *  # noqa
 from devito.interfaces import _SymbolCache
 from devito.nodes import *  # noqa
+from devito.pointdata import *  # noqa
 
 
 def clear_cache():

--- a/devito/dle/transformer.py
+++ b/devito/dle/transformer.py
@@ -331,7 +331,8 @@ class Rewriter(object):
                 mapper = {tree[0]: Iteration(properties=properties, **args)}
                 nodes = Transformer(mapper).visit(nodes)
             mapper = {i: ('parallel',) for i in tree[is_OSIP:]}
-            mapper[tree[-1]] += ('vector-dim',)
+            if len(mapper) > 0:
+                mapper[tree[-1]] += ('vector-dim',)
             for i in tree[is_OSIP:]:
                 args = i.args
                 properties = as_tuple(args.pop('properties')) + mapper[i]

--- a/devito/interfaces.py
+++ b/devito/interfaces.py
@@ -592,59 +592,17 @@ class TimeData(DenseData):
         return as_finite_diff(self.diff(_t, _t), indt)
 
 
-class CoordinateData(SymbolicData):
-    """
-    Data object for sparse coordinate data that acts as a Function symbol
-    """
-
-    is_Coordinates = True
-
-    def __init__(self, *args, **kwargs):
-        if not self._cached():
-            self.name = kwargs.get('name')
-            self.ndim = kwargs.get('ndim')
-            self.npoint = kwargs.get('npoint')
-            self.shape = (self.npoint, self.ndim)
-            self.indices = self._indices(**kwargs)
-            self.dtype = kwargs.get('dtype', np.float32)
-            self.numa = kwargs.get('numa', False)
-            self._data_object = CMemory(self.shape, dtype=self.dtype)
-            self.data = self._data_object.ndpointer
-            if self.numa:
-                first_touch(self)
-            else:
-                self.data.fill(0)
-
-    def __new__(cls, *args, **kwargs):
-        ndim = kwargs.get('ndim')
-        npoint = kwargs.get('npoint')
-        kwargs['shape'] = (npoint, ndim)
-        return SymbolicData.__new__(cls, *args, **kwargs)
-
-    @classmethod
-    def _indices(cls, **kwargs):
-        """Return the default dimension indices for a given data shape
-
-        :param shape: Shape of the spatial data
-        :return: indices used for axis.
-        """
-        dimensions = kwargs.get('dimensions', None)
-        return dimensions or [p, d]
-
-
 class PointData(DenseData):
     """
     Data object for sparse point data that acts as a Function symbol
 
     :param name: Name of the resulting :class:`sympy.Function` symbol
     :param npoint: Number of points to sample
-    :param coordinates: Coordinates data for the sparse points
     :param nt: Size of the time dimension for point data
-    :param dtype: Data type of the buffered data
+    :param ndim: Dimension of the coordinate data
+    :param coordinates: Optional coordinate data for the sparse points
 
-    Note: This class is expected to eventually evolve into a
-    full-fledged sparse data container. For now, the naming and
-    symbolic behaviour follows the use in the current problem.
+    :param dtype: Data type of the buffered data
     """
 
     is_PointData = True
@@ -653,15 +611,15 @@ class PointData(DenseData):
         if not self._cached():
             self.nt = kwargs.get('nt')
             self.npoint = kwargs.get('npoint')
-            ndim = kwargs.get('ndim')
+            self.ndim = kwargs.get('ndim')
             kwargs['shape'] = (self.nt, self.npoint)
             super(PointData, self).__init__(self, *args, **kwargs)
-            coordinates = kwargs.get('coordinates')
-            self.coordinates = CoordinateData(name='%s_coords' % self.name,
-                                              dimensions=[self.indices[1], d],
-                                              data=coordinates, ndim=ndim,
-                                              nt=self.nt, npoint=self.npoint)
-            self.coordinates.data[:] = kwargs.get('coordinates')[:]
+            self.coordinates = DenseData(name='%s_coords' % self.name,
+                                         dimensions=[self.indices[1], d],
+                                         shape=(self.npoint, self.ndim))
+            coordinates = kwargs.get('coordinates', None)
+            if coordinates is not None:
+                self.coordinates.data[:] = coordinates[:]
 
     def __new__(cls, *args, **kwargs):
         nt = kwargs.get('nt')

--- a/devito/interfaces.py
+++ b/devito/interfaces.py
@@ -4,7 +4,7 @@ import numpy as np
 from sympy import Function, IndexedBase, Symbol, as_finite_diff, symbols
 from sympy.abc import h, s
 
-from devito.dimension import d, p, t, x, y, z, time
+from devito.dimension import t, x, y, z, time
 from devito.finite_difference import (centered, cross_derivative,
                                       first_derivative, left, right,
                                       second_derivative)
@@ -12,7 +12,7 @@ from devito.logger import debug, error
 from devito.memmap_manager import MemmapManager
 from devito.memory import CMemory, first_touch
 
-__all__ = ['DenseData', 'TimeData', 'PointData', 'Forward', 'Backward']
+__all__ = ['DenseData', 'TimeData', 'Forward', 'Backward']
 
 
 # This cache stores a reference to each created data object
@@ -590,53 +590,6 @@ class TimeData(DenseData):
         indt = [(_t + i * s) for i in range(-width_t, width_t + 1)]
 
         return as_finite_diff(self.diff(_t, _t), indt)
-
-
-class PointData(DenseData):
-    """
-    Data object for sparse point data that acts as a Function symbol
-
-    :param name: Name of the resulting :class:`sympy.Function` symbol
-    :param npoint: Number of points to sample
-    :param nt: Size of the time dimension for point data
-    :param ndim: Dimension of the coordinate data
-    :param coordinates: Optional coordinate data for the sparse points
-
-    :param dtype: Data type of the buffered data
-    """
-
-    is_PointData = True
-
-    def __init__(self, *args, **kwargs):
-        if not self._cached():
-            self.nt = kwargs.get('nt')
-            self.npoint = kwargs.get('npoint')
-            self.ndim = kwargs.get('ndim')
-            kwargs['shape'] = (self.nt, self.npoint)
-            super(PointData, self).__init__(self, *args, **kwargs)
-            self.coordinates = DenseData(name='%s_coords' % self.name,
-                                         dimensions=[self.indices[1], d],
-                                         shape=(self.npoint, self.ndim))
-            coordinates = kwargs.get('coordinates', None)
-            if coordinates is not None:
-                self.coordinates.data[:] = coordinates[:]
-
-    def __new__(cls, *args, **kwargs):
-        nt = kwargs.get('nt')
-        npoint = kwargs.get('npoint')
-        kwargs['shape'] = (nt, npoint)
-
-        return DenseData.__new__(cls, *args, **kwargs)
-
-    @classmethod
-    def _indices(cls, **kwargs):
-        """Return the default dimension indices for a given data shape
-
-        :param shape: Shape of the spatial data
-        :return: indices used for axis.
-        """
-        dimensions = kwargs.get('dimensions', None)
-        return dimensions or [t, p]
 
 
 class IndexedData(IndexedBase):

--- a/devito/memory.py
+++ b/devito/memory.py
@@ -73,8 +73,9 @@ def first_touch(array):
     in the same pattern that would later be used to access it.
     """
     from devito.propagator import Propagator
-    from devito.interfaces import TimeData, PointData
+    from devito.interfaces import TimeData
     from devito.nodes import Iteration
+    from devito.pointdata import PointData
 
     exp_init = [Eq(array.indexed[array.indices], 0)]
     it_init = []

--- a/devito/pointdata.py
+++ b/devito/pointdata.py
@@ -192,5 +192,5 @@ class PointData(DenseData):
         # Substitute coordinate base symbols into the coefficients
         subs = OrderedDict(zip(self.point_symbols, self.coordinate_bases))
         return [Eq(field.subs(vsub),
-                   field.subs(vsub) + expr.subs(subs) * b.subs(subs))
+                   field.subs(vsub) + expr.subs(subs).subs(vsub) * b.subs(subs))
                 for b, vsub in zip(self.coefficients, idx_subs)]

--- a/devito/pointdata.py
+++ b/devito/pointdata.py
@@ -27,7 +27,6 @@ class PointData(DenseData):
     def __init__(self, *args, **kwargs):
         if not self._cached():
             self.nt = kwargs.get('nt')
-            self.h = kwargs.get('h')
             self.npoint = kwargs.get('npoint')
             self.ndim = kwargs.get('ndim')
             kwargs['shape'] = (self.nt, self.npoint)
@@ -104,7 +103,7 @@ class PointData(DenseData):
                   "%d dimensions." % self.ndim)
 
         # Map to reference cell
-        reference_cell = {x1: 0, y1: 0, z1: 0, x2: self.h, y2: self.h, z2: self.h}
+        reference_cell = {x1: 0, y1: 0, z1: 0, x2: h, y2: h, z2: h}
         A = A.subs(reference_cell)
         return A.inv().T.dot(p)
 
@@ -132,13 +131,13 @@ class PointData(DenseData):
     @property
     def coordinate_indices(self):
         """Symbol for each grid index according to the coordinates"""
-        return tuple([Function('INT')(Function('floor')(x / self.h))
+        return tuple([Function('INT')(Function('floor')(x / h))
                       for x in self.coordinate_symbols])
 
     @property
     def coordinate_bases(self):
         """Symbol for the base coordinates of the reference grid point"""
-        return tuple([Function('FLOAT')(x - idx * self.h)
+        return tuple([Function('FLOAT')(x - idx * h)
                       for x, idx in zip(self.coordinate_symbols,
                                         self.coordinate_indices)])
 

--- a/devito/pointdata.py
+++ b/devito/pointdata.py
@@ -1,0 +1,51 @@
+from devito.dimension import d, p, t
+from devito.interfaces import DenseData
+
+__all__ = ['PointData']
+
+
+class PointData(DenseData):
+    """
+    Data object for sparse point data that acts as a Function symbol
+
+    :param name: Name of the resulting :class:`sympy.Function` symbol
+    :param npoint: Number of points to sample
+    :param nt: Size of the time dimension for point data
+    :param ndim: Dimension of the coordinate data
+    :param coordinates: Optional coordinate data for the sparse points
+
+    :param dtype: Data type of the buffered data
+    """
+
+    is_PointData = True
+
+    def __init__(self, *args, **kwargs):
+        if not self._cached():
+            self.nt = kwargs.get('nt')
+            self.npoint = kwargs.get('npoint')
+            self.ndim = kwargs.get('ndim')
+            kwargs['shape'] = (self.nt, self.npoint)
+            super(PointData, self).__init__(self, *args, **kwargs)
+            self.coordinates = DenseData(name='%s_coords' % self.name,
+                                         dimensions=[self.indices[1], d],
+                                         shape=(self.npoint, self.ndim))
+            coordinates = kwargs.get('coordinates', None)
+            if coordinates is not None:
+                self.coordinates.data[:] = coordinates[:]
+
+    def __new__(cls, *args, **kwargs):
+        nt = kwargs.get('nt')
+        npoint = kwargs.get('npoint')
+        kwargs['shape'] = (nt, npoint)
+
+        return DenseData.__new__(cls, *args, **kwargs)
+
+    @classmethod
+    def _indices(cls, **kwargs):
+        """Return the default dimension indices for a given data shape
+
+        :param shape: Shape of the spatial data
+        :return: indices used for axis.
+        """
+        dimensions = kwargs.get('dimensions', None)
+        return dimensions or [t, p]

--- a/devito/pointdata.py
+++ b/devito/pointdata.py
@@ -182,11 +182,12 @@ class PointData(DenseData):
                               in zip(inc, self.coordinate_indices))
                         for inc in self.point_increments]
 
-        # Generate index substituions for all grid variables
+        # Generate index substituions for all grid variables except
+        # the sparse `PointData` types
         idx_subs = []
         for i, idx in enumerate(index_matrix):
             v_subs = [(v, v.base[v.indices[:-self.ndim] + idx])
-                      for v in variables]
+                      for v in variables if not v.base.function.is_PointData]
             idx_subs += [OrderedDict(v_subs)]
 
         # Substitute coordinate base symbols into the coefficients

--- a/devito/pointdata.py
+++ b/devito/pointdata.py
@@ -99,8 +99,10 @@ class PointData(DenseData):
                         [py*pz],
                         [px*py*pz]])
         else:
-            error("Interpolation coefficients not implemented for "
-                  "%d dimensions." % self.ndim)
+            error('Point interpolation only supported for 2D and 3D')
+            raise NotImplementedError('Interpolation coefficients not '
+                                      'implemented for %d dimensions.'
+                                      % self.ndim)
 
         # Map to reference cell
         reference_cell = {x1: 0, y1: 0, z1: 0, x2: h, y2: h, z2: h}
@@ -120,6 +122,10 @@ class PointData(DenseData):
         elif self.ndim == 3:
             return ((0, 0, 0), (0, 1, 0), (1, 0, 0), (0, 0, 1),
                     (1, 1, 0), (0, 1, 1), (1, 0, 1), (1, 1, 1))
+        else:
+            error('Point interpolation only supported for 2D and 3D')
+            raise NotImplementedError('Point increments not defined '
+                                      'for %d dimensions.' % self.ndim)
 
     @property
     def coordinate_symbols(self):

--- a/examples/source_type.py
+++ b/examples/source_type.py
@@ -1,8 +1,6 @@
 from sympy import Eq, Function, Matrix, symbols
 
-from devito.dimension import t
-from devito.interfaces import PointData, DenseData
-from devito.nodes import Iteration
+from devito import Iteration, DenseData, PointData, t
 
 
 class SourceLike(PointData):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -25,7 +25,7 @@ def dims():
             'j': Dimension(name='j', size=5),
             'k': Dimension(name='k', size=7),
             's': Dimension(name='s', size=4),
-            'p': Dimension(name='p', size=4)}
+            'q': Dimension(name='q', size=4)}
 
 
 @pytest.fixture(scope="session")
@@ -34,7 +34,7 @@ def iters(dims):
             lambda ex: Iteration(ex, dims['j'], (0, 5, 1)),
             lambda ex: Iteration(ex, dims['k'], (0, 7, 1)),
             lambda ex: Iteration(ex, dims['s'], (0, 4, 1)),
-            lambda ex: Iteration(ex, dims['p'], (0, 4, 1))]
+            lambda ex: Iteration(ex, dims['q'], (0, 4, 1))]
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -84,5 +84,5 @@ def d(dims):
 
 @pytest.fixture(scope="session", autouse=True)
 def e(dims):
-    dimensions = [dims['k'], dims['s'], dims['p'], dims['i'], dims['j']]
+    dimensions = [dims['k'], dims['s'], dims['q'], dims['i'], dims['j']]
     return tensorfunction('e', (7, 4, 4, 3, 5), dimensions).indexify()

--- a/tests/test_declarator.py
+++ b/tests/test_declarator.py
@@ -103,14 +103,14 @@ def test_stack_vector_temporaries(c_stack, e):
   {
     for (int s = 0; s < 4; s += 1)
     {
-      for (int p = 0; p < 4; p += 1)
+      for (int q = 0; q < 4; q += 1)
       {
         double c_stack[3][5] __attribute__((aligned(64)));
         for (int i = 0; i < 3; i += 1)
         {
           for (int j = 0; j < 5; j += 1)
           {
-            c_stack[i][j] = 1.0F*e[k][s][p][i][j];
+            c_stack[i][j] = 1.0F*e[k][s][q][i][j];
           }
         }
       }

--- a/tests/test_dle.py
+++ b/tests/test_dle.py
@@ -221,7 +221,7 @@ void f_0_2(float *restrict a_vec, float *restrict b_vec, const int i)
 {
   float (*restrict a) __attribute__((aligned(64))) = (float (*)) a_vec;
   float (*restrict b) __attribute__((aligned(64))) = (float (*)) b_vec;
-  for (int p = 0; p < 4; p += 1)
+  for (int q = 0; q < 4; q += 1)
   {
     a[i] = 8.0F*a[i] + 6.0F/b[i];
   }

--- a/tests/test_point_data.py
+++ b/tests/test_point_data.py
@@ -3,8 +3,7 @@ import pytest
 from sympy import Eq
 from sympy.abc import h
 
-from devito import Operator, DenseData, PointData, TimeData, t
-from examples.source_type import SourceLike
+from devito import Operator, DenseData, PointData
 
 
 @pytest.fixture
@@ -21,8 +20,8 @@ def points(npoints=20):
     x = np.linspace(.05, .9, npoints)
     y = np.linspace(.01, .8, npoints)
     coords = np.concatenate((x, y)).reshape(npoints, 2)
-    return SourceLike(name='points', nt=1, npoint=npoints,
-                      ndim=2, coordinates=coords, h=0.1, nbpml=0)
+    return PointData(name='points', nt=1, npoint=npoints,
+                     ndim=2, coordinates=coords)
 
 
 @pytest.fixture
@@ -30,8 +29,8 @@ def points_horizontal(npoints=19, ycoord=0.45):
     coords = np.empty((npoints, 2), dtype=np.float32)
     coords[:, 0] = np.linspace(.05, .95, npoints)
     coords[:, 1] = ycoord
-    return SourceLike(name='points', nt=1, npoint=npoints,
-                      ndim=2, coordinates=coords, h=0.1, nbpml=0)
+    return PointData(name='points', nt=1, npoint=npoints,
+                     ndim=2, coordinates=coords)
 
 
 def test_interpolate_2d(a, points):

--- a/tests/test_point_data.py
+++ b/tests/test_point_data.py
@@ -1,0 +1,36 @@
+import numpy as np
+import pytest
+from sympy import Eq
+from sympy.abc import h
+
+from devito import Operator, DenseData, PointData, TimeData, t
+from examples.source_type import SourceLike
+
+
+@pytest.fixture
+def a(shape=(11, 11)):
+    x = np.linspace(0., 1., shape[0])
+    y = np.linspace(0., 1., shape[1])
+    a = DenseData(name='a', shape=shape)
+    a.data[:] = np.meshgrid(x, y)[1]
+    return a
+
+
+@pytest.fixture
+def points(npoints=20):
+    x = np.linspace(.05, .9, npoints)
+    y = np.linspace(.01, .8, npoints)
+    coords = np.concatenate((x, y)).reshape(npoints, 2)
+    return SourceLike(name='points', nt=1, npoint=npoints,
+                      ndim=2, coordinates=coords, h=0.1, nbpml=0)
+
+
+def test_interpolate_2d(a, points):
+    """Test generic point interpolation testing the x-coordinate of an
+    abitrary set of points going across the grid.
+    """
+    spacing = a.data[1, 1]
+    xcoords = points.coordinates.data[:, 0]
+    expr = Eq(points, points.interpolate(a))
+    Operator(expr, subs={h: spacing})(t=1)
+    assert np.allclose(points.data, xcoords, rtol=1e-7)

--- a/tests/test_point_data.py
+++ b/tests/test_point_data.py
@@ -1,6 +1,6 @@
 import numpy as np
 import pytest
-from sympy import Eq
+from sympy import Eq, Function
 from sympy.abc import h
 
 from devito import Operator, DenseData, PointData
@@ -52,6 +52,6 @@ def test_inject_2d(a, points_horizontal):
     points = points_horizontal
     spacing = a.data[1, 1]
     a.data[:] = 0.
-    expr = Eq(points, points.inject(1.))
+    expr = points.inject(a, Function('FLOAT')(1.))
     Operator(expr, dse=None, dle=None, subs={h: spacing})(t=1)
     assert np.allclose(a.data[1:-1, 4:6], 1., rtol=1.e-6)

--- a/tests/test_point_data.py
+++ b/tests/test_point_data.py
@@ -15,56 +15,82 @@ def a(shape=(11, 11)):
     return a
 
 
-@pytest.fixture
-def points(npoints=20):
-    x = np.linspace(.05, .9, npoints)
-    y = np.linspace(.01, .8, npoints)
-    coords = np.concatenate((x, y)).reshape(npoints, 2)
-    return PointData(name='points', nt=1, npoint=npoints,
-                     ndim=2, coordinates=coords)
+def unit_box(name='a', shape=(11, 11)):
+    """Create a field with value 0. to 1. in each dimension"""
+    a = DenseData(name='a', shape=shape)
+    dims = tuple([np.linspace(0., 1., d) for d in shape])
+    a.data[:] = np.meshgrid(*dims)[1]
+    return a
 
 
-@pytest.fixture
-def points_horizontal(npoints=19, ycoord=0.45):
-    coords = np.empty((npoints, 2), dtype=np.float32)
-    coords[:, 0] = np.linspace(.05, .95, npoints)
-    coords[:, 1] = ycoord
-    return PointData(name='points', nt=1, npoint=npoints,
-                     ndim=2, coordinates=coords)
+def points(ranges, npoints):
+    """Create a set of sparse points from a set of coordinate
+    ranges for each spatial dimension.
+    """
+    points = PointData(name='points', nt=1, npoint=npoints, ndim=len(ranges))
+    for i, r in enumerate(ranges):
+        points.coordinates.data[:, i] = np.linspace(r[0], r[1], npoints)
+    return points
 
 
-def test_interpolate_2d(a, points):
+@pytest.mark.parametrize('shape, coords', [
+    ((11, 11), [(.05, .9), (.01, .8)]),
+    ((11, 11, 11), [(.05, .9), (.01, .8), (0.07, 0.84)])
+])
+def test_interpolate(shape, coords, npoints=20):
     """Test generic point interpolation testing the x-coordinate of an
     abitrary set of points going across the grid.
     """
-    spacing = a.data[1, 1]
-    xcoords = points.coordinates.data[:, 0]
-    expr = Eq(points, points.interpolate(a))
-    Operator(expr, subs={h: spacing})(t=1)
-    assert np.allclose(points.data, xcoords, rtol=1e-7)
+    a = unit_box(shape=shape)
+    spacing = a.data[tuple([1 for _ in shape])]
+    p = points(coords, npoints=npoints)
+    xcoords = p.coordinates.data[:, 0]
+
+    expr = Eq(p, p.interpolate(a))
+    Operator(expr, subs={h: spacing})(a=a, t=1)
+
+    assert np.allclose(p.data[0, :], xcoords, rtol=1e-6)
 
 
-def test_inject_2d(a, points_horizontal):
+@pytest.mark.parametrize('shape, coords, result', [
+    ((11, 11), [(.05, .95), (.45, .45)], 1.),
+    ((11, 11, 11), [(.05, .95), (.45, .45), (.45, .45)], 0.5)
+])
+def test_inject(shape, coords, result, npoints=19):
     """Test point injection with a set of points forming a line
     through the middle of the grid.
     """
-    points = points_horizontal
-    spacing = a.data[1, 1]
+    a = unit_box(shape=shape)
+    spacing = a.data[tuple([1 for _ in shape])]
     a.data[:] = 0.
-    expr = points.inject(a, Function('FLOAT')(1.))
-    Operator(expr, dse=None, dle=None, subs={h: spacing})(t=1)
-    assert np.allclose(a.data[1:-1, 4:6], 1., rtol=1.e-6)
+    p = points(ranges=coords, npoints=npoints)
+
+    expr = p.inject(a, Function('FLOAT')(1.))
+    Operator(expr, subs={h: spacing})(a=a, t=1)
+
+    indices = [slice(4, 6, 1) for _ in coords]
+    indices[0] = slice(1, -1, 1)
+    assert np.allclose(a.data[indices], result, rtol=1.e-5)
 
 
-def test_inject_from_field_2d(a, points_horizontal):
+@pytest.mark.parametrize('shape, coords, result', [
+    ((11, 11), [(.05, .95), (.45, .45)], 1.),
+    ((11, 11, 11), [(.05, .95), (.45, .45), (.45, .45)], 0.5)
+])
+def test_inject_from_field(shape, coords, result, npoints=19):
     """Test point injection from a second field along a line
     through the middle of the grid.
     """
-    points = points_horizontal
-    spacing = a.data[1, 1]
+    a = unit_box(shape=shape)
+    spacing = a.data[tuple([1 for _ in shape])]
+    a.data[:] = 0.
     b = DenseData(name='b', shape=a.data.shape)
-    b.data[:] = 0.
-    expr = points.inject(field=b, expr=a)
-    StencilKernel(expr, dse=None, dle=None, subs={h: spacing})(t=1)
-    assert np.allclose(a.data[1:-1, 4], np.arange(.1, 1., 0.1), rtol=1.e-6)
-    assert np.allclose(a.data[1:-1, 5], np.arange(.1, 1., 0.1), rtol=1.e-6)
+    b.data[:] = 1.
+    p = points(ranges=coords, npoints=npoints)
+
+    expr = p.inject(field=a, expr=b)
+    Operator(expr, subs={h: spacing})(a=a, b=b, t=1)
+
+    indices = [slice(4, 6, 1) for _ in coords]
+    indices[0] = slice(1, -1, 1)
+    assert np.allclose(a.data[indices], result, rtol=1.e-5)

--- a/tests/test_point_data.py
+++ b/tests/test_point_data.py
@@ -48,10 +48,23 @@ def test_inject_2d(a, points_horizontal):
     """Test point injection with a set of points forming a line
     through the middle of the grid.
     """
-    np.set_printoptions(precision=10, linewidth=200)
     points = points_horizontal
     spacing = a.data[1, 1]
     a.data[:] = 0.
     expr = points.inject(a, Function('FLOAT')(1.))
     Operator(expr, dse=None, dle=None, subs={h: spacing})(t=1)
     assert np.allclose(a.data[1:-1, 4:6], 1., rtol=1.e-6)
+
+
+def test_inject_from_field_2d(a, points_horizontal):
+    """Test point injection from a second field along a line
+    through the middle of the grid.
+    """
+    points = points_horizontal
+    spacing = a.data[1, 1]
+    b = DenseData(name='b', shape=a.data.shape)
+    b.data[:] = 0.
+    expr = points.inject(field=b, expr=a)
+    StencilKernel(expr, dse=None, dle=None, subs={h: spacing})(t=1)
+    assert np.allclose(a.data[1:-1, 4], np.arange(.1, 1., 0.1), rtol=1.e-6)
+    assert np.allclose(a.data[1:-1, 5], np.arange(.1, 1., 0.1), rtol=1.e-6)

--- a/tests/test_point_data.py
+++ b/tests/test_point_data.py
@@ -25,6 +25,15 @@ def points(npoints=20):
                       ndim=2, coordinates=coords, h=0.1, nbpml=0)
 
 
+@pytest.fixture
+def points_horizontal(npoints=19, ycoord=0.45):
+    coords = np.empty((npoints, 2), dtype=np.float32)
+    coords[:, 0] = np.linspace(.05, .95, npoints)
+    coords[:, 1] = ycoord
+    return SourceLike(name='points', nt=1, npoint=npoints,
+                      ndim=2, coordinates=coords, h=0.1, nbpml=0)
+
+
 def test_interpolate_2d(a, points):
     """Test generic point interpolation testing the x-coordinate of an
     abitrary set of points going across the grid.
@@ -34,3 +43,16 @@ def test_interpolate_2d(a, points):
     expr = Eq(points, points.interpolate(a))
     Operator(expr, subs={h: spacing})(t=1)
     assert np.allclose(points.data, xcoords, rtol=1e-7)
+
+
+def test_inject_2d(a, points_horizontal):
+    """Test point injection with a set of points forming a line
+    through the middle of the grid.
+    """
+    np.set_printoptions(precision=10, linewidth=200)
+    points = points_horizontal
+    spacing = a.data[1, 1]
+    a.data[:] = 0.
+    expr = Eq(points, points.inject(1.))
+    Operator(expr, dse=None, dle=None, subs={h: spacing})(t=1)
+    assert np.allclose(a.data[1:-1, 4:6], 1., rtol=1.e-6)

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -80,7 +80,7 @@ def test_printAST(block1, block2, block3):
     <Iteration k::k::[0, 7, 1]::[0, 0]>
       <Expression a[i] = -a[i] + b[i]>
       <Expression a[i] = 4*a[i]*b[i]>
-  <Iteration p::p::[0, 4, 1]::[0, 0]>
+  <Iteration q::q::[0, 4, 1]::[0, 0]>
     <Expression a[i] = 8.0*a[i] + 6.0/b[i]>
 """
 


### PR DESCRIPTION
This merge moves the `PointData` class into it's own sub-module and provides an explicit API for supporting `point.interpolate(expr)` and `point.inject(expr)` methods to perform sparse-point interpolation of custom user-defined expressions in and out of grid variables. This is a pre-requisite for providing more general source/receiver terms in our seismic examples. 

Note, the merge does not yet integrate this new API with our actual examples, since there is more required to make this shine (to come in a separate PR). The current test set is also limited, in that it only interpolates the expression "1" at the moment. Input with more advanced expressions and their analytical solutions would be greatly appreciated.

Other details in this PR:
* We now store the sparse point coordinates as plan `DenseData` objects, removing the previous `CoordinateData` class.
* Moved `PointData` to it's own sub-module, since all it contains is the automated symbolic derivation of the interpolation expressions, which is conceptually quite far removed from the rest of things residing in `interfaces.py`.
* A small DLE bug-fix to avoid access to an empty `mapper` dict