### PR TITLE
Test emptiness of array object

### DIFF
--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -446,3 +446,12 @@ class TestForeign(object):
         arg, _ = op.arguments(a=b)
         op2.cfunction(*list(arg.values()))
         assert(np.allclose(a.data[:], b.data[:]))
+
+    def test_empty_arrays(self):
+        shape = (11, 11)
+        a = TimeData(name='a', shape=shape, time_order=1,
+                     time_dim=6, save=True)
+        eqn = Eq(a.forward, a + 1.)
+        op = Operator(eqn, external=True)
+        arg = dict(op.arguments())
+        assert (arg['a'] is None)


### PR DESCRIPTION
Extra small test. The main point of `OperatorForeign' is to bypass devito memory allocation for 'DenseData' objects. This new test makes sure of it.

I do know that this is not the main aim of Devito but this is necessary for the Julia interface to avoid duplicate allocation, specially for large object such as the full wavefield for the gradient.