### PR TITLE
Yask integration phase2

### DIFF
--- a/devito/dle/__init__.py
+++ b/devito/dle/__init__.py
@@ -1,4 +1,4 @@
 from devito.dle.inspection import *  # noqa
 from devito.dle.manipulation import *  # noqa
 from devito.dle.transformer import *  # noqa
-from devito.dle.backends import init, make_grid  # noqa
+from devito.dle.backends import YaskGrid, init  # noqa

--- a/devito/dle/__init__.py
+++ b/devito/dle/__init__.py
@@ -1,4 +1,4 @@
 from devito.dle.inspection import *  # noqa
 from devito.dle.manipulation import *  # noqa
 from devito.dle.transformer import *  # noqa
-from devito.dle.backends import yaskarray  # noqa
+from devito.dle.backends import init, make_grid  # noqa

--- a/devito/dle/__init__.py
+++ b/devito/dle/__init__.py
@@ -1,4 +1,4 @@
 from devito.dle.inspection import *  # noqa
 from devito.dle.manipulation import *  # noqa
 from devito.dle.transformer import *  # noqa
-from devito.dle.backends import yaskarray
+from devito.dle.backends import yaskarray  # noqa

--- a/devito/dle/__init__.py
+++ b/devito/dle/__init__.py
@@ -1,3 +1,4 @@
 from devito.dle.inspection import *  # noqa
 from devito.dle.manipulation import *  # noqa
 from devito.dle.transformer import *  # noqa
+from devito.dle.backends import yaskarray

--- a/devito/dle/backends/__init__.py
+++ b/devito/dle/backends/__init__.py
@@ -3,4 +3,4 @@ from devito.dle.backends.utils import *  # noqa
 from devito.dle.backends.basic import BasicRewriter  # noqa
 from devito.dle.backends.advanced import (DevitoRewriter, DevitoSpeculativeRewriter,  # noqa
                                           DevitoCustomRewriter)  # noqa
-from devito.dle.backends.yask import YaskRewriter  # noqa
+from devito.dle.backends.yask import *  # noqa

--- a/devito/dle/backends/yask.py
+++ b/devito/dle/backends/yask.py
@@ -1,3 +1,4 @@
+import numpy as np
 from sympy import Indexed
 
 from devito.dimension import LoweredDimension
@@ -13,6 +14,8 @@ try:
     fac = yask.node_factory()
 except ImportError:
     yask = None
+
+__all__ = ['YaskRewriter', 'yaskarray']
 
 
 class YaskRewriter(BasicRewriter):
@@ -117,3 +120,22 @@ class sympy2yask(object):
                 raise NotImplementedError
 
         return run(expr)
+
+
+class yaskarray(np.ndarray):
+
+    """
+    An implementation of a ``numpy.ndarray`` suitable for the YASK storage layout.
+
+    This subclass follows the ``numpy`` rules for subclasses detailed at: ::
+
+        https://docs.scipy.org/doc/numpy/user/basics.subclassing.html
+    """
+
+    def __new__(cls, array):
+        # Input array is an already formed ndarray instance
+        # We first cast to be our class type
+        return np.asarray(array).view(cls)
+
+    def __array_finalize__(self, obj):
+        if obj is None: return

