### PR TITLE
Remove critical circular dependencies

### DIFF
--- a/devito/__init__.py
+++ b/devito/__init__.py
@@ -8,8 +8,9 @@ from devito.backends import init_backend
 from devito.finite_difference import *  # noqa
 from devito.dimension import *  # noqa
 from devito.interfaces import Forward, Backward, _SymbolCache  # noqa
+from devito.logger import error, warning, info  # noqa
 from devito.parameters import (configuration, init_configuration,  # noqa
-                               print_defaults, print_state)
+                               env_vars_mapper)
 
 
 def clear_cache():
@@ -27,5 +28,21 @@ del get_versions
 
 
 # Initialize the Devito backend
+configuration.add('travis_test', 0, [0, 1], lambda i: bool(i))
+configuration.add('autotuning', 'basic', ['none', 'basic', 'aggressive'])
 init_configuration()
 init_backend(configuration['backend'])
+
+
+def print_defaults():
+    """Print the environment variables accepted by Devito, their default value,
+    as well as all of the accepted values."""
+    for k, v in env_vars_mapper.items():
+        info('%s: %s. Default: %s' % (k, configuration._accepted[v],
+                                      configuration._defaults[v]))
+
+
+def print_state():
+    """Print the current configuration state."""
+    for k, v in configuration.items():
+        info('%s: %s' % (k, v))

--- a/devito/backends.py
+++ b/devito/backends.py
@@ -11,6 +11,7 @@ from sympy.core.function import FunctionClass
 
 from devito.exceptions import DevitoError
 from devito.logger import warning
+from devito.parameters import configuration
 
 backends = {}
 
@@ -144,3 +145,6 @@ def init_backend(backend):
             set_backend(backend)
         except (ImportError, RuntimeError):
             raise DevitoError("Couldn't initialize Devito.")
+
+
+configuration.add('backend', 'core', list(backends_registry))

--- a/devito/core/autotuning.py
+++ b/devito/core/autotuning.py
@@ -8,12 +8,13 @@ import resource
 
 from devito.logger import info, info_at
 from devito.nodes import Iteration
+from devito.parameters import configuration
 from devito.visitors import FindNodes, FindSymbols
 
 __all__ = ['autotune']
 
 
-def autotune(operator, arguments, tunable, mode='basic'):
+def autotune(operator, arguments, tunable):
     """
     Acting as a high-order function, take as input an operator and a list of
     operator arguments to perform empirical autotuning. Some of the operator
@@ -37,7 +38,7 @@ def autotune(operator, arguments, tunable, mode='basic'):
     mapper = OrderedDict([(i.argument.symbolic_size.name, i) for i in tunable])
     blocksizes = [OrderedDict([(i, v) for i in mapper])
                   for v in options['at_blocksize']]
-    if mode == 'aggressive':
+    if configuration['autotuning'] == 'aggressive':
         blocksizes = more_heuristic_attempts(blocksizes)
 
     # How many temporaries are allocated on the stack?

--- a/devito/core/operator.py
+++ b/devito/core/operator.py
@@ -5,7 +5,6 @@ from devito.cgen_utils import printmark
 from devito.dle import filter_iterations, retrieve_iteration_tree
 from devito.nodes import List
 from devito.operator import OperatorRunnable
-from devito.parameters import configuration
 from devito.visitors import Transformer
 from devito.tools import flatten
 
@@ -20,8 +19,7 @@ class OperatorCore(OperatorRunnable):
         best block sizes when loop blocking is in use.
         """
         if self.dle_flags.get('blocking', False):
-            return autotune(self, arguments, self.dle_arguments,
-                            mode=configuration['autotuning'])
+            return autotune(self, arguments, self.dle_arguments)
         else:
             return arguments
 

--- a/devito/dle/transformer.py
+++ b/devito/dle/transformer.py
@@ -5,6 +5,7 @@ from devito.dle.backends import (State, BasicRewriter, DevitoCustomRewriter,
                                  DevitoSpeculativeRewriter)
 from devito.exceptions import DLEException
 from devito.logger import dle_warning
+from devito.parameters import configuration
 
 __all__ = ['transform', 'modes', 'default_options']
 
@@ -23,6 +24,11 @@ default_options = {
     'blockalways': False
 }
 """Default values for the various optimization options."""
+
+configuration.add('dle', 'advanced', list(modes))
+configuration.add('dle_options',
+                  ';'.join('%s:%s' % (k, v) for k, v in default_options.items()),
+                  list(default_options))
 
 
 def transform(node, mode='basic', options=None):
