### PR TITLE
(Incomplete) documentation cleanup

### DIFF
--- a/docs/devito.rst
+++ b/docs/devito.rst
@@ -25,18 +25,18 @@ devito.compiler module
     :undoc-members:
     :show-inheritance:
 
-devito.finite_difference module
--------------------------------
+devito.dimension module
+--------------------------
 
-.. automodule:: devito.finite_difference
+.. automodule:: devito.dimension
     :members:
     :undoc-members:
     :show-inheritance:
 
-devito.function_manager module
-------------------------------
+devito.finite_difference module
+-------------------------------
 
-.. automodule:: devito.function_manager
+.. automodule:: devito.finite_difference
     :members:
     :undoc-members:
     :show-inheritance:
@@ -49,7 +49,39 @@ devito.interfaces module
     :undoc-members:
     :show-inheritance:
 
-devito.operator module
+devito.logger module
+------------------------
+
+.. automodule:: devito.logger
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+devito.memmap_manager module
+------------------------
+
+.. automodule:: devito.memmap_manager
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+devito.memory module
+------------------------
+
+.. automodule:: devito.memory
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+devito.nodes module
+------------------------
+
+.. automodule:: devito.nodes
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+       devito.operator module
 ----------------------
 
 .. automodule:: devito.operator
@@ -57,42 +89,34 @@ devito.operator module
     :undoc-members:
     :show-inheritance:
 
-devito.propagator module
+devito.parameters module
 ------------------------
 
-.. automodule:: devito.propagator
+.. automodule:: devito.parameters
     :members:
     :undoc-members:
     :show-inheritance:
 
-devito.stencilkernel module
----------------------------
-
-.. automodule:: devito.stencilkernel
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-devito.dimension module
------------------------
-
-.. automodule:: devito.dimension
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-devito.iteration module
------------------------
-
-.. automodule:: devito.iteration
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
-devito.expression module
+devito.pointdata module
 ------------------------
 
-.. automodule:: devito.expression
+.. automodule:: devito.pointdata
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+devito.profiler module
+------------------------
+
+.. automodule:: devito.profiler
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+devito.stencil module
+------------------------
+
+.. automodule:: devito.stencil
     :members:
     :undoc-members:
     :show-inheritance:
@@ -105,22 +129,10 @@ devito.tools module
     :undoc-members:
     :show-inheritance:
 
-devito.logger module
---------------------
-
-.. automodule:: devito.logger
-    :members:
-    :undoc-members:
-    :show-inheritance:
-    
-
-devito.at_controller module
+devito.visitor module
 -------------------
 
-.. automodule:: devito.at_controller
+.. automodule:: devito.visitor
     :members:
     :undoc-members:
     :show-inheritance:
-
-
-

--- a/docs/heat.rst
+++ b/docs/heat.rst
@@ -42,17 +42,18 @@ We plug the stencil in an Operator, as shown, and define the values of the
 thermal conductivity :obj:`a`, the spacing between cells :obj:`h` and the
 temporal spacing :obj:`s`.::
 
-   op = Operator(
-           stencils = Eq(u.forward, stencil),
-           substitutions = {a: tc, h: dx, s: dt},
-           nt = timesteps,
-           shape = (nx, ny),
-           spc_border = 1,
-           time_border = 1)
+   op = Operator(Eq(u.forward, stencil),
+                 subs={h: spacing, s: dt, a: tc})
 
 
-To execute the generated Operator, we simply call :samp:`op.apply()`. The
-results will then be found in :obj:`u.data[1, :]`.
+To execute the generated Operator, we simply call :samp:`op.apply(u=u,
+t=timesteps)`. The results will then be found in :obj:`u.data[1, :]`.
 
-For a complete example of this code, check file `test_diffusion.py` in the
-`tests` folder.
+For a complete example of this code, please see
+`examples/diffusion/example_diffusion.py`. A more comprehensive set of
+CFD tutorials based on the excellent `12 steps to Navier-Stokes`__
+tutorial is currently under construction and will be published here soon.
+
+.. _cfdtutorial: http://lorenabarba.com/blog/cfd-python-12-steps-to-navier-stokes/
+
+__ cfdtutorial_


### PR DESCRIPTION
Following the reinstatement of the auto-documentation deployment, this PR updates the module list for the core `devito` documentation (excluding DLE and DSE). It also adds minor updates to the diffusion tutorial for the website to align with the new 3.0 API. 