--- a/devito/dle/backends/yask.py
+++ b/devito/dle/backends/yask.py
@@ -81,6 +81,9 @@ class YaskGrid(object):
     of the different storage layout.
     """
 
+    # Force __rOP__ methods (OP={add,mul,...) to get arrays, not scalars, for efficiency
+    __array_priority__ = 1000
+
     def __init__(self, name, grid, shape, dtype, buffer=None):
         self.name = name
         self.shape = shape
@@ -130,11 +133,30 @@ class YaskGrid(object):
     def __repr__(self):
         return repr(self[:])
 
-    def __eq__(self, other):
-        if isinstance(other, (np.ndarray, numbers.Number)):
-            return self[:] == other
-        else:
-            raise NotImplementedError
+    def __meta_binop(op):
+        # Used to build all binary operations such as __eq__, __add__, etc.
+        # These all boil down to calling the numpy equivalents
+        def f(self, other):
+            return getattr(self[:], op)(other)
+        return f
+    __eq__ = __meta_binop('__eq__')
+    __ne__ = __meta_binop('__ne__')
+    __le__ = __meta_binop('__le__')
+    __lt__ = __meta_binop('__lt__')
+    __ge__ = __meta_binop('__ge__')
+    __gt__ = __meta_binop('__gt__')
+    __add__ = __meta_binop('__add__')
+    __radd__ = __meta_binop('__add__')
+    __sub__ = __meta_binop('__sub__')
+    __rsub__ = __meta_binop('__sub__')
+    __mul__ = __meta_binop('__mul__')
+    __rmul__ = __meta_binop('__mul__')
+    __div__ = __meta_binop('__div__')
+    __rdiv__ = __meta_binop('__div__')
+    __truediv__ = __meta_binop('__truediv__')
+    __rtruediv__ = __meta_binop('__truediv__')
+    __mod__ = __meta_binop('__mod__')
+    __rmod__ = __meta_binop('__mod__')
 
 
 class YaskRewriter(BasicRewriter):

--- a/devito/dle/backends/yask.py
+++ b/devito/dle/backends/yask.py
@@ -1,4 +1,3 @@
-import numbers
 import os
 import sys
 
@@ -10,7 +9,7 @@ from devito.dimension import LoweredDimension
 from devito.dle import retrieve_iteration_tree
 from devito.dle.backends import BasicRewriter, dle_pass
 from devito.exceptions import CompilationError, DLEException
-from devito.logger import debug, dle, dle_warning, error
+from devito.logger import debug, dle, dle_warning
 from devito.visitors import FindSymbols
 from devito.tools import as_tuple
 
@@ -107,7 +106,7 @@ class YaskGrid(object):
         self.grid = YASK.setdefault(name)
 
         # Always init the grid, at least with 0.0
-        self[:] = 0.0 if buffer is None else val
+        self[:] = 0.0 if buffer is None else buffer
 
     def __getitem__(self, index):
         # TODO: ATM, no MPI support.

--- a/devito/dle/backends/yask.py
+++ b/devito/dle/backends/yask.py
@@ -101,7 +101,7 @@ class YaskGrid(object):
             assert start == stop
             out = self.grid.get_element(*start)
         else:
-            debug("YaskGrid: Getting full-array/block via slices/indices")
+            debug("YaskGrid: Getting full-array/block via index [%s]" % str(index))
             out = np.empty(shape, self.dtype, 'C')
             self.grid.get_elements_in_slice(out.data, start, stop)
         return out
@@ -113,12 +113,15 @@ class YaskGrid(object):
             debug("YaskGrid: Setting single entry")
             assert start == stop
             self.grid.set_element(val, *start)
+        elif isinstance(val, np.ndarray):
+            debug("YaskGrid: Setting full-array/block via index [%s]" % str(index))
+            self.grid.set_elements_in_slice(val, start, stop)
+        elif all(i == j-1 for i, j in zip(shape, self.shape)):
+            debug("YaskGrid: Setting full-array to given scalar via single grid sweep")
+            self.grid.set_all_elements_same(val)
         else:
-            debug("YaskGrid: Setting full-array/block via multiple slices/indices")
-            if isinstance(val, np.ndarray):
-                self.grid.set_elements_in_slice(val, start, stop)
-            else:
-                self.grid.set_elements_in_slice_same(val, start, stop)
+            debug("YaskGrid: Setting block to given scalar via index [%s]" % str(index))
+            self.grid.set_elements_in_slice_same(val, start, stop)
 
     def __getslice__(self, start, stop):
         if stop == sys.maxint:

--- a/devito/dle/backends/yask.py
+++ b/devito/dle/backends/yask.py
@@ -60,15 +60,15 @@ class YaskRewriter(BasicRewriter):
                     try:
                         ast = transformer(i.stencil)
                         # Scalar
-                        print(ast.format_simple())
+                        # print(ast.format_simple())
 
                         # AVX2 intrinsics
                         # print soln.format('avx2')
 
                         # AVX2 intrinsics to file
-                        # import os
-                        # path = os.path.join(os.environ.get('YASK_HOME', '.'), 'src')
-                        # soln.write(os.path.join(path, 'stencil_code.hpp'), 'avx2')
+                        import os
+                        path = os.path.join(os.environ.get('YASK_HOME', '.'), 'src')
+                        soln.write(os.path.join(path, 'stencil_code.hpp'), 'avx2')
                     except:
                         pass
 

--- a/devito/dle/backends/yask.py
+++ b/devito/dle/backends/yask.py
@@ -127,6 +127,9 @@ class yaskarray(np.ndarray):
     """
     An implementation of a ``numpy.ndarray`` suitable for the YASK storage layout.
 
