### PR TITLE
cached-property install

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ mpmath>=0.19
 pytest
 pytest-ipynb
 flake8>=2.1.0
-cached_property
+cached-property
 isort
 py-cpuinfo
 psutil>=5.1.0

--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,5 @@ setup(name='devito',
       license='MIT',
       packages=find_packages(exclude=['docs', 'examples', 'tests']),
       install_requires=['numpy', 'sympy==1.0', 'mpmath', 'cgen', 'codepy',
-                        'psutil', 'py-cpuinfo'],
+                        'psutil', 'py-cpuinfo', 'cached-property'],
       test_requires=['pytest', 'flake8', 'isort'])


### PR DESCRIPTION
Added missing entry in the `setup.py` file.

Also for some reason install wants `cached-property` instead of `cached_property`