### PR TITLE
Generalized loop blocking

### DIFF
--- a/devito/cgen_utils.py
+++ b/devito/cgen_utils.py
@@ -172,3 +172,5 @@ def ccode_eq(eq, **settings):
 
 
 blankline = c.Line("")
+printmark = lambda i: c.Line('printf("Here: %s\\n"); fflush(stdout);' % i)
+printvar = lambda i: c.Statement('printf("%s=%%s\\n", %s); fflush(stdout);' % (i, i))

--- a/devito/cgen_utils.py
+++ b/devito/cgen_utils.py
@@ -20,14 +20,10 @@ class Allocator(object):
         """
         Generate a cgen statement that allocates ``obj`` on the stack.
         """
-        dtype = c.dtype_to_ctype(obj.dtype)
-        shape = "".join("[%d]" % j for j in obj.shape)
+        shape = "".join("[%s]" % ccode(i) for i in obj.symbolic_shape)
         alignment = "__attribute__((aligned(64)))"
-
-        item = c.POD(dtype, "%s%s %s" % (obj.name, shape, alignment))
-        handle = self.stack.setdefault(scope, [])
-        if item not in handle:
-            handle.append(item)
+        handle = self.stack.setdefault(scope, OrderedDict())
+        handle[obj] = c.POD(obj.dtype, "%s%s %s" % (obj.name, shape, alignment))
 
     def push_heap(self, obj):
         """
@@ -37,10 +33,11 @@ class Allocator(object):
         if obj in self.heap:
             return
 
-        decl = "(*%s)%s" % (obj.name, "".join("[%d]" % j for j in obj.shape[1:]))
+        decl = "(*%s)%s" % (obj.name,
+                            "".join("[%s]" % i.symbolic_size for i in obj.indices[1:]))
         decl = c.Value(c.dtype_to_ctype(obj.dtype), decl)
 
-        shape = "".join("[%d]" % j for j in obj.shape)
+        shape = "".join("[%s]" % i.symbolic_size for i in obj.indices)
         alloc = "posix_memalign((void**)&%s, 64, sizeof(%s%s))"
         alloc = alloc % (obj.name, c.dtype_to_ctype(obj.dtype), shape)
         alloc = c.Statement(alloc)
@@ -51,7 +48,7 @@ class Allocator(object):
 
     @property
     def onstack(self):
-        return self.stack.items()
+        return [(k, v.values()) for k, v in self.stack.items()]
 
     @property
     def onheap(self):

--- a/devito/dimension.py
+++ b/devito/dimension.py
@@ -1,7 +1,7 @@
 import cgen
 
 import numpy as np
-from sympy import Symbol
+from sympy import Number, Symbol
 
 __all__ = ['Dimension', 'x', 'y', 'z', 't', 'p', 'd', 'time']
 
@@ -32,7 +32,10 @@ class Dimension(Symbol):
     @property
     def symbolic_size(self):
         """The symbolic size of this dimension."""
-        return Symbol(self.ccode)
+        try:
+            return Number(self.ccode)
+        except ValueError:
+            return Symbol(self.ccode)
 
     @property
     def ccode(self):

--- a/devito/dle/__init__.py
+++ b/devito/dle/__init__.py
@@ -1,4 +1,5 @@
 from devito.dle.inspection import *  # noqa
 from devito.dle.manipulation import *  # noqa
+from devito.dle.blocking_utils import *  # noqa
 from devito.dle.transformer import *  # noqa
 from devito.dle.backends import YaskGrid, init  # noqa

--- a/devito/dle/backends/advanced.py
+++ b/devito/dle/backends/advanced.py
@@ -168,14 +168,16 @@ class DevitoRewriter(BasicRewriter):
                     # non-blocked ("remainder") iterations.
                     start = inter_block.limits[0]
                     finish = inter_block.limits[1]
-                    main = i._rebuild([], limits=[start, finish, 1], offsets=None)
+                    main = i._rebuild([], limits=[start, finish, 1], offsets=None,
+                                      properties=('parallel', 'remainder'))
 
                     # Build unitary-increment Iteration over the 'leftover' region:
                     # again as above, this may be necessary when the dimension size
                     # is not a multiple of the block size.
                     start = inter_block.limits[1]
                     finish = iter_size - i.offsets[1]
-                    leftover = i._rebuild([], limits=[start, finish, 1], offsets=None)
+                    leftover = i._rebuild([], limits=[start, finish, 1], offsets=None,
+                                          properties=('parallel', 'remainder'))
 
                     regions[i] = Region(main, leftover)
 

--- a/devito/dle/backends/advanced.py
+++ b/devito/dle/backends/advanced.py
@@ -282,7 +282,7 @@ class DevitoRewriter(BasicRewriter):
             for tree in retrieve_iteration_tree(node):
                 # Determine the number of consecutive parallelizable Iterations
                 key = lambda i: i.is_Parallel and not i.is_Vectorizable
-                candidates = filter_iterations(tree, key=key, stop='consecutive')
+                candidates = filter_iterations(tree, key=key, stop='any')
                 if not candidates:
                     continue
 

--- a/devito/dle/backends/advanced.py
+++ b/devito/dle/backends/advanced.py
@@ -101,25 +101,23 @@ class DevitoRewriter(BasicRewriter):
         """
         Apply loop blocking to :class:`Iteration` trees.
 
-        By default, the blocked :class:`Iteration` objects and the block size are
-        determined heuristically. The heuristic consists of searching the deepest
-        Iteration/Expression tree and blocking all dimensions except:
+        Blocking is applied to parallel iteration trees. Heuristically, innermost
+        dimensions are not blocked to maximize the trip count of the SIMD loops.
 
-            * The innermost (eg, to retain SIMD vectorization);
-            * Those dimensions inducing loop-carried dependencies.
-
-        The caller may take over the heuristic through ``kwargs['blocking']``,
-        a dictionary indicating the block size of each blocked dimension. For
-        example, for the :class:`Iteration` tree below: ::
+        Different heuristics may be specified via ``kwargs['blockshape']`` and
+        ``kwargs['blockinner']``. The former, a dictionary, is used to indicate
+        a specific block size for each blocked dimension. For example, for the
+        :class:`Iteration` tree: ::
 
             for i
               for j
                 for k
                   ...
 
