### PR TITLE
Various fixes to runtime argument derivation

### DIFF
--- a/devito/interfaces.py
+++ b/devito/interfaces.py
@@ -482,6 +482,8 @@ class TimeData(DenseData):
 
     :param name: Name of the resulting :class:`sympy.Function` symbol
     :param shape: Shape of the spatial data grid
+    :param dimensions: The symbolic dimensions of the function in addition
+                       to time.
     :param dtype: Data type of the buffered data
     :param save: Save the intermediate results to the data buffer. Defaults
                  to `False`, indicating the use of alternating buffers.
@@ -494,7 +496,9 @@ class TimeData(DenseData):
     Note: The parameter :shape: should only define the spatial shape of the
     grid. The temporal dimension will be inserted automatically as the
     leading dimension, according to the :param time_dim:, :param time_order:
-    and whether we want to write intermediate timesteps in the buffer.
+    and whether we want to write intermediate timesteps in the buffer. The
+    same is true for explicitly provided dimensions, which will be added to
+    the automatically derived time dimensions symbol.
     """
 
     is_TimeData = True
@@ -533,15 +537,10 @@ class TimeData(DenseData):
                       automatically infer dimension symbols.
         :return: Dimension indices used for each axis.
         """
-        dimensions = kwargs.get('dimensions', None)
-        if dimensions is None:
-            # Infer dimensions from default and data shape
-            save = kwargs.get('save', None)
-            tidx = time if save else t
-            _indices = [tidx, x, y, z]
-            shape = kwargs.get('shape')
-            dimensions = _indices[:len(shape) + 1]
-        return dimensions
+        save = kwargs.get('save', None)
+        tidx = time if save else t
+        _indices = DenseData._indices(**kwargs)
+        return tuple([tidx] + list(_indices))
 
     def _allocate_memory(self):
         """function to allocate memmory in terms of numpy ndarrays."""

--- a/devito/interfaces.py
+++ b/devito/interfaces.py
@@ -8,7 +8,7 @@ from devito.dimension import t, x, y, z, time
 from devito.finite_difference import (centered, cross_derivative,
                                       first_derivative, left, right,
                                       second_derivative)
-from devito.logger import debug, error
+from devito.logger import debug, error, warning
 from devito.memmap_manager import MemmapManager
 from devito.memory import CMemory, first_touch
 
@@ -507,11 +507,16 @@ class TimeData(DenseData):
         if not self._cached():
             super(TimeData, self).__init__(*args, **kwargs)
             self._full_data = self._data.view() if self._data else None
-            time_dim = kwargs.get('time_dim')
+            time_dim = kwargs.get('time_dim', None)
             self.time_order = kwargs.get('time_order', 1)
             self.save = kwargs.get('save', False)
 
             if not self.save:
+                if time_dim is not None:
+                    warning('Explicit time dimension size (time_dim) found for '
+                            'TimeData symbol %s, despite \nusing a buffered time '
+                            'dimension (save=False). This value will be ignored!'
+                            % self.name)
                 time_dim = self.time_order + 1
                 self.indices[0].modulo = time_dim
             else:

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -158,9 +158,10 @@ class OperatorBasic(Function):
             arguments[argname] = o_vals[argname]
 
         # Traverse positional args and infer loop sizes for open dimensions
-        f_args = [f for f in arguments.values() if isinstance(f, SymbolicData)]
-        for f in f_args:
-            arguments[f.name] = self._arg_data(f)
+        f_args = [(name, f) for name, f in arguments.items()
+                  if isinstance(f, SymbolicData)]
+        for fname, f in f_args:
+            arguments[fname] = self._arg_data(f)
             shape = self._arg_shape(f)
 
             # Ensure data dimensions match symbol dimensions
@@ -174,7 +175,7 @@ class OperatorBasic(Function):
                 if dim.size is not None:
                     if not shape[i] <= dim.size:
                         error('Size of data argument for %s is greater than the size '
-                              'of dimension %s: %d' % (f.name, dim.name, dim.size))
+                              'of dimension %s: %d' % (fname, dim.name, dim.size))
                         raise InvalidArgument('Wrong data shape encountered')
                     else:
                         continue
@@ -188,7 +189,7 @@ class OperatorBasic(Function):
                     if not dim_sizes[dim.name] <= shape[i]:
                         error('Size of dimension %s was determined to be %d, '
                               'but data for symbol %s has shape %d.'
-                              % (dim.name, dim_sizes[dim.name], f.name, shape[i]))
+                              % (dim.name, dim_sizes[dim.name], fname, shape[i]))
                         raise InvalidArgument('Wrong data shape encountered')
 
         # Make sure we have defined all buffered dimensions and their parents,

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -12,7 +12,7 @@ import sympy
 from devito.autotuning import autotune
 from devito.cgen_utils import Allocator, blankline
 from devito.compiler import jit_compile, load
