### PR TITLE
Global configuration

### DIFF
--- a/devito/__init__.py
+++ b/devito/__init__.py
@@ -10,6 +10,7 @@ from devito.interfaces import *  # noqa
 from devito.interfaces import _SymbolCache
 from devito.nodes import *  # noqa
 from devito.pointdata import *  # noqa
+from devito.parameters import * # noqa
 
 
 def clear_cache():

--- a/devito/logger.py
+++ b/devito/logger.py
@@ -3,6 +3,7 @@
 import logging
 import sys
 from contextlib import contextmanager
+from devito.parameters import parameters
 
 __all__ = ('set_log_level', 'set_log_noperf', 'log',
            'DEBUG', 'INFO', 'AUTOTUNER', 'DSE', 'DSE_WARN', 'DLE', 'DLE_WARN',
@@ -34,7 +35,8 @@ logging.addLevelName(DSE_WARN, "DSE_WARN")
 logging.addLevelName(DSE, "DLE")
 logging.addLevelName(DSE_WARN, "DLE_WARN")
 
-logger.setLevel(INFO)
+init_log_level = eval(parameters["log_level"])
+logger.setLevel(init_log_level)
 
 NOCOLOR = '%s'
 RED = '\033[1;37;31m%s\033[0m'

--- a/devito/logger.py
+++ b/devito/logger.py
@@ -17,6 +17,14 @@ logger = logging.getLogger('Devito')
 _ch = logging.StreamHandler()
 logger.addHandler(_ch)
 
+log_level = "log_level"
+
+
+def parameters_updated(key, value):
+    if key == log_level:
+        logger.setLevel(eval(value))
+
+
 # Add extra levels between INFO (value=20) and WARNING (value=30)
 DEBUG = logging.DEBUG
 AUTOTUNER = 19
@@ -35,8 +43,8 @@ logging.addLevelName(DSE_WARN, "DSE_WARN")
 logging.addLevelName(DSE, "DLE")
 logging.addLevelName(DSE_WARN, "DLE_WARN")
 
-init_log_level = eval(parameters["log_level"])
-logger.setLevel(init_log_level)
+parameters_updated(log_level, parameters[log_level])
+parameters.update_functions.append(parameters_updated)
 
 NOCOLOR = '%s'
 RED = '\033[1;37;31m%s\033[0m'

--- a/devito/parameters.py
+++ b/devito/parameters.py
@@ -1,0 +1,40 @@
+"""The parameters dictionary contains global parameter settings."""
+
+__all__ = ['Parameters', 'parameters']
+
+# Be EXTREMELY careful when writing to a Parameters dictionary
+# Read here for reference: http://wiki.c2.com/?GlobalVariablesAreBad
+# If any issues related to global state arise, the following class should
+# be made immutable. It shall only be written to at application startup
+# and never modified. 
+
+class Parameters(dict):
+    """ A dictionary-like class to hold global configuration parameters for devito
+        On top of a normal dict, this provides the option to provide callback functions
+        so that any interested module can be informed when the configuration changes. 
+    """
+    def __init__(self, name=None, **kwargs):
+        self._name = name
+        self.update_functions = None
+
+        for key, value in iteritems(kwargs):
+            self[key] = value
+
+    def __setitem__(self, key, value):
+        super(Parameters, self).__setitem__(key, value)
+
+        # If a Parameters dictionary is being added as a child,
+        # ask it to tell us when it is updated
+        
+        if isinstance(value, Parameters):
+            child_update = lambda x: self._updated(*x)
+            value.update_functions.push(child_update) 
+
+        # Tell everyone we've been updated
+        self._updated(key, value)
+
+    def _updated(self, key, value):
+        """ Call any provided update functions so everyone knows we've been updated
+        """
+        for f in self.update_functions:
+            f(key, value)

--- a/devito/parameters.py
+++ b/devito/parameters.py
@@ -7,29 +7,30 @@ __all__ = ['Parameters', 'parameters']
 # https://softwareengineering.stackexchange.com/questions/148108/why-is-global-state-so-evil
 # If any issues related to global state arise, the following class should
 # be made immutable. It shall only be written to at application startup
-# and never modified. 
+# and never modified.
+
 
 class Parameters(dict):
     """ A dictionary-like class to hold global configuration parameters for devito
         On top of a normal dict, this provides the option to provide callback functions
-        so that any interested module can be informed when the configuration changes. 
+        so that any interested module can be informed when the configuration changes.
     """
     def __init__(self, name=None, **kwargs):
         self._name = name
-        self.update_functions = None
-
-        for key, value in iteritems(kwargs):
-            self[key] = value
+        self.update_functions = []
+        if kwargs is not None:
+            for key, value in kwargs.items():
+                self[key] = value
 
     def __setitem__(self, key, value):
         super(Parameters, self).__setitem__(key, value)
 
         # If a Parameters dictionary is being added as a child,
         # ask it to tell us when it is updated
-        
+
         if isinstance(value, Parameters):
             child_update = lambda x: self._updated(*x)
-            value.update_functions.push(child_update) 
+            value.update_functions.push(child_update)
 
         # Tell everyone we've been updated
         self._updated(key, value)
@@ -40,5 +41,7 @@ class Parameters(dict):
         for f in self.update_functions:
             f(key, value)
 
+
 parameters = Parameters()
-parameters["log_level"] = 'info'
+# Default log level set to INFO
+parameters["log_level"] = 'INFO'

--- a/devito/parameters.py
+++ b/devito/parameters.py
@@ -4,6 +4,7 @@ __all__ = ['Parameters', 'parameters']
 
 # Be EXTREMELY careful when writing to a Parameters dictionary
 # Read here for reference: http://wiki.c2.com/?GlobalVariablesAreBad
+# https://softwareengineering.stackexchange.com/questions/148108/why-is-global-state-so-evil
 # If any issues related to global state arise, the following class should
 # be made immutable. It shall only be written to at application startup
 # and never modified. 
@@ -38,3 +39,6 @@ class Parameters(dict):
         """
         for f in self.update_functions:
             f(key, value)
+
+parameters = Parameters()
+parameters["log_level"] = 'info'

--- a/devito/parameters.py
+++ b/devito/parameters.py
@@ -30,7 +30,7 @@ class Parameters(dict):
 
         if isinstance(value, Parameters):
             child_update = lambda x: self._updated(*x)
-            value.update_functions.push(child_update)
+            value.update_functions.append(child_update)
 
         # Tell everyone we've been updated
         self._updated(key, value)

--- a/examples/acoustic/Acoustic_codegen.py
+++ b/examples/acoustic/Acoustic_codegen.py
@@ -15,7 +15,7 @@ class Acoustic_cg(object):
 
     Note: s_order must always be greater than t_order
     """
-    def __init__(self, model, source, nbpml=40, t_order=2, s_order=2,
+    def __init__(self, model, data, source, nbpml=40, t_order=2, s_order=2,
                  auto_tuning=False, dse=True, dle='advanced', compiler=None):
         self.model = model
         self.t_order = t_order
@@ -101,7 +101,7 @@ class Acoustic_cg(object):
                      dtype=self.model.dtype)
 
         # Execute operator and return wavefield and receiver data
-        adj = AdjointOperator(self.model, v, srca, rec, 
+        adj = AdjointOperator(self.model, v, srca, rec,
                               time_order=self.t_order, spc_order=self.s_order,
                               cache_blocking=cache_blocking, dse=dse,
                               dle=dle, compiler=compiler, profile=True)

--- a/examples/acoustic/Acoustic_codegen.py
+++ b/examples/acoustic/Acoustic_codegen.py
@@ -15,7 +15,7 @@ class Acoustic_cg(object):
 
     Note: s_order must always be greater than t_order
     """
-    def __init__(self, model, data, source, nbpml=40, t_order=2, s_order=2,
+    def __init__(self, model, source, nbpml=40, t_order=2, s_order=2,
                  auto_tuning=False, dse=True, dle='advanced', compiler=None):
         self.model = model
         self.t_order = t_order
@@ -62,7 +62,7 @@ class Acoustic_cg(object):
             u.data[0:3, :] = u_ini[:]
 
         # Execute operator and return wavefield and receiver data
-        fw = ForwardOperator(self.model, u, src, rec, self.data,
+        fw = ForwardOperator(self.model, u, src, rec,
                              time_order=self.t_order, spc_order=self.s_order,
                              save=save, cache_blocking=cache_blocking, dse=dse,
                              dle=dle, compiler=compiler, profile=True, u_ini=u_ini)
@@ -101,7 +101,7 @@ class Acoustic_cg(object):
                      dtype=self.model.dtype)
 
         # Execute operator and return wavefield and receiver data
-        adj = AdjointOperator(self.model, v, srca, rec, self.data,
+        adj = AdjointOperator(self.model, v, srca, rec, 
                               time_order=self.t_order, spc_order=self.s_order,
                               cache_blocking=cache_blocking, dse=dse,
                               dle=dle, compiler=compiler, profile=True)
@@ -138,7 +138,7 @@ class Acoustic_cg(object):
                      dtype=self.model.dtype)
 
         # Execute operator and return wavefield and receiver data
-        gradop = GradientOperator(self.model, v, grad, rec, u, self.data,
+        gradop = GradientOperator(self.model, v, grad, rec, u,
                                   time_order=self.t_order, spc_order=self.s_order,
                                   cache_blocking=cache_blocking, dse=dse,
                                   dle=dle, compiler=compiler, profile=True)
@@ -185,7 +185,7 @@ class Acoustic_cg(object):
         else:
             dm = dmin
         # Execute operator and return wavefield and receiver data
-        born = BornOperator(self.model, u, U, src, rec, dm, self.data,
+        born = BornOperator(self.model, u, U, src, rec, dm,
                             time_order=self.t_order, spc_order=self.s_order,
                             cache_blocking=cache_blocking, dse=dse,
                             dle=dle, compiler=compiler, profile=True)

--- a/examples/acoustic/fwi_operators.py
+++ b/examples/acoustic/fwi_operators.py
@@ -4,7 +4,7 @@ from sympy.abc import h, s
 from devito import Operator, Forward, Backward, t, time
 
 
-def ForwardOperator(model, u, src, rec, data, time_order=2, spc_order=6,
+def ForwardOperator(model, u, src, rec, time_order=2, spc_order=6,
                     save=False, u_ini=None, **kwargs):
     """
     Constructor method for the forward modelling operator in an acoustic media
@@ -55,7 +55,7 @@ def ForwardOperator(model, u, src, rec, data, time_order=2, spc_order=6,
                     time_axis=Forward, name="Forward")
 
 
-def AdjointOperator(model, v, srca, rec, data, time_order=2, spc_order=6,
+def AdjointOperator(model, v, srca, rec, time_order=2, spc_order=6,
                     save=False, u_ini=None, **kwargs):
     """
     Class to setup the adjoint modelling operator in an acoustic media
@@ -103,7 +103,7 @@ def AdjointOperator(model, v, srca, rec, data, time_order=2, spc_order=6,
                     time_axis=Backward, name="Adjoint")
 
 
-def GradientOperator(model, v, grad, rec, u, data, time_order=2, spc_order=6,
+def GradientOperator(model, v, grad, rec, u, time_order=2, spc_order=6,
                      **kwargs):
     """
     Class to setup the gradient operator in an acoustic media
@@ -158,7 +158,7 @@ def GradientOperator(model, v, grad, rec, u, data, time_order=2, spc_order=6,
                     time_axis=Backward, name="Gradient")
 
 
-def BornOperator(model, u, U, src, rec, dm, data, time_order=2, spc_order=6,
+def BornOperator(model, u, U, src, rec, dm, time_order=2, spc_order=6,
                  **kwargs):
     """
     Class to setup the linearized modelling operator in an acoustic media


### PR DESCRIPTION
This PR:
- Introduces a global configuration dictionary named `parameters` since we like to take inspiration from Firedrake. 
- Changes the logger to pick up its log-level from this configuration rather than setting the default in the logger itself. This is provided as an example of the intended use of this dictionary plus @mloubout seemed to want something like this anyway. 
- The `Forward`, `Adjoint` etc. methods of `Acoustic` had a superfluous parameter `data` which is also removed in this PR. 

Nearly a year after this issue was raised in #26 

In the next iteration, the config can be extended to read from a file/environment variables but I believe this should do for the current purposes. 