+    WIP: Currently, the YASK storage layout is assumed transposed w.r.t. the
+         usual row-major format.
+
     This subclass follows the ``numpy`` rules for subclasses detailed at: ::
 
         https://docs.scipy.org/doc/numpy/user/basics.subclassing.html
@@ -139,3 +142,10 @@ class yaskarray(np.ndarray):
 
     def __array_finalize__(self, obj):
         if obj is None: return
+
+    def __getitem__(self, index):
+        expected_layout = self.transpose()
+        return super(yaskarray, expected_layout).__getitem__(index)
+
+    def __setitem__(self, index, val):
+        super(yaskarray, self).__setitem__(index, val)

--- a/devito/exceptions.py
+++ b/devito/exceptions.py
@@ -1,3 +1,7 @@
+class CompilationError(Exception):
+    pass
+
+
 class InvalidArgument(Exception):
     pass
 

--- a/devito/interfaces.py
+++ b/devito/interfaces.py
@@ -307,15 +307,6 @@ class DenseData(SymbolicData):
         if configuration['dle'] == 'yask':
             from devito.dle import make_grid
             self._data = make_grid(self.name, self.shape, self.indices, self.dtype)
-
-            # self._data = self._data_object.ndpointer
-            # TODO: DELETE THE BELOW
-            debug("Allocating memory for %s (%s)" % (self.name, str(self.shape)))
-            self._data_object = CMemory(self.shape, dtype=self.dtype)
-            if self.numa:
-                first_touch(self)
-            else:
-                self.data.fill(0)
         else:
             debug("Allocating memory for %s (%s)" % (self.name, str(self.shape)))
             self._data_object = CMemory(self.shape, dtype=self.dtype)

--- a/devito/interfaces.py
+++ b/devito/interfaces.py
@@ -302,12 +302,27 @@ class DenseData(SymbolicData):
 
     def _allocate_memory(self):
         """Allocate memory in terms of numpy ndarrays."""
-        debug("Allocating memory for %s (%s)" % (self.name, str(self.shape)))
-        self._data_object = CMemory(self.shape, dtype=self.dtype)
-        if self.numa:
-            first_touch(self)
+        from devito.parameters import configuration
+
+        if configuration['dle'] == 'yask':
+            from devito.dle import make_grid
+            self._data = make_grid(self.name, self.shape, self.indices, self.dtype)
+
+            # self._data = self._data_object.ndpointer
+            # TODO: DELETE THE BELOW
+            debug("Allocating memory for %s (%s)" % (self.name, str(self.shape)))
+            self._data_object = CMemory(self.shape, dtype=self.dtype)
+            if self.numa:
+                first_touch(self)
+            else:
+                self.data.fill(0)
         else:
-            self.data.fill(0)
+            debug("Allocating memory for %s (%s)" % (self.name, str(self.shape)))
+            self._data_object = CMemory(self.shape, dtype=self.dtype)
+            if self.numa:
+                first_touch(self)
+            else:
+                self.data.fill(0)
 
     @property
     def data(self):

--- a/devito/memory.py
+++ b/devito/memory.py
@@ -10,12 +10,25 @@ from sympy import Eq
 
 from devito.dimension import t
 from devito.logger import error
