### PR TITLE
Travis: Drop external conda channels and use pip instead

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,20 +1,18 @@
 name: devito
 channels:
   - defaults
-  - conda-forge
-  - omnia  # pytest-ipynb
 dependencies:
   - numpy >=1.11
   - sympy ==1.0
   - matplotlib
   - pytest
-  - pytest-ipynb
   - flake8>=2.1.0
   - cached-property
-  - py-cpuinfo
   - psutil>=5.1.0
   - sphinx
   - sphinx_rtd_theme
   - pip:
     - "git+git://github.com/inducer/cgen"
     - "git+git://github.com/inducer/codepy"
+    - pytest-ipynb >=1.1
+    - py-cpuinfo


### PR DESCRIPTION
Should fix travis testing and needs to be rebased/merged into ongoing development.