-        one may pass in ``kwargs['blocking'] = {i: 4, j: 7}``, in which case the
-        two outer loops would be blocked, and the resulting 2-dimensional block
-        would be of size 4x7.
+        one may provide ``kwargs['blockshape'] = {i: 4, j: 7}``, in which case the
+        two outer loops will blocked, and the resulting 2-dimensional block will
+        have size 4x7. The latter may be set to True to also block innermost parallel
+        :class:`Iteration` objects.
         """
         Region = namedtuple('Region', 'main leftover')
 

--- a/devito/dle/backends/advanced.py
+++ b/devito/dle/backends/advanced.py
@@ -159,9 +159,7 @@ class DevitoRewriter(BasicRewriter):
                     # Build Iteration within a block
                     start = inter_block.dim
                     finish = start + block_size
-                    properties = 'vector-dim' if i.is_Vectorizable else None
-                    intra_block = i._rebuild([], limits=[start, finish, 1], offsets=None,
-                                             properties=as_tuple(properties))
+                    intra_block = i._rebuild([], limits=[start, finish, 1], offsets=None)
 
                     blocked_iterations.append((inter_block, intra_block))
 
@@ -170,16 +168,14 @@ class DevitoRewriter(BasicRewriter):
                     # non-blocked ("remainder") iterations.
                     start = inter_block.limits[0]
                     finish = inter_block.limits[1]
-                    main = i._rebuild([], limits=[start, finish, 1], offsets=None,
-                                      properties=i.properties)
+                    main = i._rebuild([], limits=[start, finish, 1], offsets=None)
 
                     # Build unitary-increment Iteration over the 'leftover' region:
                     # again as above, this may be necessary when the dimension size
                     # is not a multiple of the block size.
                     start = inter_block.limits[1]
                     finish = iter_size - i.offsets[1]
-                    leftover = i._rebuild([], limits=[start, finish, 1], offsets=None,
-                                          properties=i.properties)
+                    leftover = i._rebuild([], limits=[start, finish, 1], offsets=None)
 
                     regions[i] = Region(main, leftover)
 

--- a/devito/dle/backends/advanced.py
+++ b/devito/dle/backends/advanced.py
@@ -31,11 +31,11 @@ class DevitoRewriter(BasicRewriter):
     def _pipeline(self, state):
         self._avoid_denormals(state)
         self._loop_fission(state)
-        #self._create_elemental_functions(state)
         self._loop_blocking(state)
         self._simdize(state)
         if self.params['openmp'] is True:
             self._ompize(state)
+        self._create_elemental_functions(state)
 
     @dle_pass
     def _loop_fission(self, state, **kwargs):
@@ -314,12 +314,12 @@ class DevitoSpeculativeRewriter(DevitoRewriter):
         self._avoid_denormals(state)
         self._loop_fission(state)
         self._padding(state)
-        self._create_elemental_functions(state)
         self._loop_blocking(state)
         self._simdize(state)
         self._nontemporal_stores(state)
         if self.params['openmp'] is True:
             self._ompize(state)
+        self._create_elemental_functions(state)
 
     @dle_pass
     def _padding(self, state, **kwargs):

--- a/devito/dle/backends/advanced.py
+++ b/devito/dle/backends/advanced.py
@@ -8,8 +8,6 @@ from itertools import combinations
 import numpy as np
 import psutil
 
-import cgen as c
-
 from devito.dimension import Dimension
 from devito.dle import (compose_nodes, copy_arrays, filter_iterations,
                         fold_blockable_tree, unfold_blocked_tree,
@@ -20,8 +18,8 @@ from devito.dse import promote_scalar_expressions
 from devito.exceptions import DLEException
 from devito.interfaces import TensorFunction
 from devito.logger import dle_warning
-from devito.nodes import Block, Denormals, Element, Expression, Iteration, List
-from devito.tools import as_tuple, flatten, grouper, roundm
+from devito.nodes import Block, Denormals, Expression, Iteration, List
+from devito.tools import as_tuple, grouper, roundm
 from devito.visitors import (FindNodes, FindSymbols, IsPerfectIteration,
                              SubstituteExpression, Transformer)
 

--- a/devito/dle/backends/advanced.py
+++ b/devito/dle/backends/advanced.py
@@ -103,8 +103,8 @@ class DevitoRewriter(BasicRewriter):
         Blocking is applied to parallel iteration trees. Heuristically, innermost
         dimensions are not blocked to maximize the trip count of the SIMD loops.
 
-        Different heuristics may be specified via ``kwargs['blockshape']`` and
-        ``kwargs['blockinner']``. The former, a dictionary, is used to indicate
+        Different heuristics may be specified by passing the keywords ``blockshape``
+        and ``blockinner`` to the DLE. The former, a dictionary, is used to indicate
         a specific block size for each blocked dimension. For example, for the
         :class:`Iteration` tree: ::
 
@@ -113,7 +113,7 @@ class DevitoRewriter(BasicRewriter):
                 for k
                   ...
 
-        one may provide ``kwargs['blockshape'] = {i: 4, j: 7}``, in which case the
+        one may provide ``blockshape = {i: 4, j: 7}``, in which case the
         two outer loops will blocked, and the resulting 2-dimensional block will
         have size 4x7. The latter may be set to True to also block innermost parallel
         :class:`Iteration` objects.

--- a/devito/dle/backends/basic.py
+++ b/devito/dle/backends/basic.py
@@ -22,10 +22,10 @@ class BasicRewriter(AbstractRewriter):
     @dle_pass
     def _avoid_denormals(self, state, **kwargs):
         """