+from devito.parameters import parameters
 from devito.tools import convert_dtype_to_ctype
 
 
 class CMemory(object):
+
     def __init__(self, shape, dtype=np.float32, alignment=None):
         self.ndpointer, self.data_pointer = malloc_aligned(shape, alignment, dtype)
+
+    @classmethod
+    def cast(cls, ndpointer):
+        """
+        Pick a different ndarray type depending on how the backend will access the data.
+        """
+        if parameters['dle']['mode'] == 'yask':
+            from devito.dle import yaskarray
+            return yaskarray(ndpointer)
+        else:
+            return ndpointer
 
     def __del__(self):
         free(self.data_pointer)

--- a/devito/memory.py
+++ b/devito/memory.py
@@ -10,7 +10,6 @@ from sympy import Eq
 
 from devito.dimension import t
 from devito.logger import error
-from devito.parameters import parameters
 from devito.tools import convert_dtype_to_ctype
 
 
@@ -24,8 +23,10 @@ class CMemory(object):
         """
         Pick a different ndarray type depending on how the backend will access the data.
         """
-        if parameters['dle']['mode'] == 'yask':
-            from devito.dle import yaskarray
+        from devito.parameters import configuration
+        from devito.dle import yaskarray
+
+        if configuration['dle'] == 'yask':
             return yaskarray(ndpointer)
         else:
             return ndpointer

--- a/devito/memory.py
+++ b/devito/memory.py
@@ -18,19 +18,6 @@ class CMemory(object):
     def __init__(self, shape, dtype=np.float32, alignment=None):
         self.ndpointer, self.data_pointer = malloc_aligned(shape, alignment, dtype)
 
-    @classmethod
-    def cast(cls, ndpointer):
-        """
-        Pick a different ndarray type depending on how the backend will access the data.
-        """
-        from devito.parameters import configuration
-        from devito.dle import yaskarray
-
-        if configuration['dle'] == 'yask':
-            return yaskarray(ndpointer)
-        else:
-            return ndpointer
-
     def __del__(self):
         free(self.data_pointer)
         self.data_pointer = None

--- a/devito/tools.py
+++ b/devito/tools.py
@@ -1,3 +1,4 @@
+import os
 import ctypes
 from collections import Callable, Iterable, OrderedDict
 try:
@@ -195,3 +196,22 @@ class DefaultOrderedDict(OrderedDict):
 
     def __copy__(self):
         return type(self)(self.default_factory, self)
+
+
+class change_directory(object):
+    """
+    Context manager for changing the current working directory.
+
+    Adapted from: ::
+
+        https://stackoverflow.com/questions/431684/how-do-i-cd-in-python/
+    """
+    def __init__(self, newPath):
+        self.newPath = os.path.expanduser(newPath)
+
+    def __enter__(self):
+        self.savedPath = os.getcwd()
+        os.chdir(self.newPath)
+
+    def __exit__(self, etype, value, traceback):
+        os.chdir(self.savedPath)

--- a/tests/test_yask.py
+++ b/tests/test_yask.py
@@ -3,16 +3,17 @@ from sympy import Eq
 
 import pytest
 
-from devito import DLE_DEFAULT, Operator, DenseData, parameters, x, y, z
+from devito import Operator, DenseData, x, y, z
+from devito.parameters import configuration, defaults
 from devito.dle.backends import yaskarray
 
 
 def setup_module(module):
-    parameters['dle']['mode'] = 'yask'
+    configuration['dle'] = 'yask'
 
 
 def teardown_module(module):
-    parameters['dle']['mode'] = DLE_DEFAULT
+    configuration['dle'] = defaults['dle']
 
 
 def test_data_type():

--- a/tests/test_yask.py
+++ b/tests/test_yask.py
@@ -1,8 +1,9 @@
+import numpy as np
 from sympy import Eq
 
 import pytest
 
-from devito import DLE_DEFAULT, Operator, DenseData, parameters, x, y
+from devito import DLE_DEFAULT, Operator, DenseData, parameters, x, y, z
 from devito.dle.backends import yaskarray
 
 
