### PR TITLE
Small fixes for Python3 environments

### DIFF
--- a/devito/memory.py
+++ b/devito/memory.py
@@ -12,6 +12,11 @@ from devito.dimension import t
 from devito.logger import error
 from devito.tools import convert_dtype_to_ctype
 
+"""
+Pre-load ``libc`` to explicitly manage C memory
+"""
+libc = ctypes.CDLL(find_library('c'))
+
 
 class CMemory(object):
 
@@ -38,7 +43,6 @@ def malloc_aligned(shape, alignment=None, dtype=np.float32):
     object. The second element is the low-level reference that is
     needed only for the call to free.
     """
-    libc = ctypes.CDLL(find_library('c'))
     data_pointer = ctypes.cast(ctypes.c_void_p(), ctypes.POINTER(ctypes.c_float))
     arraysize = int(reduce(mul, shape))
     ctype = convert_dtype_to_ctype(dtype)
@@ -67,7 +71,6 @@ def free(internal_pointer):
     """Use the C function free to free the memory allocated for the
     given pointer.
     """
-    libc = ctypes.CDLL(find_library('c'))
     libc.free(internal_pointer)
 
 

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -118,10 +118,10 @@ class Operator(Function):
         self.symbolic_data = [i for i in parameters if isinstance(i, SymbolicData)]
         dims = [i for i in parameters if isinstance(i, Dimension)]
         dims_parents = [d.parent for d in dims if d.is_Buffered]
-        self.dims = list(set(dims + dims_parents))
+        self.dims = filter_ordered(dims + dims_parents)
         assert(all(isinstance(i, ArgumentProvider) for i in self.symbolic_data +
                    self.dims))
-        parameters = list(set(parameters + dims_parents))
+        parameters = filter_ordered(parameters + dims_parents)
 
         # Translate into backend-specific representation (e.g., GPU, Yask)
         nodes, elemental_functions = self._specialize(nodes, elemental_functions)


### PR DESCRIPTION
1) Pre-load `libc` in `memory.py` to avoid race-conditions on unclean shutdowns in Python3, eg.:
```
ImportError: sys.meta_path is None, Python is likely shutting down
```
2) Use `filter_ordered` instead of `list(set(...))` during parameter derivation in `operator.py` (the former is deterministic, the latter is not).