-        Introduce nodes in the Iteration/Expression tree that will generate macros
-        to avoid computing with denormal numbers. These are normally flushed away
-        when using SSE-like instruction sets in a complete C program, but when
-        compiling shared objects specific instructions must instead be inserted.
+        Introduce nodes in the Iteration/Expression tree that will expand to C
+        macros telling the CPU to flush denormal numbers in hardware. Denormals
+        are normally flushed when using SSE-based instruction sets, except when
+        compiling shared objects.
         """
         return {'nodes': (Denormals(),) + state.nodes,
                 'includes': ('xmmintrin.h', 'pmmintrin.h')}

--- a/devito/dle/backends/utils.py
+++ b/devito/dle/backends/utils.py
@@ -9,7 +9,7 @@ A dictionary to quickly access standard OpenMP pragmas
 omplang = {
     'for': c.Pragma('omp for schedule(static)'),
     'collapse': lambda i: c.Pragma('omp for collapse(%d) schedule(static)' % i),
-    'par-region': c.Pragma('omp parallel'),
+    'par-region': lambda i: c.Pragma('omp parallel %s' % i),
     'par-for': c.Pragma('omp parallel for schedule(static)'),
     'simd-for': c.Pragma('omp simd'),
     'simd-for-aligned': lambda i, j: c.Pragma('omp simd aligned(%s:%d)' % (i, j))

--- a/devito/dle/blocking_utils.py
+++ b/devito/dle/blocking_utils.py
@@ -1,0 +1,140 @@
+import cgen as c
+
+from devito.dle import compose_nodes, is_foldable, retrieve_iteration_tree
+from devito.nodes import Iteration, List
+from devito.visitors import (FindAdjacentIterations, IsPerfectIteration,
+                             NestedTransformer, Transformer)
+from devito.tools import as_tuple
+
+__all__ = ['fold_blockable_tree', 'unfold_blocked_tree']
+
+
+def fold_blockable_tree(node):
+    """
+    Create :class:`IterationFold`s from sequences of nested :class:`Iteration`.
+    """
+    found = FindAdjacentIterations().visit(node)
+    found.pop('seen_iteration')
+
+    mapper = {}
+    for k, v in found.items():
+        for i in v:
+            # Check if the Iterations in /i/ are foldable or not
+            assert len(i) > 1
+            if any(not IsPerfectIteration().visit(j) for j in i):
+                continue
+            trees = [retrieve_iteration_tree(j)[0] for j in i]
+            if any(len(trees[0]) != len(j) for j in trees):
+                continue
+            pairwise_folds = zip(*reversed(trees))
+            if any(not is_foldable(j) for j in pairwise_folds):
+                continue
+            for j in pairwise_folds:
+                root, remainder = j[0], j[1:]
+                folds = [(tuple(y-x for x, y in zip(i.offsets, root.offsets)), i.nodes)
+                         for i in remainder]
+                mapper[root] = IterationFold(folds=folds, **root.args)
+                for k in remainder:
+                    mapper[k] = None
+
+    # Insert the IterationFolds in the Iteration/Expression tree
+    processed = NestedTransformer(mapper).visit(node)
+
+    return processed
+
+
+def unfold_blocked_tree(node):
+    """
+    Unfold nested :class:`IterationFold`.
+
+    Examples
+    ========
+    Given a section of Iteration/Expression tree as below: ::
+
+        for i = 1 to N-1  // folded
+          for j = 1 to N-1  // folded
+            foo1()
+
+    Assuming a fold with offset 1 in both /i/ and /j/ and body ``foo2()``, create:
+
+        for i = 1 to N-1
+          for j = 1 to N-1
+            foo1()
+        for i = 2 to N-2
+          for j = 2 to N-2
+            foo2()
+    """
+    # Search the unfolding candidates
+    candidates = []
+    for tree in retrieve_iteration_tree(node):
+        handle = tuple(i for i in tree if i.is_IterationFold)
+        if handle:
+            # Sanity check
+            assert IsPerfectIteration().visit(handle[0])
+            candidates.append(handle)
+
+    # Perform unfolding
+    mapper = {}
+    for tree in candidates:
+        unfolded = zip(*[i.unfold() for i in tree])
+        unfolded = [compose_nodes(i) for i in unfolded]
+        mapper[tree[0]] = List(body=unfolded)
+
+    # Insert the unfolded Iterations in the Iteration/Expression tree
+    processed = Transformer(mapper).visit(node)
+
+    return processed
+
+
+class IterationFold(Iteration):
+
+    """
+    An IterationFold is a special :class:`Iteration` object that represents
+    a sequence of consecutive (in program order) Iterations. In an IterationFold,
+    all Iterations of the sequence but the so called ``root`` are "hidden"; that is,
+    they cannot be visited by an Iteration/Expression tree visitor.
+
+    The Iterations in the sequence represented by the IterationFold all have same
+    dimension and properties. However, their extent is relative to that of the ``root``.
+    """
+
+    is_IterationFold = True
+
+    def __init__(self, nodes, dimension, limits, index=None, offsets=None,
+                 properties=None, folds=None):
+        super(IterationFold, self).__init__(nodes, dimension, limits, index,
+                                            offsets, properties)
+        self.folds = folds
+
+    def __repr__(self):
+        properties = ""
+        if self.properties:
+            properties = "WithProperties[%s]::" % ",".join(self.properties)
+        length = "Length %d" % len(self.folds)
+        return "<%sIterationFold %s; %s; %s>" % (properties, self.index,
+                                                 self.limits, length)
+
+    @property
+    def ccode(self):
+        comment = c.Comment('This IterationFold is "hiding" ore or more Iterations')
+        code = super(IterationFold, self).ccode
+        return c.Module([comment, code])
+
+    def unfold(self):
+        """
+        Return the corresponding :class:`Iteration` objects from each fold in ``self``.
+        """
+        args = self.args
+        args.pop('folds')
+
+        # Construct the root Iteration
+        root = Iteration(**args)
+
+        # Construct the folds
+        args.pop('nodes')
+        args.pop('offsets')
+        start, end, incr = args.pop('limits')
+        folds = tuple(Iteration(nodes, limits=[start+ofs[0], end+ofs[1], incr], **args)
+                      for ofs, nodes in self.folds)
+
+        return folds + as_tuple(root)

--- a/devito/dle/blocking_utils.py
+++ b/devito/dle/blocking_utils.py
@@ -190,9 +190,9 @@ class IterationFold(Iteration):
     is_IterationFold = True
 
     def __init__(self, nodes, dimension, limits, index=None, offsets=None,
-                 properties=None, folds=None):
+                 properties=None, pragmas=None, folds=None):
         super(IterationFold, self).__init__(nodes, dimension, limits, index,
-                                            offsets, properties)
+                                            offsets, properties, pragmas)
         self.folds = folds
 
     def __repr__(self):

--- a/devito/dle/blocking_utils.py
+++ b/devito/dle/blocking_utils.py
@@ -7,7 +7,7 @@ from devito.dse import xreplace_indices
 from devito.nodes import Expression, Iteration, List, LocalExpression
 from devito.visitors import (FindAdjacentIterations, FindNodes, IsPerfectIteration,
                              NestedTransformer, Transformer)
-from devito.tools import as_tuple, flatten
+from devito.tools import as_tuple
 
 __all__ = ['fold_blockable_tree', 'unfold_blocked_tree']
 

--- a/devito/dle/blocking_utils.py
+++ b/devito/dle/blocking_utils.py
@@ -156,9 +156,12 @@ def optimize_unfolded_tree(unfolded, root):
         handle = handle._rebuild(nodes=(zip(*stmts)[0] + handle.nodes))
         processed.append(tuple(otree[:-1]) + (handle,))
 
-        # Temporary arrays are now local storage
-        for j in subs:
-            j.output_function._mem_stack = True
+        # Temporary arrays can now be moved to the stack
+        if all(not j.is_Remainder for j in otree):
+            shape = tuple(j.bounds_symbolic[1] for j in otree)
+            for j in subs:
+                shape += j.output_function.shape[len(otree):]
+                j.output_function.update(shape=shape, onstack=True)
 
         # Introduce the new iteration variables within root
         candidates = [j.output for j in subs]

--- a/devito/dle/blocking_utils.py
+++ b/devito/dle/blocking_utils.py
@@ -205,7 +205,7 @@ class IterationFold(Iteration):
 
     @property
     def ccode(self):
-        comment = c.Comment('This IterationFold is "hiding" ore or more Iterations')
+        comment = c.Comment('This IterationFold is "hiding" one or more Iterations')
         code = super(IterationFold, self).ccode
         return c.Module([comment, code])
 

--- a/devito/dle/inspection.py
+++ b/devito/dle/inspection.py
@@ -3,7 +3,7 @@ from devito.visitors import FindSections
 __all__ = ['filter_iterations', 'retrieve_iteration_tree']
 
 
-def retrieve_iteration_tree(node):
+def retrieve_iteration_tree(node, mode='normal'):
     """Return a list of all :class:`Iteration` sub-trees rooted in ``node``.
     For example, given the Iteration tree:
 
@@ -19,9 +19,24 @@ def retrieve_iteration_tree(node):
     Return the list: ::
 
         [(Iteration i, Iteration j, Iteration k), (Iteration i, Iteration p)]
-    """
 
-    return [i for i in FindSections().visit(node).keys() if i]
+    :param node: The searched Iteration/Expression tree.
+    :param mode: Accepted values are 'normal' (default) and 'superset', in which
+                 case iteration trees that are subset of larget iteration trees
+                 are dropped.
+    """
+    assert mode in ('normal', 'superset')
+
+    trees = [i for i in FindSections().visit(node) if i]
+    if mode == 'normal':
+        return trees
+    else:
+        match = []
+        for i in trees:
+            if any(set(i).issubset(set(j)) for j in trees if i != j):
+                continue
+            match.append(i)
+        return match
 
 
 def filter_iterations(tree, key=lambda i: i, stop=lambda i: False):

--- a/devito/dle/inspection.py
+++ b/devito/dle/inspection.py
@@ -1,6 +1,7 @@
 from devito.visitors import FindSections
+from devito.tools import as_tuple
 
-__all__ = ['filter_iterations', 'retrieve_iteration_tree']
+__all__ = ['filter_iterations', 'retrieve_iteration_tree', 'is_foldable']
 
 
 def retrieve_iteration_tree(node, mode='normal'):
@@ -62,3 +63,16 @@ def filter_iterations(tree, key=lambda i: i, stop=lambda i: False):
             break
 
     return filtered
+
+
+def is_foldable(nodes):
+    """
+    Return True if the iterable ``nodes`` consists of foldable :class:`Iteration`
+    objects, False otherwise.
+    """
+    nodes = as_tuple(nodes)
+    if len(nodes) <= 1 or any(not i.is_Iteration for i in nodes):
+        return False
+    main = nodes[0]
+    return all(i.dim == main.dim and i.limits == main.limits and i.index == main.index
+               and i.properties == main.properties for i in nodes)

--- a/devito/dle/inspection.py
+++ b/devito/dle/inspection.py
@@ -23,7 +23,7 @@ def retrieve_iteration_tree(node, mode='normal'):
 
     :param node: The searched Iteration/Expression tree.
     :param mode: Accepted values are 'normal' (default) and 'superset', in which