@@ -17,3 +18,22 @@ def teardown_module(module):
 def test_data_type():
     u = DenseData(name='yu', shape=(10, 10), dimensions=(x, y))
     assert type(u.data) == yaskarray
+
+
+def test_data_swap():
+    u = DenseData(name='yu1D', shape=(10,), dimensions=(x,))
+    u.data[1] = 1.
+    assert u.data[1] == 1.
+    u = DenseData(name='yu2D', shape=(10, 10), dimensions=(x, y))
+    u.data[0, 1] = 1.
+    assert u.data[1, 0] == 1.
+    u = DenseData(name='yu3D', shape=(10, 10, 10), dimensions=(x, y, z))
+    u.data[0, 1, 1] = 1.
+    assert u.data[1, 1, 0] == 1.
+
+
+def test_storage_layout():
+    u = DenseData(name='yu', shape=(10, 10), dimensions=(x, y))
+    op = Operator(Eq(u, 1.), dse='noop', dle='noop')
+    op.apply(u)
+    assert np.allclose(u.data, 1)

--- a/tests/test_yask.py
+++ b/tests/test_yask.py
@@ -30,19 +30,33 @@ def test_data_movement_1D():
     assert all(i == 0 for i in u.data[2:])
 
 
-@pytest.mark.xfail(reason="FAIL on block insertion")
 def test_data_movement_nD():
     u = DenseData(name='yu3D', shape=(10, 10, 10), dimensions=(x, y, z))
+
+    # Test simple insertion and extraction
     u.data[0, 1, 1] = 1.
     assert u.data[0, 0, 0] == 0.
     assert u.data[0, 1, 1] == 1.
     assert np.all(u.data[:] == u.data[:,:,:])
 
-    # Test block insertion
-    block = np.ndarray(shape=(1, 10, 1))
-    block.fill(5.)
-    u.data[5,:,5] = block
-    assert np.all(u.data[5,:,5] == block)
+    # Test negative indices
+    assert u.data[0, -9, -9] == 1.
+    u.data[6,0,0] = 1.
+    assert u.data[-4,:,:].sum() == 1.
+
+    # Test setting whole array to given value
+    u.data[:] = 3.
+    assert np.all(u.data[:] == 3.)
+
+    # Test insertion of single value into block
+    u.data[5,:,5] = 5.
+    assert np.all(u.data[5,:,5] == 5.)
+
+    # Test insertion of block into block
+    block = np.ndarray(shape=(1, 10, 1), dtype=np.float32)
+    block.fill(4.)
+    u.data[4,:,4] = block
+    assert np.all(u.data[4,:,4] == block)
 
 
 def test_storage_layout():

--- a/tests/test_yask.py
+++ b/tests/test_yask.py
@@ -1,7 +1,7 @@
 import numpy as np
 from sympy import Eq
 
-import pytest
+import pytest  # noqa
 
 from devito import Operator, DenseData, x, y, z
 from devito.parameters import configuration, defaults

--- a/tests/test_yask.py
+++ b/tests/test_yask.py
@@ -4,8 +4,10 @@ from sympy import Eq
 import pytest  # noqa
 
 from devito import Operator, DenseData, x, y, z
+from devito.dle import YaskGrid
 from devito.parameters import configuration, defaults
-from devito.dle.backends.yask import YaskGrid
+
+pexpect = pytest.importorskip('yask_compiler')  # Run only if YASK is available
 
 
 def setup_module(module):
@@ -37,7 +39,6 @@ def test_data_movement_nD():
     u.data[0, 1, 1] = 1.
     assert u.data[0, 0, 0] == 0.
     assert u.data[0, 1, 1] == 1.
-    print u.data
     assert np.all(u.data == u.data[:,:,:])
     assert 1. in u.data[0]
     assert 1. in u.data[0, 1]

--- a/tests/test_yask.py
+++ b/tests/test_yask.py
@@ -64,7 +64,28 @@ def test_data_movement_nD():
 
 def test_data_arithmetic_nD():
     u = DenseData(name='yu3D', shape=(10, 10, 10), dimensions=(x, y, z))