@@ -55,8 +61,6 @@ def transform(node, mode='basic', options=None):
         * 'blockalways': Apply blocking even though the DLE thinks it's not
                          worthwhile applying it.
     """
-    from devito.parameters import configuration
-
     # Check input parameters
     if not (mode is None or isinstance(mode, str)):
         raise ValueError("Parameter 'mode' should be a string, not %s." % type(mode))

--- a/devito/dse/symbolics.py
+++ b/devito/dse/symbolics.py
@@ -4,8 +4,9 @@ from devito.dse.backends import (BasicRewriter, AdvancedRewriter, SpeculativeRew
                                  AggressiveRewriter, CustomRewriter)
 from devito.exceptions import DSEException
 from devito.logger import dse_warning
+from devito.parameters import configuration
 
-__all__ = ['rewrite', 'modes']
+__all__ = ['rewrite']
 
 
 modes = {
@@ -15,6 +16,8 @@ modes = {
     'aggressive': AggressiveRewriter
 }
 """The DSE transformation modes."""
+
+configuration.add('dse', 'advanced', list(modes))
 
 
 def rewrite(clusters, mode='advanced'):

--- a/devito/logger.py
+++ b/devito/logger.py
@@ -4,6 +4,8 @@ import logging
 import sys
 from contextlib import contextmanager
 
+from devito.parameters import configuration
+
 __all__ = ('set_log_level', 'set_log_noperf', 'log',
            'DEBUG', 'AUTOTUNER', 'YASK', 'YASK_WARN', 'INFO', 'DSE', 'DSE_WARN',
            'DLE', 'DLE_WARN', 'WARNING', 'ERROR', 'CRITICAL',
@@ -89,6 +91,10 @@ def set_log_level(level):
 def set_log_noperf():
     """Do not print performance-related messages."""
     logger.setLevel(WARNING)
+
+
+configuration.add('log_level', 'INFO', list(logger_registry),
+                  lambda i: set_log_level(i))
 
 
 def log(msg, level=INFO, *args, **kwargs):

--- a/devito/parameters.py
+++ b/devito/parameters.py
@@ -3,14 +3,7 @@
 from collections import OrderedDict
 from os import environ
 
-from devito.backends import backends_registry
-from devito.compiler import compiler_registry, set_compiler
-from devito.dse import modes as dse_registry
-from devito.dle import modes as dle_registry, default_options as dle_default_options
-from devito.logger import info, logger_registry, set_log_level
-from devito.interfaces import set_global_first_touch as set_first_touch
-
-__all__ = ['configuration', 'init_configuration', 'print_defaults', 'print_state']
+__all__ = ['configuration', 'init_configuration']
 
 # Be EXTREMELY careful when writing to a Parameters dictionary
 # Read here for reference: http://wiki.c2.com/?GlobalVariablesAreBad
@@ -29,6 +22,8 @@ class Parameters(OrderedDict):
     def __init__(self, name=None, **kwargs):
         super(Parameters, self).__init__(**kwargs)
         self._name = name
+        self._accepted = {}
+        self._defaults = {}
         self._update_functions = {}
         if kwargs is not None:
             for key, value in kwargs.items():
@@ -44,14 +39,32 @@ class Parameters(OrderedDict):
         been updated.
         """
         if key in self._update_functions:
-            self._update_functions[key](value)
+            retval = self._update_functions[key](value)
+            if retval is not None:
+                super(Parameters, self).__setitem__(key, retval)
 
-    def set_update_function(self, key, callable):
+    def add(self, key, value, accepted, callback=None):
         """
-        Make ``callable`` be executed when the value of ``key`` changes.
+        Add a new parameter ``key`` with default value ``value``.
+
+        Associate ``key`` with a list of ``accepted`` values.
+
+        If provided, make sure ``callback`` is executed when the value of ``key``
+        changes.
+        """
+        super(Parameters, self).__setitem__(key, value)
+        self._accepted[key] = accepted
+        self._defaults[key] = value
+        if callable(callback):
+            self._update_functions[key] = callback
+
+    def update(self, key, value):
+        """
+        Update the parameter ``key`` to ``value``. This is different from
+        ``self[key] = value`` as the callback, if any, is bypassed.
         """
         assert key in self
