### PR TITLE
Speedup schedule expressions

### DIFF
--- a/devito/dse/graph.py
+++ b/devito/dse/graph.py
@@ -203,17 +203,11 @@ class TemporariesGraph(OrderedDict):
         """
         if key not in self:
             return False
-        seen = set()
-        queue = [self[key]]
-        while queue:
-            item = queue.pop(0)
-            seen.add(item)
-            if any(key in i.atoms() for i in retrieve_indexed(item)):
-                # /key/ appears amongst the indices of /item/
-                return True
-            else:
-                queue.extend([i for i in self.extract(item.lhs, readby=True)
-                              if i not in seen])
+        match = key.base.label if self[key].is_tensor else key
+        for i in self.extract(key, readby=True):
+            for e in retrieve_indexed(i):
+                if any(match in idx.free_symbols for idx in e.indices):
+                    return True
         return False
 
     def extract(self, key, readby=False):

--- a/tests/test_dse.py
+++ b/tests/test_dse.py
@@ -228,6 +228,30 @@ def test_graph_trace(tu, tv, tw, ti0, ti1, t0, t1, exprs, expected):
 
 
 @pytest.mark.parametrize('exprs,expected', [
+    # trivial
+    (['Eq(t0, 1.)', 'Eq(t1, fa[x] + fb[x])'],
+     '{t0: False, t1: False}'),
+    # trivial
+    (['Eq(t0, 1)', 'Eq(t1, fa[t0] + fb[x])'],
+     '{t0: True, t1: False}'),
+    # simple
+    (['Eq(t0, 1)', 'Eq(t1, fa[t0*4 + 1] + fb[x])'],
+     '{t0: True, t1: False}'),
+    # two-steps
+    (['Eq(t0, 1.)', 'Eq(t1, t0 + 4)', 'Eq(t2, fa[t1*4 + 1] + fb[x])'],
+     '{t0: False, t1: True, t2: False}'),
+    # indirect
+    pytest.mark.xfail((['Eq(t0, 1)', 'Eq(t1, fa[fb[t0]] + fb[x])'],
+                      '{t0: True, t1: False}')),
+])
+def test_graph_isindex(fa, fb, fc, t0, t1, t2, exprs, expected):
+    g = temporaries_graph(EVAL(exprs, fa, fb, fc, t0, t1, t2))
+    mapper = eval(expected)
+    for k, v in mapper.items():
+        assert g.is_index(k) == v
+
+
+@pytest.mark.parametrize('exprs,expected', [
     # none (different distance)
     (['Eq(t0, fa[x] + fb[x])', 'Eq(t1, fa[x+1] + fb[x])'],
      {}),


### PR DESCRIPTION
Much faster expression scheduler (noticeable in TTI -- significantly shorter waiting time between the DSE and the DLE outputs to terminal)

Achieved through a different implementation of `is_index`, now also supported by some tests 