-from devito.dimension import BufferedDimension, Dimension, time
+from devito.dimension import Dimension, time
 from devito.dle import compose_nodes, filter_iterations, transform
 from devito.dse import (clusterize, estimate_cost, estimate_memory, indexify,
                         rewrite, q_indexed)

--- a/docs/devito.rst
+++ b/docs/devito.rst
@@ -105,10 +105,10 @@ devito.pointdata module
     :undoc-members:
     :show-inheritance:
 
-devito.profiler module
+devito.profiling module
 ------------------------
 
-.. automodule:: devito.profiler
+.. automodule:: devito.profiling
     :members:
     :undoc-members:
     :show-inheritance:

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -154,8 +154,8 @@ class TestArguments(object):
         """Test call-time symbols overrides with other symbols"""
         i, j, k, l = dimify('i j k l')
         a = symbol(name='a', dimensions=(i, j, k, l), value=2.)
-        a1 = symbol(name='a', dimensions=(i, j, k, l), value=3.)
-        a2 = symbol(name='a', dimensions=(i, j, k, l), value=4.)
+        a1 = symbol(name='a1', dimensions=(i, j, k, l), value=3.)
+        a2 = symbol(name='a2', dimensions=(i, j, k, l), value=4.)
         op = Operator(Eq(a, a + 3))
         op()
         op(a=a1)

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -7,7 +7,7 @@ import pytest
 from sympy import Eq  # noqa
 
 from devito import (clear_cache, Operator, DenseData, TimeData,
-                    time, t, x, y, z)
+                    time, x, y, z)
 from devito.dle import retrieve_iteration_tree
 from devito.visitors import IsPerfectIteration
 
@@ -188,17 +188,12 @@ class TestArguments(object):
         i, j, k = dimify('i j k')
         shape = tuple([d.size for d in [i, j, k]])
         a = DenseData(name='a', shape=shape).indexed
-        b = TimeData(name='b', shape=shape, save=False).indexed
-        c = TimeData(name='c', shape=shape, save=True, time_dim=nt).indexed
-        eqn1 = Eq(b[t, x, y, z], a[x, y, z])
-        eqn2 = Eq(c[time, x, y, z], a[x, y, z])
-        op1 = Operator(eqn1)
-        op2 = Operator(eqn2)
+        b = TimeData(name='b', shape=shape, save=True, time_dim=nt).indexed
+        eqn = Eq(b[time, x, y, z], a[x, y, z])
+        op = Operator(eqn)
 
-        _, op1_dim_sizes = op1.arguments()
-        _, op2_dim_sizes = op2.arguments()
-        assert(op1_dim_sizes[time] == 2)
-        assert(op2_dim_sizes[time] == nt)
+        _, op_dim_sizes = op.arguments()
+        assert(op_dim_sizes[time.name] == nt)
 
     def test_dimension_size_override(self, nt=100):
         """Test explicit overrides for the leading time dimension"""

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -200,6 +200,23 @@ class TestArguments(object):
         assert(op1_dim_sizes[time] == 2)
         assert(op2_dim_sizes[time] == nt)
 
+    def test_dimension_size_override(self, nt=100):
+        """Test explicit overrides for the leading time dimension"""
+        i, j, k = dimify('i j k')
+        a = TimeData(name='a', dimensions=(i, j, k))
+        one = symbol(name='one', dimensions=(i, j, k), value=1.)
+        op = Operator(Eq(a.forward, a + one))
+
+        # Test dimension override via the buffered dimenions
+        a.data[0] = 0.
+        op(a=a, t=6)
+        assert(np.allclose(a.data[1], 5.))
+
+        # Test dimension override via the parent dimenions
+        a.data[0] = 0.
+        op(a=a, time=5)
+        assert(np.allclose(a.data[0], 4.))
+
 
 class TestDeclarator(object):
 

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -150,17 +150,13 @@ class TestArguments(object):
     def setup_class(cls):
         clear_cache()
 
-    def test_override(self):
-        """Test that the call-time overriding of Operator arguments works"""
+    def test_override_symbol(self):
+        """Test call-time symbols overrides with other symbols"""
         i, j, k, l = dimify('i j k l')
