### PR TITLE
Seismic: Fix "Explicit time dimension" warning for forward wavefields

### DIFF
--- a/examples/seismic/acoustic/operators.py
+++ b/examples/seismic/acoustic/operators.py
@@ -19,9 +19,9 @@ def ForwardOperator(model, source, receiver, time_order=2, space_order=4,
     m, damp = model.m, model.damp
 
     # Create symbols for forward wavefield, source and receivers
-    u = TimeData(name='u', shape=model.shape_domain, time_dim=source.nt,
-                 time_order=time_order, space_order=space_order, save=save,
-                 dtype=model.dtype)
+    u = TimeData(name='u', shape=model.shape_domain, dtype=model.dtype,
+                 save=save, time_dim=source.nt if save else None,
+                 time_order=time_order, space_order=space_order)
     src = PointSource(name='src', ntime=source.nt, ndim=source.ndim,
                       npoint=source.npoint)
     rec = Receiver(name='rec', ntime=receiver.nt, ndim=receiver.ndim,

--- a/examples/seismic/acoustic/wavesolver.py
+++ b/examples/seismic/acoustic/wavesolver.py
@@ -96,8 +96,8 @@ class AcousticWaveSolver(object):
 
         # Create the forward wavefield if not provided
         if u is None:
-            u = TimeData(name='u', shape=self.model.shape_domain,
-                         save=save, time_dim=self.source.nt,
+            u = TimeData(name='u', shape=self.model.shape_domain, save=save,
+                         time_dim=self.source.nt if save else None,
                          time_order=self.time_order,
                          space_order=self.space_order,
                          dtype=self.model.dtype)

--- a/examples/seismic/tti/operators.py
+++ b/examples/seismic/tti/operators.py
@@ -24,12 +24,12 @@ def ForwardOperator(model, source, receiver, time_order=2, space_order=4,
                                            model.delta, model.theta, model.phi)
 
     # Create symbols for forward wavefield, source and receivers
-    u = TimeData(name='u', shape=model.shape_domain, time_dim=source.nt,
-                 time_order=time_order, space_order=space_order, save=save,
-                 dtype=model.dtype)
-    v = TimeData(name='v', shape=model.shape_domain, time_dim=source.nt,
-                 time_order=time_order, space_order=space_order, save=save,
-                 dtype=model.dtype)
+    u = TimeData(name='u', shape=model.shape_domain, dtype=model.dtype,
+                 save=save, time_dim=source.nt if save else None,
+                 time_order=time_order, space_order=space_order)
+    v = TimeData(name='v', shape=model.shape_domain, dtype=model.dtype,
+                 save=save, time_dim=source.nt if save else None,
+                 time_order=time_order, space_order=space_order)
     src = PointSource(name='src', ntime=source.nt, ndim=source.ndim,
                       npoint=source.npoint)
     rec = Receiver(name='rec', ntime=receiver.nt, ndim=receiver.ndim,

--- a/examples/seismic/tti/wavesolver.py
+++ b/examples/seismic/tti/wavesolver.py
@@ -76,8 +76,8 @@ class AnisotropicWaveSolver(object):
 
         # Create the forward wavefield if not provided
         if u is None:
-            u = TimeData(name='u', shape=self.model.shape_domain,
-                         save=save, time_dim=self.source.nt,
+            u = TimeData(name='u', shape=self.model.shape_domain, save=save,
+                         time_dim=self.source.nt if save else None,
                          time_order=self.time_order,
                          space_order=self.space_order,
                          dtype=self.model.dtype)


### PR DESCRIPTION
Should be fairly uncontroversial and fix the flood of "Explicit time dimension" warnings generated by our seismic wavesolver wrappers for forward operators.