-                 case iteration trees that are subset of larget iteration trees
+                 case iteration trees that are subset of larger iteration trees
                  are dropped.
     """
     assert mode in ('normal', 'superset')

--- a/devito/dle/manipulation.py
+++ b/devito/dle/manipulation.py
@@ -7,7 +7,9 @@ __all__ = ['compose_nodes', 'copy_arrays']
 
 
 def compose_nodes(nodes, retrieve=False):
-    """Build an Iteration/Expression tree by nesting the nodes in ``nodes``."""
+    """
+    Build an Iteration/Expression tree by nesting the nodes in ``nodes``.
+    """
     l = list(nodes)
     tree = []
 
@@ -25,10 +27,12 @@ def compose_nodes(nodes, retrieve=False):
 
 
 def copy_arrays(mapper, reverse=False):
-    """Build an Iteration/Expression tree performing the copy ``k = v``, or
+    """
+    Build an Iteration/Expression tree performing the copy ``k = v``, or
     ``v = k`` if reverse=True, for each (k, v) in mapper. (k, v) are expected
     to be of type :class:`IndexedData`. The loop bounds are inferred from
-    the dimensions used in ``k``."""
+    the dimensions used in ``k``.
+    """
     if not mapper:
         return ()
 

--- a/devito/dse/clusterizer.py
+++ b/devito/dse/clusterizer.py
@@ -34,6 +34,20 @@ class Cluster(object):
         return not self.is_dense
 
     def rebuild(self, exprs):
+        """
+        Build a new cluster with expressions ``exprs`` having same stencil
+        as ``self``.
+        """
+        return Cluster(exprs, self.stencil)
+
+    def reschedule(self, exprs):
+        """
+        Build a new cluster with expressions ``exprs`` having same stencil
+        as ``self``. The order of the expressions in the new cluster is such that
+        self's ordering is honored.
+        """
+        g = temporaries_graph(exprs)
+        exprs = g.reschedule(self.exprs)
         return Cluster(exprs, self.stencil)
 
 

--- a/devito/dse/symbolics.py
+++ b/devito/dse/symbolics.py
@@ -328,13 +328,14 @@ class Rewriter(object):
         rules = OrderedDict()
         stencils = []
         for c, (origin, alias) in enumerate(aliases.items()):
-            temporary = Indexed(template(c), *indices)
+            function = template(c)
+            temporary = Indexed(function, *indices)
             found.append(Eq(temporary, origin))
             # Track the stencil of each TensorFunction introduced
             stencils.append(alias.anti_stencil.anti(cluster.stencil))
             for aliased, distance in alias.with_distance:
                 coordinates = [sum([i, j]) for i, j in distance.items() if i in indices]
-                rules[candidates[aliased]] = Indexed(template(c), *tuple(coordinates))
+                rules[candidates[aliased]] = Indexed(function, *tuple(coordinates))
 
         # Create the alias clusters
         alias_clusters = clusterize(found, stencils)

--- a/devito/dse/symbolics.py
+++ b/devito/dse/symbolics.py
@@ -302,7 +302,7 @@ class Rewriter(object):
         # Redundancies will be stored in space-varying temporaries
         g = cluster.trace
         indices = g.space_indices
-        shape = g.space_shape
+        shape = tuple(i.symbolic_size for i in indices)
 
         # Template for captured redundancies
         name = self.conventions['redundancy'] + "%d"

--- a/devito/dse/symbolics.py
+++ b/devito/dse/symbolics.py
@@ -176,7 +176,7 @@ class Rewriter(object):
 
         processed, _ = xreplace_constrained(cluster.exprs, make, rule, cm)
 
-        return cluster.rebuild(processed)
+        return cluster.reschedule(processed)
 
     @dse_pass
     def _extract_time_invariants(self, cluster, **kwargs):
@@ -202,7 +202,7 @@ class Rewriter(object):
 
         found = common_subexprs_elimination(found, make)
 
-        return cluster.rebuild(found + leaves)
+        return cluster.reschedule(found + leaves)
 
     @dse_pass
     def _eliminate_intra_stencil_redundancies(self, cluster, **kwargs):
@@ -219,7 +219,7 @@ class Rewriter(object):
 
         processed = common_subexprs_elimination(candidates, make)
 
-        return cluster.rebuild(skip + processed)
+        return cluster.reschedule(skip + processed)
 
     @dse_pass
     def _factorize(self, cluster, **kwargs):

--- a/devito/exceptions.py
+++ b/devito/exceptions.py
@@ -14,6 +14,10 @@ class StencilOperationError(Exception):
     pass
 
 
+class VisitorException(Exception):
+    pass
+
+
 class DSEException(Exception):
     pass
 

--- a/devito/interfaces.py
+++ b/devito/interfaces.py
@@ -118,6 +118,12 @@ class AbstractSymbol(Function, CachedSymbol):
             options = kwargs.get('options', {})
             newobj = Function.__new__(newcls, *args, **options)
             newobj.__init__(*args, **kwargs)
+
+            # All objects cached on the AbstractSymbol /newobj/ keep a reference
+            # to /newobj/ through the /function/ field. Thus, all indexified
+            # object will point to /newobj/, the "actual Function".
+            newobj.function = newobj
+
             # Store new instance in symbol cache
             newcls._cache_put(newobj)
         return newobj
@@ -135,7 +141,7 @@ class AbstractSymbol(Function, CachedSymbol):
     @property
     def indexed(self):
         """Extract a :class:`IndexedData` object from the current object."""
-        return IndexedData(self.name, shape=self.shape, function=self)
+        return IndexedData(self.name, shape=self.shape, function=self.function)
 
     @property
     def _mem_external(self):

--- a/devito/interfaces.py
+++ b/devito/interfaces.py
@@ -144,6 +144,25 @@ class AbstractSymbol(Function, CachedSymbol):
         return IndexedData(self.name, shape=self.shape, function=self.function)
 
     @property
+    def symbolic_shape(self):
+        """
+        Return the symbolic shape of the object. For an entry ``E`` in ``self.shape``,
+        there are two possibilities: ::
+
+            * ``E`` is already in symbolic form, then simply use ``E``.
+            * ``E`` is an integer representing the size along a dimension ``D``,
+              then, use a symbolic representation of ``D``.
+        """
+        sshape = []
+        for i, j in zip(self.shape, self.indices):
+            try:
+                i.is_algebraic_expr()
+                sshape.append(i)
+            except AttributeError:
+                sshape.append(j.symbolic_size)
+        return tuple(sshape)
+
+    @property
     def _mem_external(self):
         """Return True if the associated data was/is/will be allocated directly
         from Python (e.g., via NumPy arrays), False otherwise."""

--- a/devito/interfaces.py
+++ b/devito/interfaces.py
@@ -215,7 +215,7 @@ class TensorFunction(SymbolicFunction):
             self.shape = kwargs.get('shape')
             self.indices = kwargs.get('dimensions')
             self.dtype = kwargs.get('dtype', np.float32)
-            self.onstack = kwargs.get('onstack', False)
+            self._onstack = kwargs.get('onstack', False)
 
     @classmethod
     def _indices(cls, **kwargs):
@@ -223,11 +223,15 @@ class TensorFunction(SymbolicFunction):
 
     @property
     def _mem_stack(self):
-        return self.onstack
+        return self._onstack
+
+    @_mem_stack.setter
+    def _mem_stack(self, val):
+        self._onstack = val
 
     @property
     def _mem_heap(self):
-        return not self.onstack
+        return not self._onstack
 
 
 class SymbolicData(AbstractSymbol):

--- a/devito/nodes.py
+++ b/devito/nodes.py
@@ -488,7 +488,8 @@ class Function(Node):
         alignment = "__attribute__((aligned(64)))"
         handle = [f for f in self.parameters
                   if isinstance(f, (SymbolicData, TensorFunction))]
-        shapes = [(f, ''.join(["[%s]" % i.ccode for i in f.indices[1:]])) for f in handle]
+        shapes = [(f, ''.join(["[%s]" % ccode(i) for i in f.symbolic_shape[1:]]))
+                  for f in handle]
         casts = [c.Initializer(c.POD(v.dtype,
                                      '(*restrict %s)%s %s' % (v.name, shape, alignment)),
                                '(%s (*)%s) %s' % (c.dtype_to_ctype(v.dtype),

--- a/devito/nodes.py
+++ b/devito/nodes.py
@@ -256,6 +256,7 @@ class Iteration(Node):
     :param properties: A bag of strings indicating properties of this Iteration.
                        For example, the string 'parallel' may be used to identify
                        a parallelizable Iteration.
+    :param pragmas: A bag of pragmas attached to this Iteration.
     """
 
     is_Iteration = True
@@ -270,11 +271,12 @@ class Iteration(Node):
                     executed in parallel.
         * vector-dim: A (SIMD) vectorizable iteration space.
         * elemental: Hoistable to an elemental function.