-    assert np.all(u.data == 0)
+
+    # Simple arithmetic
+    u.data[:] = 1
+    assert np.all(u.data == 1)
+    assert np.all(u.data + 2. == 3.)
+    assert np.all(u.data - 2. == -1.)
+    assert np.all(u.data * 2. == 2.)
+    assert np.all(u.data / 2. == 0.5)
+    assert np.all(u.data % 2 == 1.)
+
+    # Increments and parital increments
+    u.data[:] += 2.
+    assert np.all(u.data == 3.)
+    u.data[9,:,:] += 1.
+    assert all(np.all(u.data[i,:,:] == 3.) for i in range(9))
+    assert np.all(u.data[9,:,:] == 4.)
+
+    # Right operations __rOP__
+    u.data[:] = 1.
+    arr = np.ndarray(shape=(10, 10, 10), dtype=np.float32)
+    arr.fill(2.)
+    assert np.all(arr - u.data == -1.)
 
 
 def test_storage_layout():

--- a/tests/test_yask.py
+++ b/tests/test_yask.py
@@ -39,28 +39,28 @@ def test_data_movement_nD():
     u.data[0, 1, 1] = 1.
     assert u.data[0, 0, 0] == 0.
     assert u.data[0, 1, 1] == 1.
-    assert np.all(u.data == u.data[:,:,:])
+    assert np.all(u.data == u.data[:, :, :])
     assert 1. in u.data[0]
     assert 1. in u.data[0, 1]
 
     # Test negative indices
     assert u.data[0, -9, -9] == 1.
-    u.data[6,0,0] = 1.
-    assert u.data[-4,:,:].sum() == 1.
+    u.data[6, 0, 0] = 1.
+    assert u.data[-4, :, :].sum() == 1.
 
     # Test setting whole array to given value
     u.data[:] = 3.
     assert np.all(u.data == 3.)
 
     # Test insertion of single value into block
-    u.data[5,:,5] = 5.
-    assert np.all(u.data[5,:,5] == 5.)
+    u.data[5, :, 5] = 5.
+    assert np.all(u.data[5, :, 5] == 5.)
 
     # Test insertion of block into block
     block = np.ndarray(shape=(1, 10, 1), dtype=np.float32)
     block.fill(4.)
-    u.data[4,:,4] = block
-    assert np.all(u.data[4,:,4] == block)
+    u.data[4, :, 4] = block
+    assert np.all(u.data[4, :, 4] == block)
 
 
 def test_data_arithmetic_nD():
@@ -78,9 +78,9 @@ def test_data_arithmetic_nD():
     # Increments and parital increments
     u.data[:] += 2.
     assert np.all(u.data == 3.)
-    u.data[9,:,:] += 1.
-    assert all(np.all(u.data[i,:,:] == 3.) for i in range(9))
-    assert np.all(u.data[9,:,:] == 4.)
+    u.data[9, :, :] += 1.
+    assert all(np.all(u.data[i, :, :] == 3.) for i in range(9))
+    assert np.all(u.data[9, :, :] == 4.)
 
     # Right operations __rOP__
     u.data[:] = 1.

--- a/tests/test_yask.py
+++ b/tests/test_yask.py
@@ -5,7 +5,7 @@ import pytest  # noqa
 
 from devito import Operator, DenseData, x, y, z
 from devito.parameters import configuration, defaults
-from devito.dle.backends import YaskGrid
+from devito.dle.backends.yask import YaskGrid
 
 
 def setup_module(module):
@@ -21,16 +21,28 @@ def test_data_type():
     assert type(u.data) == YaskGrid
 
 
-def test_data_swap():
+@pytest.mark.xfail(reason="YASK always seems to use 3D grids")
+def test_data_movement_1D():
     u = DenseData(name='yu1D', shape=(10,), dimensions=(x,))
     u.data[1] = 1.
+    assert u.data[0] == 0.
     assert u.data[1] == 1.
