### PR TITLE
Fix doc generator problems

### DIFF
--- a/docs/deploy.sh
+++ b/docs/deploy.sh
@@ -45,7 +45,7 @@ git config user.name "Travis CI"
 git config user.email "$COMMIT_AUTHOR_EMAIL"
 
 # If there are no changes to the compiled out (e.g. this is a README update) then just bail.
-if [ -z `git diff --exit-code`  ]; then
+if [ -z `git diff --exit-code` ]; then
     echo "No changes to the output on this push; exiting."
     exit 0
 fi

--- a/docs/devito.rst
+++ b/docs/devito.rst
@@ -132,7 +132,7 @@ devito.tools module
 devito.visitor module
 -------------------
 
-.. automodule:: devito.visitor
+.. automodule:: devito.visitors
     :members:
     :undoc-members:
     :show-inheritance:


### PR DESCRIPTION
Due to some problems with the configuration of the documentation generator, the last merge build failed on master. This attempts to fix those issues. 