+        * remainder: A remainder iteration (e.g., by-product of some transformations)
     """
-    _known_properties = ['sequential', 'parallel', 'vector-dim', 'elemental']
+    _known_properties = ['sequential', 'parallel', 'vector-dim', 'elemental', 'remainder']
 
     def __init__(self, nodes, dimension, limits, index=None, offsets=None,
-                 properties=None):
+                 properties=None, pragmas=None):
         # Ensure we deal with a list of Expression objects internally
         nodes = as_tuple(nodes)
         self.nodes = as_tuple([n if isinstance(n, Node) else Expression(n)
@@ -304,9 +306,10 @@ class Iteration(Node):
             self.offsets[0] = min(self.offsets[0], int(off))
             self.offsets[1] = max(self.offsets[1], int(off))
 
-        # Track this Iteration's properties
+        # Track this Iteration's properties and pragmas
         self.properties = as_tuple(properties)
         assert (i in Iteration._known_properties for i in self.properties)
+        self.pragmas = as_tuple(pragmas)
 
     def __repr__(self):
         properties = ""
@@ -353,7 +356,10 @@ class Iteration(Node):
             loop_cond = '%s < %s' % (self.index, ccode(end))
             loop_inc = '%s += %s' % (self.index, self.limits[2])
 
-        return c.For(loop_init, loop_cond, loop_inc, c.Block(loop_body))
+        handle = c.For(loop_init, loop_cond, loop_inc, c.Block(loop_body))
+        if self.pragmas:
+            handle = c.Module(self.pragmas + (handle,))
+        return handle
 
     @property
     def is_Open(self):

--- a/devito/nodes.py
+++ b/devito/nodes.py
@@ -236,11 +236,9 @@ class Expression(Node):
 
 
 class Iteration(Node):
-    """Iteration object that encapsualtes a single loop over nodes, possibly
-    just SymPy expressions.
+    """Iteration object that encapsualtes a single loop over nodes.
 
-    :param nodes: Single or list of :class:`Node` objects that
-                        define the loop body.
+    :param nodes: Single or list of :class:`Node` objects defining the loop body.
     :param dimension: :class:`Dimension` object over which to iterate.
     :param limits: Limits for the iteration space, either the loop size or a
                    tuple of the form (start, finish, stepping).

--- a/devito/nodes.py
+++ b/devito/nodes.py
@@ -16,7 +16,7 @@ from devito.stencil import Stencil
 from devito.tools import as_tuple, filter_ordered
 
 __all__ = ['Node', 'Block', 'Denormals', 'Expression', 'Function', 'FunCall',
-           'Iteration', 'IterationFold', 'List', 'LocalExpression', 'TimedList']
+           'Iteration', 'List', 'LocalExpression', 'TimedList']
 
 
 class Node(object):
@@ -513,75 +513,6 @@ class Function(Node):
     @property
     def children(self):
         return (self.body,)
-
-
-# Special nodes useful for AST manipulation
-
-class IterationFold(Iteration):
-
-    """
-    An IterationFold is a sequence of :class:`Iteration` objects having same
-    dimension, limits and properties, but different offsets and bodies. In particular,
-    earlier :class:`Iteration` objects in the sequence have an iteration range
-    which is greater or equal than that of the later :class:`Iteration` objects.
-
-    An IterationFold, however, acts as a plain :class:`Iteration`; in other words,
-    its folds are "hidden" when the object is visited.
-
-    For example, an IterationFold could be used to represent the following sequence
-    of loops: ::
-
-        for i = 1 to N-1;
-          ...
-        for i = 2 to N-2;
-          ...
-        for i = 4 to N-4:
-          ...
-
-    In addition to the same :class:`Iteration` parameters, an :class:`IterationFold`
-    accepts the parameter ``folds``, an iterable of :class:`Iteration` objects from
-    which folds metadata is derived. In the example above, ``folds`` would be a list
-    of two items, the Iterations ``for i = 2 ..`` and ``for i = 4 ..``.
-    """
-
-    is_IterationFold = True
-
-    def __init__(self, nodes, dimension, limits, index=None, offsets=None,
-                 properties=None, folds=None):
-        super(IterationFold, self).__init__(nodes, dimension, limits, index,
-                                            offsets, properties)
-        self.folds = folds
-
-    def __repr__(self):
-        properties = ""
-        if self.properties:
-            properties = "WithProperties[%s]::" % ",".join(self.properties)
-        length = "Length %d" % len(self.folds)
-        return "<%sIterationFold %s; %s; %s>" % (properties, self.index,
-                                                 self.limits, length)
-
-    @property
-    def ccode(self):
-        comment = c.Comment('This IterationFold is "hiding" ore or more Iterations')
-        code = super(IterationFold, self).ccode
-        return c.Module([comment, code])
-
-    def unfold(self):
-        """
-        Return the corresponding :class:`Iteration` objects from each fold in ``self``.
-        """
-        args = self.args
-        args.pop('folds')
-
-        # Construct the root Iteration
-        root = Iteration(**args)
-
-        # Construct the folds
-        args.pop('nodes')
-        args.pop('offsets')
-        folds = tuple(Iteration(nodes, offsets=ofs, **args) for ofs, nodes in self.folds)
-
-        return as_tuple(root) + folds
 
 
 # Utilities

--- a/devito/nodes.py
+++ b/devito/nodes.py
@@ -60,6 +60,14 @@ class Node(object):
         raise NotImplementedError()
 
     @property
+    def view(self):
+        """
+        Generate a representation of the Iteration/Expression tree rooted in ``self``.
+        """
+        from devito.visitors import printAST
+        return printAST(self)
+
+    @property
     def children(self):
         """Return the traversable children."""
         return ()

--- a/devito/nodes.py
+++ b/devito/nodes.py
@@ -380,6 +380,10 @@ class Iteration(Node):
         return 'elemental' in self.properties
 
     @property
+    def is_Remainder(self):
+        return 'remainder' in self.properties
+
+    @property
     def bounds_symbolic(self):
         """Return a 2-tuple representing the symbolic bounds of the object."""
         start = self.limits[0]

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -399,6 +399,7 @@ class OperatorBasic(Function):
                 allocator.push_heap(k.output_function)
 
         # Introduce declarations on the stack
+        from IPython import embed; embed()
         for k, v in allocator.onstack:
             allocs = as_tuple([Element(i) for i in v])
             mapper[k] = Iteration(allocs + k.nodes, **k.args_frozen)
@@ -497,6 +498,8 @@ class OperatorCore(OperatorBasic):
                 info("Section %s with OI=%.2f computed in %.3f s [Perf: %.2f GFlops/s]" %
                      (name, v.oi, v.time, v.gflopss))
 
+        print "u_sum = ", arguments['u'].sum()
+        print "v_sum = ", arguments['v'].sum()
         return summary
 
     def _arg_data(self, argument):

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -392,14 +392,13 @@ class OperatorBasic(Function):
             elif k.output_function._mem_stack:
                 # On the stack, as established by the DLE
                 key = lambda i: i.dim not in k.output_function.indices
-                site = filter_iterations(v, key=key, stop='consecutive')
+                site = filter_iterations(reversed(v), key=key, stop='asap') or [nodes]
                 allocator.push_stack(site[-1], k.output_function)
             else:
                 # On the heap, as a tensor that must be globally accessible
                 allocator.push_heap(k.output_function)
 
         # Introduce declarations on the stack
-        from IPython import embed; embed()
         for k, v in allocator.onstack:
             allocs = as_tuple([Element(i) for i in v])
             mapper[k] = Iteration(allocs + k.nodes, **k.args_frozen)

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -404,6 +404,10 @@ class OperatorBasic(Function):
         nodes = NestedTransformer(mapper).visit(nodes)
         elemental_functions = Transformer(mapper).visit(dle_state.elemental_functions)
 
+        # TODO
+        # Use x_block_size+2, y_block_size+2 instead of x_size, y_size as shape of
+        # the tensor functions
+
         # Introduce declarations on the heap (if any)
         if allocator.onheap:
             decls, allocs, frees = zip(*allocator.onheap)

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -22,7 +22,7 @@ from devito.profiling import Profiler, create_profile
 from devito.stencil import Stencil
 from devito.tools import as_tuple, filter_ordered, flatten
 from devito.visitors import (FindSymbols, FindScopes, ResolveIterationVariable,
-                             SubstituteExpression, Transformer)
+                             SubstituteExpression, Transformer, NestedTransformer)
 from devito.exceptions import InvalidArgument, InvalidOperator
 
 __all__ = ['Operator']
@@ -400,9 +400,8 @@ class OperatorBasic(Function):
 
         # Introduce declarations on the stack
         for k, v in allocator.onstack:
-            allocs = as_tuple([Element(i) for i in v])
-            mapper[k] = Iteration(allocs + k.nodes, **k.args_frozen)
-        nodes = Transformer(mapper).visit(nodes)
+            mapper[k] = tuple(Element(i) for i in v)
+        nodes = NestedTransformer(mapper).visit(nodes)
         elemental_functions = Transformer(mapper).visit(dle_state.elemental_functions)
 
         # Introduce declarations on the heap (if any)

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -9,7 +9,7 @@ import numpy as np
 import sympy
 
 from devito.autotuning import autotune
-from devito.cgen_utils import Allocator, blankline, printmark, printvar
+from devito.cgen_utils import Allocator, blankline, printmark
 from devito.compiler import jit_compile, load
 from devito.dimension import Dimension, time
 from devito.dle import (compose_nodes, filter_iterations,
@@ -501,8 +501,6 @@ class OperatorCore(OperatorBasic):
                 info("Section %s with OI=%.2f computed in %.3f s [Perf: %.2f GFlops/s]" %
                      (name, v.oi, v.time, v.gflopss))
 
-        print "u_sum = ", arguments['u'].sum()
-        print "v_sum = ", arguments['v'].sum()
         return summary
 
     def _arg_data(self, argument):

--- a/devito/profiling.py
+++ b/devito/profiling.py
@@ -1,5 +1,88 @@
+from __future__ import absolute_import
+
+import operator
+from collections import OrderedDict, namedtuple
+from functools import reduce
+
 from ctypes import Structure, byref, c_double
 from cgen import Struct, Value
+
+from devito.dse import estimate_cost, estimate_memory
+from devito.nodes import Expression, TimedList
+from devito.visitors import IsPerfectIteration, FindSections, FindNodes, Transformer
+
+__all__ = ['Profile', 'create_profile']
+
+
+def create_profile(node):
+    """
+    Create a :class:`Profiler` for the Iteration/Expression tree ``node``.
+    The following code sections are profiled: ::
+
+        * The whole ``node``;
+        * A sequence of perfectly nested loops that have common :class:`Iteration`
+          dimensions, but possibly different extent. For example: ::
+
+            for x = 0 to N
+              ..
+            for x = 1 to N-1
+              ..
+
+          Both Iterations have dimension ``x``, and will be profiled as a single
+          section, though their extent is different.
+        * Any perfectly nested loops.
+    """
+    profiler = Profiler()
+
+    # Group by root Iteration
+    mapper = OrderedDict()
+    for itspace in FindSections().visit(node):
+        mapper.setdefault(itspace[0], []).append(itspace)
+
+    # Group sections if their iteration spaces overlap
+    key = lambda itspace: set([i.dim for i in itspace])
+    found = []
+    for v in mapper.values():
+        queue = list(v)
+        handle = []
+        while queue:
+            item = queue.pop(0)
+            if not handle or key(item) == key(handle[0]):
+                handle.append(item)
+            else:
+                # Found a timing section
+                found.append(tuple(handle))
+                handle = [item]
+        if handle:
+            found.append(tuple(handle))
+
+    # Create and track C-level timers
+    mapper = OrderedDict()
+    for i, group in enumerate(found):
+        name = 'section_%d' % i
+        section, remainder = group[0], group[1:]
+
+        index = len(section) > 1 and not IsPerfectIteration().visit(section[0])
+        root = section[index]
+
+        # Prepare to transform the Iteration/Expression tree
+        body = tuple(j[index] for j in group)
+        mapper[root] = TimedList(gname=profiler.varname, lname=name, body=body)
+        for j in remainder:
+            mapper[j[index]] = None
+
+        # Estimate computational properties of the profiled section
+        expressions = FindNodes(Expression).visit(body)
+        ops = estimate_cost([e.expr for e in expressions])
+        memory = estimate_memory([e.expr for e in expressions])
+
+        # Keep track of the new profiled section
+        profiler.add(name, section, ops, memory)
+
+    # Transform the Iteration/Expression tree introducing the C-level timers
+    processed = Transformer(mapper).visit(node)
+
+    return processed, profiler
 
 
 class Profiler(object):
@@ -12,22 +95,20 @@ class Profiler(object):
     typename = "profiler"
 
     def __init__(self):
-        self._timers = []
+        # To be populated as new sections are tracked
+        self._sections = OrderedDict()
         self._C_timings = None
 
-    def add(self, name):
+    def add(self, name, section, ops, memory):
         """