-    u = DenseData(name='yu2D', shape=(10, 10), dimensions=(x, y))
-    u.data[0, 1] = 1.
-    assert u.data[1, 0] == 1.
+    assert all(i == 0 for i in u.data[2:])
+
+
+@pytest.mark.xfail(reason="FAIL on block insertion")
+def test_data_movement_nD():
     u = DenseData(name='yu3D', shape=(10, 10, 10), dimensions=(x, y, z))
     u.data[0, 1, 1] = 1.
-    assert u.data[1, 1, 0] == 1.
+    assert u.data[0, 0, 0] == 0.
+    assert u.data[0, 1, 1] == 1.
+    assert np.all(u.data[:] == u.data[:,:,:])
+
+    # Test block insertion
+    block = np.ndarray(shape=(1, 10, 1))
+    block.fill(5.)
+    u.data[5,:,5] = block
+    assert np.all(u.data[5,:,5] == block)
 
 
 def test_storage_layout():

--- a/tests/test_yask.py
+++ b/tests/test_yask.py
@@ -37,7 +37,10 @@ def test_data_movement_nD():
     u.data[0, 1, 1] = 1.
     assert u.data[0, 0, 0] == 0.
     assert u.data[0, 1, 1] == 1.
-    assert np.all(u.data[:] == u.data[:,:,:])
+    print u.data
+    assert np.all(u.data == u.data[:,:,:])
+    assert 1. in u.data[0]
+    assert 1. in u.data[0, 1]
 
     # Test negative indices
     assert u.data[0, -9, -9] == 1.
@@ -46,7 +49,7 @@ def test_data_movement_nD():
 
     # Test setting whole array to given value
     u.data[:] = 3.
-    assert np.all(u.data[:] == 3.)
+    assert np.all(u.data == 3.)
 
     # Test insertion of single value into block
     u.data[5,:,5] = 5.
@@ -57,6 +60,11 @@ def test_data_movement_nD():
     block.fill(4.)
     u.data[4,:,4] = block
     assert np.all(u.data[4,:,4] == block)
+
+
+def test_data_arithmetic_nD():
+    u = DenseData(name='yu3D', shape=(10, 10, 10), dimensions=(x, y, z))
+    assert np.all(u.data == 0)
 
 
 def test_storage_layout():

--- a/tests/test_yask.py
+++ b/tests/test_yask.py
@@ -1,0 +1,19 @@
+from sympy import Eq
+
+import pytest
+
+from devito import DLE_DEFAULT, Operator, DenseData, parameters, x, y
+from devito.dle.backends import yaskarray
+
+
+def setup_module(module):
+    parameters['dle']['mode'] = 'yask'
+
+
+def teardown_module(module):
+    parameters['dle']['mode'] = DLE_DEFAULT
+
+
+def test_data_type():
+    u = DenseData(name='yu', shape=(10, 10), dimensions=(x, y))
+    assert type(u.data) == yaskarray

--- a/tests/test_yask.py
+++ b/tests/test_yask.py
@@ -5,7 +5,7 @@ import pytest  # noqa
 
 from devito import Operator, DenseData, x, y, z
 from devito.parameters import configuration, defaults
-from devito.dle.backends import yaskarray
+from devito.dle.backends import YaskGrid
 
 
 def setup_module(module):
@@ -18,7 +18,7 @@ def teardown_module(module):
 
 def test_data_type():
     u = DenseData(name='yu', shape=(10, 10), dimensions=(x, y))
-    assert type(u.data) == yaskarray
+    assert type(u.data) == YaskGrid
 
 
 def test_data_swap():


### PR DESCRIPTION
* Support for data movement through YaskGrids, which basically wrap YASK Grid objects and act like numpy arrays. Why wrapping was preferred over inheritance? see comments in code, but basically to avoid wasting twice as much memory, because of the difference in storage layouts (what YASK uses and what the users wanna see)
* Add tests!
* Update to more recent YASK API
* Handle many more types of grids
* Many other small features

Next step: restructuring our source directory in a way that YASK acts like a different backend, not just a different sequence of DLE passes. 