### PR TITLE
Fix wrong size inferred for buffered dimension

### DIFF
--- a/devito/stencilkernel.py
+++ b/devito/stencilkernel.py
@@ -161,13 +161,15 @@ class OperatorBasic(Function):
                     else:
                         # Derive size from grid data shape and store
                         dim_sizes[dim] = shape[i]
-
-                    # Ensure parent for buffered dims is defined
-                    if dim.is_Buffered and dim.parent not in dim_sizes:
-                        dim_sizes[dim.parent] = dim_sizes[dim]
                 else:
                     if not isinstance(dim, BufferedDimension):
                         assert dim.size == shape[i]
+
+        # Ensure parent for buffered dims is defined
+        buf_dims = [d for d in dim_sizes if d.is_Buffered]
+        for dim in buf_dims:
+            if dim.parent not in dim_sizes:
+                dim_sizes[dim.parent] = dim_sizes[dim]
 
         # Add user-provided block sizes, if any
         dle_arguments = OrderedDict()

--- a/devito/stencilkernel.py
+++ b/devito/stencilkernel.py
@@ -133,7 +133,7 @@ class OperatorBasic(Function):
         r_args = [f_n for f_n, f in arguments.items() if isinstance(f, SymbolicData)]
         o_vals = OrderedDict([arg for arg in kwargs.items() if arg[0] in r_args])
 
-        # Replace the over-ridden values with the provided ones
+        # Replace the overridden values with the provided ones
         for argname in o_vals.keys():
             if not arguments[argname].shape == o_vals[argname].shape:
                 raise InvalidArgument("Shapes must match")

--- a/examples/acoustic/Acoustic_codegen.py
+++ b/examples/acoustic/Acoustic_codegen.py
@@ -237,7 +237,7 @@ class Acoustic_cg(object):
         u = TimeData(name="u", shape=self.model.shape_domain, time_dim=nt,
                      time_order=2, space_order=self.s_order,
                      dtype=self.model.dtype)
-        U = TimeData(name="ul", shape=self.model.shape_domain, time_dim=nt,
+        U = TimeData(name="U", shape=self.model.shape_domain, time_dim=nt,
                      time_order=2, space_order=self.s_order,
                      dtype=self.model.dtype)
 


### PR DESCRIPTION
Issue #228 points out a case where changing the name of a `SymbolicData` object changes the order in which dimension sizes are inferred and this causes the size of the `time` dimension to be inferred incorrectly. 

This was being caused because of the way sizes are being inferred. Particularly, when a `BufferedDimension` is encountered, a parent dimension was [added](https://github.com/opesci/devito/blob/master/devito/stencilkernel.py#L166) to the list of `Dimension`s if not already present. This last condition introduced a requirement on the order in which the `Dimension`s are presented to this loop since if the parent `Dimension` appears later in the list of dimensions, its size would already be set by the child `Dimension` and its real size would never be captured. 

This PR fixes that by moving the check for parent dimension sizes outside the loop that traverses the stencil expression. This way, we have ensured that the entire expression has been checked for the presence of the parent `Dimension`. 

Caveat: This PR introduces an extra loop of the order of the number of dimensions in the expression but removes the dependency on the ordering of the dimensions.