-        Add a C-level timer.
-        """
-        self._timers.append(name)
+        Add a profiling section.
 
-    @property
-    def ctype(self):
+        :param name: The name which uniquely identifies the profiled code section.
+        :param section: The code section, represented as a tuple of :class:`Iteration`s.
+        :param ops: The number of floating-point operations in the section.
+        :param memory: The memory traffic in the section, as bytes moved from/to memory.
         """
-        Returns a :class:`cgen.Struct` relative to the profiler.
-        """
-        return Struct(Profiler.typename,
-                      [Value('double', n) for n in self._timers])
+        self._sections[section] = Profile(name, ops, memory)
 
     def setup(self):
         """
@@ -35,9 +116,50 @@ class Profiler(object):
         all timers added to ``self`` through ``self.add(...)``.
         """
         cls = type("Timings", (Structure,),
-                   {"_fields_": [(n, c_double) for n in self._timers]})
+                   {"_fields_": [(i.name, c_double) for i in self._sections.values()]})
         self._C_timings = cls()
         return byref(self._C_timings)
+
+    def summary(self, dim_sizes, dtype):
+        """
+        Return a summary of the performance numbers measured.
+
+        :param dim_sizes: The run-time extent of each :class:`Iteration` tracked
+                          by this Profiler. Used to compute the operational intensity
+                          and the perfomance achieved in GFlops/s.
+        :param dtype: The data type of the objects in the profiled sections. Used
+                      to compute the operational intensity.
+        """
+
+        summary = PerformanceSummary()
+        for itspace, profile in self._sections.items():
+            dims = {i: i.dim.parent if i.dim.is_Buffered else i.dim for i in itspace}
+
+            # Time
+            time = self.timings[profile.name]
+
+            # Flops
+            itershape = [i.extent(finish=dim_sizes.get(dims[i].name)) for i in itspace]
+            iterspace = reduce(operator.mul, itershape)
+            flops = float(profile.ops*iterspace)
+            gflops = flops/10**9
+
+            # Compulsory traffic
+            datashape = [i.dim.size or dim_sizes[dims[i].name] for i in itspace]
+            dataspace = reduce(operator.mul, datashape)
+            traffic = profile.memory*dataspace*dtype().itemsize
+
+            # Derived metrics
+            oi = flops/traffic
+            gflopss = gflops/time
+
+            # Keep track of performance achieved
+            summary.setsection(profile.name, time, gflopss, oi, itershape, datashape)
+
+        # Rename the most time consuming section as 'main'
+        summary['main'] = summary.pop(max(summary, key=summary.get))
+
+        return summary
 
     @property
     def timings(self):
@@ -48,3 +170,41 @@ class Profiler(object):
             raise RuntimeError("Cannot extract timings with non-finalized Profiler.")
         return {field: max(getattr(self._C_timings, field), 10**-6)
                 for field, _ in self._C_timings._fields_}
+
+    @property
+    def ctype(self):
+        """
+        Returns a :class:`cgen.Struct` relative to the profiler.
+        """
+        return Struct(Profiler.typename,
+                      [Value('double', i.name) for i in self._sections.values()])
+
+
+class PerformanceSummary(OrderedDict):
+
+    """
+    A special dictionary to track and quickly access performance data.
+    """
+
+    def setsection(self, key, time, gflopss, oi, itershape, datashape):
+        self[key] = PerfEntry(time, gflopss, oi, itershape, datashape)
+
+    @property
+    def gflopss(self):
+        return OrderedDict([(k, v.gflopss) for k, v in self.items()])
+
+    @property
+    def oi(self):
+        return OrderedDict([(k, v.oi) for k, v in self.items()])
+
+    @property
+    def timings(self):
+        return OrderedDict([(k, v.time) for k, v in self.items()])
+
+
+Profile = namedtuple('Profile', 'name ops memory')
+"""Metadata for a profiled code section."""
+
+
+PerfEntry = namedtuple('PerfEntry', 'time gflopss oi itershape datashape')
+"""Structured performance data."""

--- a/devito/tools.py
+++ b/devito/tools.py
@@ -134,27 +134,6 @@ def convert_dtype_to_ctype(dtype):
     return conversion_dict[dtype]
 
 
-def aligned(a, alignment=16):
-    """Function to align the memmory
-
-    :param a: The given memory
-    :param alignment: Granularity of alignment, 16 bytes by default
-    :returns: Reference to the start of the aligned memory
-    """
-    if (a.ctypes.data % alignment) == 0:
-        return a
-
-    extra = alignment / a.itemsize
-    buf = np.empty(a.size + extra, dtype=a.dtype)
-    ofs = (-buf.ctypes.data % alignment) / a.itemsize
-    aa = buf[ofs:ofs+a.size].reshape(a.shape)
-    np.copyto(aa, a)
-
-    assert (aa.ctypes.data % alignment) == 0
-
-    return aa
-
-
 def pprint(node, verbose=True):
     """
     Shortcut to pretty print Iteration/Expression trees.