-        a = symbol(name='a', dimensions=(i, j, k, l), value=2.,
-                   mode='indexed').base.function
-        a1 = symbol(name='a', dimensions=(i, j, k, l), value=3.,
-                    mode='indexed').base.function
-        a2 = symbol(name='a', dimensions=(i, j, k, l), value=4.,
-                    mode='indexed').base.function
-        eqn = Eq(a, a+3)
-        op = Operator(eqn)
+        a = symbol(name='a', dimensions=(i, j, k, l), value=2.)
+        a1 = symbol(name='a', dimensions=(i, j, k, l), value=3.)
+        a2 = symbol(name='a', dimensions=(i, j, k, l), value=4.)
+        op = Operator(Eq(a, a + 3))
         op()
         op(a=a1)
         op(a=a2)
@@ -169,6 +165,23 @@ class TestArguments(object):
         assert(np.allclose(a.data, np.zeros(shape) + 5))
         assert(np.allclose(a1.data, np.zeros(shape) + 6))
         assert(np.allclose(a2.data, np.zeros(shape) + 7))
+
+    def test_override_array(self):
+        """Test call-time symbols overrides with numpy arrays"""
+        i, j, k, l = dimify('i j k l')
+        shape = tuple(d.size for d in (i, j, k, l))
+        a = symbol(name='a', dimensions=(i, j, k, l), value=2.)
+        a1 = np.zeros(shape=shape, dtype=np.float32) + 3.
+        a2 = np.zeros(shape=shape, dtype=np.float32) + 4.
+        op = Operator(Eq(a, a + 3))
+        op()
+        op(a=a1)
+        op(a=a2)
+        shape = [d.size for d in [i, j, k, l]]
+
+        assert(np.allclose(a.data, np.zeros(shape) + 5))
+        assert(np.allclose(a1, np.zeros(shape) + 6))
+        assert(np.allclose(a2, np.zeros(shape) + 7))
 
     def test_dimension_size_infer(self, nt=100):
         """Test that the dimension sizes are being inferred correctly"""

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -188,7 +188,7 @@ class TestArguments(object):
         i, j, k = dimify('i j k')
         shape = tuple([d.size for d in [i, j, k]])
         a = DenseData(name='a', shape=shape).indexed
-        b = TimeData(name='b', shape=shape, save=False, time_dim=nt).indexed
+        b = TimeData(name='b', shape=shape, save=False).indexed
         c = TimeData(name='c', shape=shape, save=True, time_dim=nt).indexed
         eqn1 = Eq(b[t, x, y, z], a[x, y, z])
         eqn2 = Eq(c[time, x, y, z], a[x, y, z])

--- a/tests/test_save.py
+++ b/tests/test_save.py
@@ -26,7 +26,7 @@ def run_simulation(save=False, dx=0.01, dy=0.01, a=0.5, timesteps=100):
 
     u = TimeData(
         name='u', shape=(nx, ny), time_dim=timesteps, initializer=initializer,
-        time_order=1, space_order=2, save=save, pad_time=save
+        time_order=1, space_order=2, save=save
     )
 
     a, h, s = symbols('a h s')
@@ -35,7 +35,7 @@ def run_simulation(save=False, dx=0.01, dy=0.01, a=0.5, timesteps=100):
     op = Operator(Eq(u.forward, stencil),
                   subs={a: 0.5, h: dx, s: dt},
                   time_axis=Forward)
-    op.apply()
+    op.apply(time=timesteps)
 
     if save:
         return u.data[timesteps - 1, :]


### PR DESCRIPTION
The primary goal of this PR is to fix the derivation of dimension sizes so that we can supply the number of timesteps as `op(time=no_timesteps)` or `op(t=no_timesteps)`. The PR _should_ make that part of `Operator.arguments()` easier to understand, and also fixes various other issues in the process: issues #236, #250 #251 and the problem outlines in #255. In particular it does:

* Add a separate test for symbol overrides via numpy arrays
* Fix the `TimeData` constructor so that the `dimensions` parameter now works as the `shape` one - ie. user-supplied argument for `shape` and `dimensions` ignore time and we implicitly add the time dimension based on `save`/`time_order`/`time_dim`.
* We now explicitly warn if the user sets `time_dim` on a buffered time object (`save=False`), since the `TimeData` objects do not retain that information, and defaulting to the buffer size makes little sense.
* In the same vain, we remove a test that checks for defaulting to the size of the time buffer if no `time_dim` is supplied - instead this code will now error and prompt the user to supply a value for `time` at runtime.
* Dimension size checks now check for `<=` than the actual data size. This means we can now iterate over subsets of our data, for example for processing small time-slices. 
* Use the "target" name of a substituted symbol, so that `op(a=a1)` works if `a1` has a different name to `a`.

Final developer note: This PR fixes a bunch of issues and slightly improves the `arguments` function in `operator.py`. However, a more comprehensive re-write would still be desirable to improve readability, modularity and maintainability and avoid users having to scroll through a huge backtrace to get to explicit warning messages. This is left for another PR though due to time constraints. 