-        self._update_functions[key] = callable
+        super(Parameters, self).__setitem__(key, value)
 
     def initialize(self):
         """
@@ -64,34 +77,6 @@ class Parameters(OrderedDict):
 
 configuration = Parameters("Devito-Configuration")
 """The Devito configuration parameters."""
-
-defaults = {
-    'backend': 'core',
-    'log_level': 'INFO',
-    'autotuning': 'basic',
-    'compiler': 'custom',
-    'openmp': '0',
-    'dse': 'advanced',
-    'dle': 'advanced',
-    'dle_options': ';'.join('%s:%s' % (k, v) for k, v in dle_default_options.items()),
-    'first_touch': '0',
-    'travis_test': '0',
-}
-"""The default Devito configuration parameters"""
-
-accepted = {
-    'backend': list(backends_registry),
-    'log_level': list(logger_registry),
-    'autotuning': ('none', 'basic', 'aggressive'),
-    'compiler': list(compiler_registry),
-    'openmp': [1, 0],
-    'dse': list(dse_registry),
-    'dle': list(dle_registry),
-    'dle_options': list(dle_default_options),
-    'first_touch': [1, 0],
-    'travis_test': [1, 0],
-}
-"""Accepted values for the Devito environment variables."""
 
 env_vars_mapper = {
     'DEVITO_ARCH': 'compiler',
@@ -108,25 +93,29 @@ env_vars_mapper = {
 
 
 def init_configuration():
-    # Populate /parameters/
+    # Populate /configuration/ with user-provided options
     if environ.get('DEVITO_CONFIG') is None:
-        # Try env variables, otherwise pick defaults
+        # Try env variables, otherwise stick to defaults
         for k, v in sorted(env_vars_mapper.items()):
-            configuration[v] = environ.get(k, defaults[v])
+            configuration.update(v, environ.get(k, configuration._defaults[v]))
     else:
         # Attempt reading from the specified configuration file
-        raise NotImplementedError("Devito doesn't support configuration via file.")
+        raise NotImplementedError("Devito doesn't support configuration via file yet.")
 
     # Parameters validation
     for k, v in list(configuration.items()):
-        items = v.split(';')
         try:
-            # Env variable format: 'k1:v1;k2:v2:k3:v3:...'
+            items = v.split(';')
+            # Env variable format: 'var=k1:v1;k2:v2:k3:v3:...'
             keys, values = zip(*[i.split(':') for i in items])
             # Casting
             values = [eval(i) for i in values]
+        except AttributeError:
+            # Env variable format: 'var=v', 'v' is not a string
+            keys = [v]
+            values = []
         except ValueError:
-            # Env variable format: 'k1;k2:...' or even just 'k1'
+            # Env variable format: 'var=k1;k2:v2...' or even just 'var=v'
             keys = [i.split(':')[0] for i in items]
             values = []
             # Cast to integer
@@ -135,36 +124,15 @@ def init_configuration():
                     keys[i] = int(j)
                 except (TypeError, ValueError):
                     keys[i] = j
-        if any(i not in accepted[k] for i in keys):
+        accepted = configuration._accepted[k]
+        if any(i not in accepted for i in keys):
             raise ValueError("Illegal configuration parameter (%s, %s). "
-                             "Accepted: %s" % (k, v, str(accepted[k])))
+                             "Accepted: %s" % (k, v, str(accepted)))
         if len(keys) == len(values):
-            configuration[k] = dict(zip(keys, values))
+            configuration.update(k, dict(zip(keys, values)))
         elif len(keys) == 1:
-            configuration[k] = keys[0]
+            configuration.update(k, keys[0])
         else:
-            configuration[k] = keys
+            configuration.update(k, keys)
 
-    # Global setup
-    # - Logger
-    configuration.set_update_function('log_level', lambda i: set_log_level(i))
-    # - Compilation toolchain
-    configuration['compiler'] = set_compiler(configuration['compiler'],
-                                             configuration['openmp'])
-    configuration['openmp'] = bool(configuration['openmp'])
-    configuration['first_touch'] = bool(configuration['first_touch'])
-    configuration.set_update_function('first_touch', lambda i: set_first_touch(i))
     configuration.initialize()
-
-
-def print_defaults():
-    """Print the environment variables accepted by Devito, their default value,
-    as well as all of the accepted values."""
-    for k, v in env_vars_mapper.items():
-        info('%s: %s. Default: %s' % (k, accepted[v], defaults[v]))
-
-
-def print_state():
-    """Print the current configuration state."""
-    for k, v in configuration.items():
-        info('%s: %s' % (k, v))

--- a/examples/PERFORMANCE.md
+++ b/examples/PERFORMANCE.md
@@ -111,6 +111,17 @@ Significant reductions in operation count due to using `aggressive` mode have
 been observed in several TTI examples. The `aggressive` mode may or may not
 increase the Devito processing time.
 
+### Loop tiling with 3D blocks
+
+Loop tiling is applied if the DLE is set to the `advanced` level. By default,
+Devito tiles loop nests using 2D blocks. In some circumstances, however,
+employing 3D blocks may lead to better performance. This is clearly a
+problem-dependent aspect. To switch to using 3D blocks, one should set the
+following environment variable:
+```
+DEVITO_DLE_OPTIONS="blockinner:True"
+```
+
 ### Auto-tuning
 
 Operator auto-tuning can greatly improve the run-time performance. It can be

--- a/tests/test_autotuner.py
+++ b/tests/test_autotuner.py
@@ -13,7 +13,6 @@ from sympy import Eq
 
 from devito import DenseData, Operator, configuration
 from devito.logger import logger, logging, set_log_level
-from devito.parameters import defaults
 
 
 def test_at_is_actually_working():
@@ -44,7 +43,7 @@ def test_at_is_actually_working():
     op(infield=infield, outfield=outfield, autotune=True)
     out = [i for i in buffer.getvalue().split('\n') if 'AutoTuner:' in i]
     assert len(out) == 12
-    configuration['autotuning'] = defaults['autotuning']
+    configuration['autotuning'] = configuration._defaults['autotuning']
 
     logger.removeHandler(temporary_handler)
 


### PR DESCRIPTION
fixes #334 

This makes it possible to access ``configuration`` from basically everywhere in Devito, w/o having to use local imports