--- a/devito/visitors.py
+++ b/devito/visitors.py
@@ -363,8 +363,9 @@ class FindNodes(Visitor):
 
 class IsPerfectIteration(Visitor):
 
-    """Return True if an :class:`Iteration` defines a perfect loop nest,
-    False otherwise."""
+    """
+    Return True if an :class:`Iteration` defines a perfect loop nest, False otherwise.
+    """
 
     def visit_object(self, o, **kwargs):
         return False
@@ -385,7 +386,8 @@ class IsPerfectIteration(Visitor):
 
 class Transformer(Visitor):
 
-    """Given an Iteration/Expression tree T and a mapper from nodes in T to
+    """
+    Given an Iteration/Expression tree T and a mapper from nodes in T to
     a set of new nodes L, M : N --> L, build a new Iteration/Expression tree T'
     where a node ``n`` in N is replaced with ``M[n]``.
     """
@@ -419,8 +421,9 @@ class Transformer(Visitor):
 
 
 class NestedTransformer(Transformer):
+
     """
-    As opposed to a :class:`Transformer`, a :class:`NestedTransforer` applies
+    Unlike a :class:`Transformer`, a :class:`NestedTransforer` applies
     replacements in a depth-first fashion.
     """
 

--- a/tests/test_dle.py
+++ b/tests/test_dle.py
@@ -148,11 +148,11 @@ def test_create_elemental_functions_simple(simple_function):
   {
     for (int j = 0; j < 5; j += 1)
     {
-      f_0_0((float*) a,(float*) b,(float*) c,(float*) d,i,j);
+      f_0((float*) a,(float*) b,(float*) c,(float*) d,i,j);
     }
   }
 }
-void f_0_0(float *restrict a_vec, float *restrict b_vec,"""
+void f_0(float *restrict a_vec, float *restrict b_vec,"""
          """ float *restrict c_vec, float *restrict d_vec, const int i, const int j)
 {
   float (*restrict a) __attribute__((aligned(64))) = (float (*)) a_vec;
@@ -187,15 +187,15 @@ def test_create_elemental_functions_complex(complex_function):
   float (*restrict d)[5][7] __attribute__((aligned(64))) = (float (*)[5][7]) d_vec;
   for (int i = 0; i < 3; i += 1)
   {
-    f_0_0((float*) a,(float*) b,i);
+    f_0((float*) a,(float*) b,i);
     for (int j = 0; j < 5; j += 1)
     {
-      f_0_1((float*) a,(float*) b,(float*) c,(float*) d,i,j);
+      f_1((float*) a,(float*) b,(float*) c,(float*) d,i,j);
     }
-    f_0_2((float*) a,(float*) b,i);
+    f_2((float*) a,(float*) b,i);
   }
 }
-void f_0_0(float *restrict a_vec, float *restrict b_vec, const int i)
+void f_0(float *restrict a_vec, float *restrict b_vec, const int i)
 {
   float (*restrict a) __attribute__((aligned(64))) = (float (*)) a_vec;
   float (*restrict b) __attribute__((aligned(64))) = (float (*)) b_vec;
@@ -204,7 +204,7 @@ void f_0_0(float *restrict a_vec, float *restrict b_vec, const int i)
     b[i] = a[i] + pow(b[i], 2) + 3;
   }
 }
-void f_0_1(float *restrict a_vec, float *restrict b_vec,"""
+void f_1(float *restrict a_vec, float *restrict b_vec,"""
          """ float *restrict c_vec, float *restrict d_vec, const int i, const int j)
 {
   float (*restrict a) __attribute__((aligned(64))) = (float (*)) a_vec;
@@ -217,7 +217,7 @@ void f_0_1(float *restrict a_vec, float *restrict b_vec,"""
     a[i] = 4*(a[i] + c[i][j])*(b[i] + d[i][j][k]);
   }
 }
-void f_0_2(float *restrict a_vec, float *restrict b_vec, const int i)
+void f_2(float *restrict a_vec, float *restrict b_vec, const int i)
 {
   float (*restrict a) __attribute__((aligned(64))) = (float (*)) a_vec;
   float (*restrict b) __attribute__((aligned(64))) = (float (*)) b_vec;

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -264,15 +264,15 @@ class TestDeclarator(object):
         assert """\
   float (*a);
   posix_memalign((void**)&a, 64, sizeof(float[3]));
-  struct timeval start_loop_i_0, end_loop_i_0;
-  gettimeofday(&start_loop_i_0, NULL);
+  struct timeval start_section_0, end_section_0;
+  gettimeofday(&start_section_0, NULL);
   for (int i = 0; i < 3; i += 1)
   {
     a[i] = a[i] + b[i] + 5.0F;
   }
-  gettimeofday(&end_loop_i_0, NULL);
-  timings->loop_i_0 += (double)(end_loop_i_0.tv_sec-start_loop_i_0.tv_sec)\
-+(double)(end_loop_i_0.tv_usec-start_loop_i_0.tv_usec)/1000000;
+  gettimeofday(&end_section_0, NULL);
+  timings->section_0 += (double)(end_section_0.tv_sec-start_section_0.tv_sec)\
++(double)(end_section_0.tv_usec-start_section_0.tv_usec)/1000000;
   free(a);
   return 0;""" in str(operator.ccode)
 
@@ -283,8 +283,8 @@ class TestDeclarator(object):
   float (*c)[5];
   posix_memalign((void**)&a, 64, sizeof(float[3]));
   posix_memalign((void**)&c, 64, sizeof(float[3][5]));
-  struct timeval start_loop_i_0, end_loop_i_0;
-  gettimeofday(&start_loop_i_0, NULL);
+  struct timeval start_section_0, end_section_0;
+  gettimeofday(&start_section_0, NULL);
   for (int i = 0; i < 3; i += 1)
   {
     for (int j = 0; j < 5; j += 1)
@@ -293,9 +293,9 @@ class TestDeclarator(object):
       c[i][j] = a[i]*c[i][j];
     }
   }
-  gettimeofday(&end_loop_i_0, NULL);
-  timings->loop_i_0 += (double)(end_loop_i_0.tv_sec-start_loop_i_0.tv_sec)\
-+(double)(end_loop_i_0.tv_usec-start_loop_i_0.tv_usec)/1000000;
+  gettimeofday(&end_section_0, NULL);
+  timings->section_0 += (double)(end_section_0.tv_sec-start_section_0.tv_sec)\
++(double)(end_section_0.tv_usec-start_section_0.tv_usec)/1000000;
   free(a);
   free(c);
   return 0;""" in str(operator.ccode)
@@ -307,19 +307,19 @@ class TestDeclarator(object):
   float (*c)[5];
   posix_memalign((void**)&a, 64, sizeof(float[3]));
   posix_memalign((void**)&c, 64, sizeof(float[3][5]));
+  struct timeval start_section_0, end_section_0;
+  gettimeofday(&start_section_0, NULL);
   for (int i = 0; i < 3; i += 1)
   {
     a[i] = 0.0F;
-    struct timeval start_loop_j_0, end_loop_j_0;
-    gettimeofday(&start_loop_j_0, NULL);
     for (int j = 0; j < 5; j += 1)
     {
       c[i][j] = a[i]*c[i][j];
     }
-    gettimeofday(&end_loop_j_0, NULL);
-    timings->loop_j_0 += (double)(end_loop_j_0.tv_sec-start_loop_j_0.tv_sec)\
-+(double)(end_loop_j_0.tv_usec-start_loop_j_0.tv_usec)/1000000;
   }
+  gettimeofday(&end_section_0, NULL);
+  timings->section_0 += (double)(end_section_0.tv_sec-start_section_0.tv_sec)\
++(double)(end_section_0.tv_usec-start_section_0.tv_usec)/1000000;
   free(a);
   free(c);
   return 0;""" in str(operator.ccode)
@@ -330,32 +330,32 @@ class TestDeclarator(object):
         assert """\
   float (*a);
   posix_memalign((void**)&a, 64, sizeof(float[3]));
-  struct timeval start_loop_i_0, end_loop_i_0;
-  gettimeofday(&start_loop_i_0, NULL);
+  struct timeval start_section_0, end_section_0;
+  gettimeofday(&start_section_0, NULL);
   for (int i = 0; i < 3; i += 1)
   {
     float t0 = 1.00000000000000F;
     float t1 = 2.00000000000000F;
     a[i] = 3.0F*t0*t1;
   }
-  gettimeofday(&end_loop_i_0, NULL);
-  timings->loop_i_0 += (double)(end_loop_i_0.tv_sec-start_loop_i_0.tv_sec)\
-+(double)(end_loop_i_0.tv_usec-start_loop_i_0.tv_usec)/1000000;
+  gettimeofday(&end_section_0, NULL);
+  timings->section_0 += (double)(end_section_0.tv_sec-start_section_0.tv_sec)\
++(double)(end_section_0.tv_usec-start_section_0.tv_usec)/1000000;
   free(a);
   return 0;""" in str(operator.ccode)
 
     def test_stack_vector_temporaries(self, c_stack, e):
         operator = Operator([Eq(c_stack, e*1.)], dse='noop', dle='noop')
         assert """\
-  struct timeval start_loop_k_0, end_loop_k_0;
-  gettimeofday(&start_loop_k_0, NULL);
+  struct timeval start_section_0, end_section_0;
+  gettimeofday(&start_section_0, NULL);
   for (int k = 0; k < 7; k += 1)
   {
     for (int s = 0; s < 4; s += 1)
     {
       for (int q = 0; q < 4; q += 1)
       {
-        double c_stack[3][5] __attribute__((aligned(64)));
+        float c_stack[3][5] __attribute__((aligned(64)));
         for (int i = 0; i < 3; i += 1)
         {
           for (int j = 0; j < 5; j += 1)
@@ -366,9 +366,9 @@ class TestDeclarator(object):
       }
     }
   }
-  gettimeofday(&end_loop_k_0, NULL);
-  timings->loop_k_0 += (double)(end_loop_k_0.tv_sec-start_loop_k_0.tv_sec)\
-+(double)(end_loop_k_0.tv_usec-start_loop_k_0.tv_usec)/1000000;
+  gettimeofday(&end_section_0, NULL);
+  timings->section_0 += (double)(end_section_0.tv_sec-start_section_0.tv_sec)\
++(double)(end_section_0.tv_usec-start_section_0.tv_usec)/1000000;
   return 0;""" in str(operator.ccode)
 
 
@@ -403,7 +403,7 @@ class TestLoopScheduler(object):
         assert outer[-1].nodes[0].expr.rhs == eq1.rhs
         assert inner[-1].nodes[0].expr.rhs == eq2.rhs
 
-    def test_different_loop_nests(self, tu, ti0, t0, t1):
+    def test_different_section_nests(self, tu, ti0, t0, t1):
         eq1 = Eq(ti0, t0*3.)
         eq2 = Eq(tu, ti0 + t1*3.)
         op = Operator([eq1, eq2], dse='noop', dle='noop')


### PR DESCRIPTION
This PR does three main things:

1- it ships a range of (relatively small) improvements all over the codebase
2- bug fixes
3- it "generalizes" the loop blocking algorithm

1 - Improvements
=============
1.1 Simpler and more effective DLE ``create_elemental_functions()``
1.2 More powerful DLE inspection routines (eg, ``filter_iterations()``)
1.3 Better, refreshed documentation
1.4 Introduction of ``OperatorDebug`` to ease C-level debugging
1.5 Refactoring. Profiling now in a separate module; dropped legacy functions (now unused); more visitors, enhanced Transformer; updated tests

2 - Bug fixes
=========
2.1 Always attempt to generate parametric array sizes
2.2 Fix data type construction at code generation time (see changes in ``cgen_utils.py``)
2.3 Attach pragmas to ``Iteration``, not through ``List`` objects
2.4 Fix DLE's data dependence analysis (subtle, rare bug arising due to the other changes in this PR)
2.5 Minor fixes to some visitors (handle some corner cases)
2.6 DSE: Introduce ``cluster.reschedule()`` to honor original expression ordering (fixes subtle, rare bug)
2.7 Reuse existing ``function`` instance (type: ``AbstractSymbol``) when calling ``.indexed`` on a data object

3 - Generalized loop blocking
=======================
This is the main contribution of the PR. 
Here's the problem: *if* cross-stencil redundancies are detected by the DSE (also read the note at the bottom), then what you see [here](https://gist.github.com/FabioLuporini/0f8be298523d10b6978d55e1e5553f8f) at the top is the resulting loop nest; that is, this is the loop nest in **input** to the DLE. Capturing cross-stencil redundancies increases the memory footprint, so the only option to avoid an explosion in occupied memory is to apply loop blocking **across** the two loop nests that you see at the link (the first loop nest is pre-evaluating the cross-stencil redundancies into vector temporaries). This required two major changes to the loop blocking algorithm:

* The introduction of ``IterationFold``, as well as routines to "fold" and "unfold" iterations. Folding (which has **nothing** to do with YASK's vector folding) is the process by means of which a sequence of consecutive loop nests are mapped onto a "single abstract loop nest". You see these routines in the new Python module ``blocking_utils.py``. The usual loop blocking algorithm is then applied to ``IterationFold``s, rather than ``Iteration``s.
* Changing the original blocking algorithm so that the remainder loops are also blocked. This is necessary because the created vector temporaries are of size ``[x_block_size][y_block_size][z_block_size]``, and if a remainder loop went from 0 to say ``x_size-1``, rather than to ``x_block_size-1``, then we would end up accessing illegal memory

The (crazy) structure of the loop nest returned by the DLE is shown at the link above.

***FINAL NOTE***
The cross-stencil redundancies detection algorithm is now available in Devito and all tests pass if activated, but at the moment it is still off by default. This is because of two reasons: 1) a complete performance evaluation is missing; 2) a few minor (performance) fixes are still required. To turn the pass on, just switch the following line in ``dse/symbolics.py``:

`'_extract_time_varying': ('future',),` --> `'_extract_time_varying': ('advanced',),`