### PR TITLE
YASK: Support for loops with indirect accesses

### DIFF
--- a/devito/arguments.py
+++ b/devito/arguments.py
@@ -127,6 +127,7 @@ class PtrArgument(Argument):
         super(PtrArgument, self).__init__(name, provider, provider.value)
 
     def verify(self, value):
+        self._value = value or self._value
         return True
 
 

--- a/devito/cgen_utils.py
+++ b/devito/cgen_utils.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 
 import cgen as c
 from mpmath.libmp import prec_to_dps, to_str
-from sympy import Eq
+from sympy import Eq, Function
 from sympy.printing.ccode import CCodePrinter
 
 
@@ -58,17 +58,16 @@ class Allocator(object):
 # Utils to print C strings
 
 class CodePrinter(CCodePrinter):
+
+    custom_functions = {'INT': '(int)', 'FLOAT': '(float)'}
+
     """Decorator for sympy.printing.ccode.CCodePrinter.
 
     :param settings: A dictionary containing relevant settings
     """
     def __init__(self, settings={}):
         CCodePrinter.__init__(self, settings)
-        custom_functions = {
-            'INT': '(int)',
-            'FLOAT': '(float)'
-        }
-        self.known_functions.update(custom_functions)
+        self.known_functions.update(self.custom_functions)
 
     def _print_Indexed(self, expr):
         """Print field as C style multidimensional array
@@ -178,3 +177,5 @@ def ccode_eq(eq, **settings):
 blankline = c.Line("")
 printmark = lambda i: c.Line('printf("Here: %s\\n"); fflush(stdout);' % i)
 printvar = lambda i: c.Statement('printf("%s=%%s\\n", %s); fflush(stdout);' % (i, i))
+INT = Function('INT')
+FLOAT = Function('FLOAT')

--- a/devito/cgen_utils.py
+++ b/devito/cgen_utils.py
@@ -144,6 +144,10 @@ class CodePrinter(CCodePrinter):
     def _print_FrozenExpr(self, expr):
         return self._print(expr.args[0])
 
+    def _print_FunctionFromPointer(self, expr):
+        indices = [self._print(i) for i in expr.params]
+        return "%s->%s(%s)" % (expr.pointer, expr.name, ', '.join(indices))
+
 
 def ccode(expr, **settings):
     """Generate C++ code from an expression calling CodePrinter class

--- a/devito/dse/extended_sympy.py
+++ b/devito/dse/extended_sympy.py
@@ -7,8 +7,8 @@ from sympy import Expr, Float
 from sympy.core.basic import _aresame
 from sympy.functions.elementary.trigonometric import TrigonometricFunction
 
-__all__ = ['FrozenExpr', 'Eq', 'Mul', 'Add', 'taylor_sin', 'taylor_cos',
-           'bhaskara_sin', 'bhaskara_cos']
+__all__ = ['FrozenExpr', 'Eq', 'Mul', 'Add', 'FunctionFromPointer',
+           'taylor_sin', 'taylor_cos', 'bhaskara_sin', 'bhaskara_cos']
 
 
 class FrozenExpr(Expr):
@@ -50,6 +50,21 @@ class Mul(sympy.Mul, FrozenExpr):
 
 class Add(sympy.Add, FrozenExpr):
     pass
+
+
+class FunctionFromPointer(sympy.Symbol):
+
+    def __new__(cls, name, pointer, params=None):
+        obj = sympy.Symbol.__new__(cls, name)
+        obj.pointer = pointer
+        obj.params = params or ()
+        return obj
+
+    def __str__(self):
+        return "%s->%s(%s)" % (self.pointer, self.name,
+                               ', '.join([str(i) for i in self.params]))
+
+    __repr__ = __str__
 
 
 class taylor_sin(TrigonometricFunction):

--- a/devito/nodes.py
+++ b/devito/nodes.py
@@ -139,30 +139,13 @@ class Element(Node):
 
 class FunCall(Node):
 
-    """A node representing a function/method call.
-
-    :param name: The function/method name.
-    :param params: An Iterator of strings, representing the function parameters.
-    :param mode: Three possible values: ['free', 'obj', 'pobj'] to characterize
-                 the function call: ::
-
-                    * 'free': a free function, e.g. ``name(params)``.
-                    * 'obj': a method invoked on an object, e.g. ``obj.name(params)``.
-                    * 'pobj': a method invoked on a pointer to an object,
-                        e.g. ``obj->name(params)``.
-    :param obj: A string, representing the name of the object on which the method
-                ``name`` is invoked. Ignored if ``mode == 'free'``.
-    """
+    """A node representing a function call."""
 
     is_FunCall = True
 
-    def __init__(self, name, params=None, mode='free', obj=None):
-        assert mode in ['free', 'obj', 'pobj']
-        assert mode == 'free' or obj is not None
+    def __init__(self, name, params=None):
         self.name = name
         self.params = as_tuple(params)
-        self.obj = obj
-        self._mode = mode
 
     def __repr__(self):
         return "FunCall::\n\t%s(...)" % self.name

--- a/devito/nodes.py
+++ b/devito/nodes.py
@@ -90,6 +90,9 @@ class Node(object):
         """Arguments used to construct the Node that cannot be traversed."""
         return {k: v for k, v in self.args.items() if k not in self._traversable}
 
+    def __str__(self):
+        return str(self.ccode)
+
 
 class Block(Node):
 

--- a/devito/nodes.py
+++ b/devito/nodes.py
@@ -120,15 +120,13 @@ class List(Block):
 
 class Element(Node):
 
-    """A generic node that is worth identifying in an Iteration/Expression tree.
-
-    It corresponds to a single :class:`cgen.Statement`.
-    """
+    """A generic node in an Iteration/Expression tree. Can be a comment,
+    a statement, ..."""
 
     is_Element = True
 
     def __init__(self, element):
-        assert isinstance(element, (c.Comment, c.Statement, c.Value,
+        assert isinstance(element, (c.Comment, c.Statement, c.Value, c.Initializer,
                                     c.Pragma, c.Line, c.Assign, c.POD))
         self.element = element
 

--- a/devito/nodes.py
+++ b/devito/nodes.py
@@ -138,13 +138,30 @@ class Element(Node):
 
 class FunCall(Node):
 
-    """A node representing a function call."""
+    """A node representing a function/method call.
+
+    :param name: The function/method name.
+    :param params: An Iterator of strings, representing the function parameters.
+    :param mode: Three possible values: ['free', 'obj', 'pobj'] to characterize
+                 the function call: ::
+
+                    * 'free': a free function, e.g. ``name(params)``.
+                    * 'obj': a method invoked on an object, e.g. ``obj.name(params)``.
+                    * 'pobj': a method invoked on a pointer to an object,
+                        e.g. ``obj->name(params)``.
+    :param obj: A string, representing the name of the object on which the method
+                ``name`` is invoked. Ignored if ``mode == 'free'``.
+    """
 
     is_FunCall = True
 
-    def __init__(self, name, params=None):
+    def __init__(self, name, params=None, mode='free', obj=None):
+        assert mode in ['free', 'obj', 'pobj']
+        assert mode == 'free' or obj is not None
         self.name = name
         self.params = as_tuple(params)
+        self.obj = obj
+        self._mode = mode
 
     def __repr__(self):
         return "FunCall::\n\t%s(...)" % self.name

--- a/devito/pointdata.py
+++ b/devito/pointdata.py
@@ -1,6 +1,8 @@
+from collections import OrderedDict
+
 from sympy import Eq, Function, Matrix, symbols
 
-from collections import OrderedDict
+from devito.cgen_utils import INT, FLOAT
 from devito.dimension import d, p, t, time, x, y, z
 from devito.dse.inspection import indexify, retrieve_indexed
 from devito.interfaces import DenseData, CompositeData
@@ -139,14 +141,14 @@ class PointData(CompositeData):
     def coordinate_indices(self):
         """Symbol for each grid index according to the coordinates"""
         indices = (x, y, z)
-        return tuple([Function('INT')(Function('floor')(c / i.spacing))
+        return tuple([INT(Function('floor')(c / i.spacing))
                       for c, i in zip(self.coordinate_symbols, indices[:self.ndim])])
 
     @property
     def coordinate_bases(self):
         """Symbol for the base coordinates of the reference grid point"""
         indices = (x, y, z)
-        return tuple([Function('FLOAT')(c - idx * i.spacing)
+        return tuple([FLOAT(c - idx * i.spacing)
                       for c, idx, i in zip(self.coordinate_symbols,
                                            self.coordinate_indices,
                                            indices[:self.ndim])])

--- a/devito/visitors.py
+++ b/devito/visitors.py
@@ -282,7 +282,10 @@ class CGen(Visitor):
                              ccode(o.expr.lhs)), ccode(o.expr.rhs))
 
     def visit_FunCall(self, o):
-        return c.Statement('%s(%s)' % (o.name, ','.join(o.params)))
+        meth = {'free': '', 'obj': '.', 'pobj': '->'}[o._mode]
+        if meth:
+            meth = "%s%s" % (o.obj, meth)
+        return c.Statement('%s%s(%s)' % (meth, o.name, ','.join(o.params)))
 
     def visit_Iteration(self, o):
         body = flatten(self.visit(i) for i in o.children)

--- a/devito/visitors.py
+++ b/devito/visitors.py
@@ -282,11 +282,7 @@ class CGen(Visitor):
                              ccode(o.expr.lhs)), ccode(o.expr.rhs))
 
     def visit_FunCall(self, o):
-        meth = {'free': '', 'obj': '.', 'pobj': '->'}[o._mode]
-        if meth:
-            meth = "%s%s" % (o.obj, meth)
-        return c.Statement('%s%s(%s)' % (meth, o.name,
-                                         ','.join([str(i) for i in o.params])))
+        return c.Statement('%s(%s)' % (o.name, ','.join(o.params)))
 
     def visit_Iteration(self, o):
         body = flatten(self.visit(i) for i in o.children)

--- a/devito/visitors.py
+++ b/devito/visitors.py
@@ -285,7 +285,8 @@ class CGen(Visitor):
         meth = {'free': '', 'obj': '.', 'pobj': '->'}[o._mode]
         if meth:
             meth = "%s%s" % (o.obj, meth)
-        return c.Statement('%s%s(%s)' % (meth, o.name, ','.join(o.params)))
+        return c.Statement('%s%s(%s)' % (meth, o.name,
+                                         ','.join([str(i) for i in o.params])))
 
     def visit_Iteration(self, o):
         body = flatten(self.visit(i) for i in o.children)
@@ -359,7 +360,7 @@ class CGen(Visitor):
         header = [c.Line(i) for i in o._headers]
         includes = [c.Include(i, system=False) for i in o._includes]
         includes += [blankline]
-        cglobals = o._globals
+        cglobals = list(o._globals)
         if o._compiler.src_ext == 'cpp':
             cglobals += [c.Extern('C', signature)]
         cglobals = [i for j in cglobals for i in (j, blankline)]
@@ -406,8 +407,8 @@ class FindSections(Visitor):
     def visit_Expression(self, o, ret=None, queue=None):
         if ret is None:
             ret = self.default_retval()
-        key = tuple(queue) if queue is not None else ()
-        ret.setdefault(key, []).append(o)
+        if queue is not None:
+            ret.setdefault(tuple(queue), []).append(o)
         return ret
 
     visit_Element = visit_Expression

--- a/devito/yask/__init__.py
+++ b/devito/yask/__init__.py
@@ -46,10 +46,15 @@ namespace['kernel-path-gen'] = os.path.join(namespace['kernel-path'], 'gen')
 namespace['kernel-output'] = os.path.join(namespace['kernel-path-gen'],
                                           namespace['kernel-filename'])
 namespace['time-dim'] = 't'
+namespace['code-soln-type'] = 'yask::yk_solution'
+namespace['code-soln-name'] = 'soln'
+namespace['code-soln-run'] = 'run_solution'
+namespace['code-grid-type'] = 'yask::yk_grid'
+namespace['code-grid-name'] = lambda i: "grid_%s" % str(i)
+namespace['code-grid-get'] = 'get_element'
+namespace['code-grid-put'] = 'set_element'
 namespace['type-solution'] = ctypes_pointer('yask::yk_solution_ptr')
 namespace['type-grid'] = ctypes_pointer('yask::yk_grid_ptr')
-namespace['code-grid'] = lambda i: "grid_%s" % str(i)
-namespace['code-soln'] = 'soln'
 
 
 # Need a custom compiler to compile YASK kernels

--- a/devito/yask/__init__.py
+++ b/devito/yask/__init__.py
@@ -47,6 +47,9 @@ namespace['kernel-output'] = os.path.join(namespace['kernel-path-gen'],
                                           namespace['kernel-filename'])
 namespace['time-dim'] = 't'
 namespace['type-solution'] = ctypes_pointer('yask::yk_solution_ptr')
+namespace['type-grid'] = ctypes_pointer('yask::yk_grid_ptr')
+namespace['code-grid'] = lambda i: "grid_%s" % str(i)
+namespace['code-soln'] = 'soln'
 
 
 # Need a custom compiler to compile YASK kernels

--- a/devito/yask/interfaces.py
+++ b/devito/yask/interfaces.py
@@ -1,5 +1,4 @@
 import devito.interfaces as interfaces
-from devito.logger import yask as log
 
 from devito.yask import exit
 from devito.yask.wrappers import yask_context

--- a/devito/yask/interfaces.py
+++ b/devito/yask/interfaces.py
@@ -22,14 +22,8 @@ class DenseData(interfaces.DenseData):
     def _allocate_memory(self):
         """Allocate memory in terms of YASK grids."""
 
-        log("Allocating YaskGrid for %s (%s)" % (self.name, str(self.shape)))
-
         # Fetch the appropriate context
         context = yask_context(self.indices, self.shape, self.dtype, self.space_order)
-
-        # Sanity check
-        if self.name in context.grids:
-            exit("A grid with name %s already exits" % self.name)
 
         # Only create a YaskGrid if the requested grid is dense
         dimensions = tuple(i.name for i in self.indices)
@@ -38,8 +32,7 @@ class DenseData(interfaces.DenseData):
             self._data_object = context.make_grid(self.name, dimensions, self.shape,
                                                   self.space_order, self.dtype)
         else:
-            log("Failed. Reverting to plain allocation...")
-            super(DenseData, self)._allocate_memory()
+            exit("Couldn't allocate YaskGrid.")
 
     @property
     def _data_buffer(self):

--- a/devito/yask/interfaces.py
+++ b/devito/yask/interfaces.py
@@ -7,11 +7,17 @@ from devito.yask.wrappers import yask_context
 __all__ = ['ConstantData', 'DenseData', 'TimeData']
 
 
+interfaces.Basic.from_YASK = False
+
+
 class ConstantData(interfaces.ConstantData):
-    pass
+
+    from_YASK = True
 
 
 class DenseData(interfaces.DenseData):
+
+    from_YASK = True
 
     def _allocate_memory(self):
         """Allocate memory in terms of YASK grids."""
@@ -68,4 +74,5 @@ class DenseData(interfaces.DenseData):
 
 
 class TimeData(interfaces.TimeData, DenseData):
-    pass
+
+    from_YASK = True

--- a/devito/yask/operator.py
+++ b/devito/yask/operator.py
@@ -138,7 +138,7 @@ class Operator(OperatorRunnable):
         # Update the parameters list adding all necessary YASK grids
         for i in list(parameters):
             try:
-                if i.is_SymbolicData and isinstance(i.data, YaskGrid):
+                if i.from_YASK:
                     parameters.append(Object(namespace['code-grid-name'](i.name),
                                              namespace['type-grid'],
                                              i.data.rawpointer))

--- a/devito/yask/operator.py
+++ b/devito/yask/operator.py
@@ -152,12 +152,19 @@ class Operator(OperatorRunnable):
 
     def arguments(self, **kwargs):
         # The user has the illusion to provide plain data objects to the
-        # generated kernels, but what we will actually also drop in are
-        # pointers to the wrapped YASK grids
+        # generated kernels, but what we actually need and thus going to
+        # provide are pointers to the wrapped YASK grids
+        shadow_kwargs = {}
+        for k, v in kwargs.items():
+            try:
+                if v.from_YASK is True:
+                    shadow_kwargs[namespace['code-grid-name'](k)] = v
+            except AttributeError:
+                pass
         for i in self.parameters:
-            obj = kwargs.get(i.name)
+            obj = shadow_kwargs.get(i.name)
             if i.is_PtrArgument and obj is not None:
-                assert(i.verify(obj.data))
+                assert(i.verify(obj.data.rawpointer))
         return super(Operator, self).arguments(**kwargs)
 
     def apply(self, **kwargs):

--- a/devito/yask/operator.py
+++ b/devito/yask/operator.py
@@ -173,7 +173,7 @@ class Operator(OperatorRunnable):
 
         # Share the grids from the hook solution
         for kgrid in self.ksoln.grids:
-            hgrid = self.context.grids[kgrid.get_name()]
+            hgrid = self.context.grids[kgrid.get_name()].grid
             kgrid.share_storage(hgrid)
             log("Shared storage from hook grid <%s>" % hgrid.get_name())
 

--- a/devito/yask/operator.py
+++ b/devito/yask/operator.py
@@ -1,19 +1,23 @@
 from __future__ import absolute_import
 
+import cgen as c
 from sympy import Indexed
 
+from devito.cgen_utils import ccode
 from devito.compiler import jit_compile
 from devito.dimension import LoweredDimension
-from devito.dle import retrieve_iteration_tree
+from devito.dle import filter_iterations, retrieve_iteration_tree
 from devito.interfaces import Object
-from devito.nodes import FunCall
 from devito.logger import yask as log, yask_warning as warning
+from devito.nodes import Element
 from devito.operator import OperatorRunnable, FunMeta
 from devito.tools import flatten
 from devito.visitors import IsPerfectIteration, Transformer
 
 from devito.yask import cfac, nfac, ofac, namespace, exit, yask_configuration
-from devito.yask.wrappers import YaskGrid, yask_context
+from devito.yask.utils import make_grid_accesses, make_sharedptr_funcall
+from devito.yask.wrappers import (YaskGrid, YaskNullContext, YaskNullSolution,
+                                  yask_context)
 
 __all__ = ['Operator']
 
@@ -29,7 +33,7 @@ class Operator(OperatorRunnable):
     _default_includes = OperatorRunnable._default_includes + ['yask_kernel_api.hpp']
 
     def __init__(self, expressions, **kwargs):
-        kwargs['dle'] = 'noop'
+        kwargs['dle'] = 'basic'
         super(Operator, self).__init__(expressions, **kwargs)
         # Each YASK Operator needs to have its own compiler (hence the copy()
         # below) because Operator-specific shared object will be added to the
@@ -53,8 +57,12 @@ class Operator(OperatorRunnable):
         ycsoln.set_debug_output(self.yask_compiler_output)
 
         # Find offloadable Iteration/Expression trees
-        candidates = []
+        offloadable = []
         for tree in retrieve_iteration_tree(nodes):
+            parallel = filter_iterations(tree, lambda i: i.is_Parallel)
+            if not parallel:
+                # Cannot offload non-parallel loops
+                continue
             if not (IsPerfectIteration().visit(tree) and
                     all(i.is_Expression for i in tree[-1].nodes)):
                 # Don't know how to offload this Iteration/Expression to YASK
@@ -62,63 +70,81 @@ class Operator(OperatorRunnable):
             functions = flatten(i.functions for i in tree[-1].nodes)
             keys = set([(i.indices, i.shape, i.dtype, i.space_order) for i in functions
                         if i.is_TimeData])
-            if len(keys) > 1:
+            if len(keys) == 0:
+                continue
+            elif len(keys) > 1:
                 exit("Cannot handle Operators w/ heterogeneous grids")
             dimensions, shape, dtype, space_order = keys.pop()
             if len(dimensions) == len(tree) and\
                     all(i.dim == j for i, j in zip(tree, dimensions)):
                 # Detected a "full" Iteration/Expression tree (over both
                 # time and space dimensions)
-                candidates.append((tree, dimensions, shape, dtype, space_order))
+                offloadable.append((tree, dimensions, shape, dtype, space_order))
 
-        # Fetch a YaskContext
-        if len(candidates) == 0:
-            exit("Currently unable to handle YASK Operators w/o offloadable trees")
-        elif len(candidates) > 1:
-            exit("Currently unable to handle YASK Operators w/ > 1 offloadable trees")
-        tree, dimensions, shape, dtype, space_order = candidates[0]
-        self.context = yask_context(dimensions, shape, dtype, space_order)
+        # Construct YASK ASTs given Devito expressions. New grids may be allocated.
+        if len(offloadable) == 0:
+            # No offloadable trees found
+            self.context = YaskNullContext()
+            self.ksoln = YaskNullSolution()
+            processed = nodes
+            log("No offloadable trees found")
+        elif len(offloadable) == 1:
+            # Found *the* offloadable tree for this Operator
+            tree, dimensions, shape, dtype, space_order = offloadable[0]
+            self.context = yask_context(dimensions, shape, dtype, space_order)
 
-        # Perform the translation on an expression basis
-        transform = sympy2yask(self.context, ycsoln)
-        try:
-            for i in tree[-1].nodes:
-                ast = transform(i.expr)
-                log("Converted %s into YASK AST [%s]", str(i.expr), ast.format_simple())
-        except:
-            exit("Couldn't convert %s into YASK format" % str(i.expr))
+            transform = sympy2yask(self.context, ycsoln)
+            try:
+                for i in tree[-1].nodes:
+                    transform(i.expr)
 
-        # Print some useful information about the newly constructed solution
-        log("Solution '%s' contains %d grid(s) and %d equation(s)." %
-            (ycsoln.get_name(), ycsoln.get_num_grids(), ycsoln.get_num_equations()))
+                funcall = make_sharedptr_funcall(namespace['code-soln-run'], ['time'],
+                                                 namespace['code-soln-name'])
+                funcall = Element(c.Statement(ccode(funcall)))
+                processed = Transformer({tree[1]: funcall}).visit(nodes)
 
-        # Set necessary run-time parameters
-        ycsoln.set_step_dim_name(self.context.time_dimension)
-        ycsoln.set_domain_dim_names(self.context.space_dimensions)
-        ycsoln.set_element_bytes(4)
+                # Track this is an external function call
+                self.func_table[namespace['code-soln-run']] = FunMeta(None, False)
 
-        # JIT-compile the newly-created YASK kernel
-        self.ksoln = self.context.make_solution(ycsoln)
+                # Set necessary run-time parameters
+                ycsoln.set_step_dim_name(self.context.time_dimension)
+                ycsoln.set_domain_dim_names(self.context.space_dimensions)
+                ycsoln.set_element_bytes(4)
 
-        # TODO: improve the following tree rewrite
-        space_tree = tree[1]
-        funcall = 'soln->get()->run_solution'
-        processed = Transformer({space_tree: FunCall(funcall, 'time')}).visit(nodes)
+                # JIT-compile the newly-created YASK kernel
+                self.ksoln = self.context.make_solution(ycsoln)
 
-        # Track this is an external function call
-        self.func_table[funcall] = FunMeta(None, False)
+                # Now we must drop a pointer to the YASK solution down to C-land
+                parameters.append(Object(namespace['code-soln-name'],
+                                         namespace['type-solution'],
+                                         self.ksoln.rawpointer))
 
-        # Update the parameters list adding YASK grids and solution
+                # Print some useful information about the newly constructed solution
+                log("Solution '%s' contains %d grid(s) and %d equation(s)." %
+                    (ycsoln.get_name(), ycsoln.get_num_grids(),
+                     ycsoln.get_num_equations()))
+            except:
+                self.ksoln = YaskNullSolution()
+                processed = nodes
+                log("Unable to offload a candidate tree.")
+        else:
+            exit("Found more than one offloadable trees in a single Operator")
+
+        # Some Iteration/Expression trees are not offloaded to YASK and may
+        # require further processing to be executed in YASK, due to the differences
+        # in storage layout employed by Devito and YASK
+        processed = make_grid_accesses(processed)
+
+        # Update the parameters list adding all necessary YASK grids
         for i in list(parameters):
             try:
                 if i.is_SymbolicData and isinstance(i.data, YaskGrid):
-                    parameters.append(Object(namespace['code-grid'](i.name),
-                                             namespace['type-grid'], i.data.rawpointer))
+                    parameters.append(Object(namespace['code-grid-name'](i.name),
+                                             namespace['type-grid'],
+                                             i.data.rawpointer))
             except AttributeError:
                 # Ignore e.g. Dimensions
                 pass
-        parameters.append(Object(namespace['code-soln'], namespace['type-solution'],
-                                 self.ksoln.rawpointer))
 
         log("Specialization successfully performed!")
 
@@ -176,7 +202,8 @@ class Operator(OperatorRunnable):
         """
         if self._lib is None:
             # No need to recompile if a shared object has already been loaded.
-            self._compiler.libraries.append(self.ksoln.soname)
+            if not isinstance(self.ksoln, YaskNullSolution):
+                self._compiler.libraries.append(self.ksoln.soname)
             return jit_compile(self.ccode, self._compiler)
         else:
             return self._lib.name

--- a/devito/yask/operator.py
+++ b/devito/yask/operator.py
@@ -16,8 +16,7 @@ from devito.visitors import IsPerfectIteration, Transformer
 
 from devito.yask import cfac, nfac, ofac, namespace, exit, yask_configuration
 from devito.yask.utils import make_grid_accesses, make_sharedptr_funcall
-from devito.yask.wrappers import (YaskGrid, YaskNullContext, YaskNullSolution,
-                                  yask_context)
+from devito.yask.wrappers import YaskNullContext, YaskNullSolution, yask_context
 
 __all__ = ['Operator']
 

--- a/devito/yask/wrappers.py
+++ b/devito/yask/wrappers.py
@@ -49,7 +49,7 @@ class YaskGrid(object):
         # TODO: ATM, no MPI support.
         start, stop, shape = convert_multislice(index, self.shape, self.halo)
         if not shape:
-            log("YaskGrid: Getting single entry")
+            log("YaskGrid: Getting single entry %s" % str(start))
             assert start == stop
             out = self.grid.get_element(*start)
         else:
@@ -62,7 +62,7 @@ class YaskGrid(object):
         # TODO: ATM, no MPI support.
         start, stop, shape = convert_multislice(index, self.shape, self.halo, 'set')
         if all(i == 1 for i in shape):
-            log("YaskGrid: Setting single entry")
+            log("YaskGrid: Setting single entry %s" % str(start))
             assert start == stop
             self.grid.set_element(val, *start)
         elif isinstance(val, np.ndarray):
@@ -350,6 +350,37 @@ class YaskContext(object):
         self.solutions.append(soln)
 
         return soln
+
+
+class YaskNullSolution(object):
+
+    """Used when an Operator doesn't actually have a YASK-offloadable tree."""
+
+    def __init__(self):
+        self.name = 'null solution'
+
+    def prepare(self):
+        pass
+
+    def run(self, ntimesteps):
+        exit("Cannot run a NullSolution through YASK's Python bindings")
+
+    @property
+    def grids(self):
+        return ()
+
+
+class YaskNullContext(object):
+
+    """Used when an Operator doesn't actually have a YASK-offloadable tree."""
+
+    @property
+    def space_dimensions(self):
+        return '?'
+
+    @property
+    def time_dimension(self):
+        return '?'
 
 
 contexts = OrderedDict()

--- a/devito/yask/wrappers.py
+++ b/devito/yask/wrappers.py
@@ -130,6 +130,10 @@ class YaskGrid(object):
         ndarray = np.ctypeslib.as_array(casted, shape=self.shape)
         return ndarray
 
+    @property
+    def rawpointer(self):
+        return ctypes.cast(int(self.grid), ctypes.c_void_p)
+
     def view(self):
         """
         View of the YASK grid in standard (i.e., Devito) row-major layout.

--- a/tests/test_point_data.py
+++ b/tests/test_point_data.py
@@ -1,7 +1,7 @@
 import numpy as np
 import pytest
-from sympy import Function
 
+from devito.cgen_utils import FLOAT
 from devito import Operator, DenseData, PointData, x, y, z
 
 
@@ -65,7 +65,7 @@ def test_inject(shape, coords, result, npoints=19):
     a.data[:] = 0.
     p = points(ranges=coords, npoints=npoints)
 
-    expr = p.inject(a, Function('FLOAT')(1.))
+    expr = p.inject(a, FLOAT(1.))
 
     Operator(expr, subs={x.spacing: spacing, y.spacing: spacing,
                          z.spacing: spacing})(a=a)

--- a/tests/test_yask.py
+++ b/tests/test_yask.py
@@ -5,8 +5,8 @@ import pytest  # noqa
 
 pexpect = pytest.importorskip('yask_compiler')  # Run only if YASK is available
 
-from devito import (Operator, Dimension, DenseData, TimeData, t, x, y, z,
-                    configuration, clear_cache)  # noqa
+from devito import (Operator, DenseData, TimeData, PointData,
+                    t, x, y, z, configuration, clear_cache)  # noqa
 from devito.yask.wrappers import YaskGrid  # noqa
 
 pytestmark = pytest.mark.skipif(configuration['backend'] != 'yask',
@@ -177,18 +177,16 @@ class TestOperatorExecution(object):
         Compute a simple stencil S, preceded by an "initialization loop" I and
         followed by a "random loop" R.
 
-            * S is the trivial equation ``u[t+1,x,y,z] = u[t,x,y,z] + 1``
-            * I initializes ``u`` to 3
-            * R adds 1 to another field ``v``
+            * S is the trivial equation ``u[t+1,x,y,z] = u[t,x,y,z] + 1``;
+            * I initializes ``u`` to 0;
+            * R adds 2 to another field ``v`` along the ``z`` dimension but only
+                over the planes ``[x=0, y=2]`` and ``[x=0, y=5]``.
 
         Out of these three loop nests, only S should be "offloaded" to YASK; indeed,
         I is outside the time loop, while R does not loop over space dimensions.
         This test checks that S is the only loop nest "offloaded" to YASK, and
         that the numerical output is correct.
         """
-        i = Dimension(name='i', size=16)
-        j = Dimension(name='j', size=16)
-        k = Dimension(name='k', size=16)
         space_order = 0
         u = TimeData(name='yu4D', shape=(16, 16, 16), dimensions=(x, y, z),
                      space_order=space_order)
@@ -196,8 +194,50 @@ class TestOperatorExecution(object):
                      space_order=space_order)
         v.data[:] = 0.
         eqs = [Eq(u.indexed[0, x, y, z], 0),
+               Eq(u.indexed[1, x, y, z], 0),
                Eq(u.forward, u + 1.),
-               Eq(v.indexed[t + 1, i, j, k], v.indexed[t + 1, i, j, k] + 2.)]
+               Eq(v.indexed[t + 1, 0, 2, z], v.indexed[t + 1, 0, 2, z] + 2.),
+               Eq(v.indexed[t + 1, 0, 5, z], v.indexed[t + 1, 0, 5, z] + 2.)]
         op = Operator(eqs, subs={t.spacing: 1})
         op(yu4D=u, yv4D=v, t=1)
+        assert np.all(u.data[0] == 0.)
         assert np.all(u.data[1] == 1.)
+        assert np.all(v.data[0] == 0.)
+        assert np.all(v.data[1, 0, 2] == 2.)
+        assert np.all(v.data[1, 0, 5] == 2.)
+
+    def test_irregular_write(self):
+        """
+        Compute a simple stencil S w/o offloading it to YASK because of the presence
+        of indirect write accesses (e.g. A[B[i]] = ...); YASK grid functions are however
+        used in the generated code to access the data at the right location. This
+        test checks that the numerical output is correct after this transformation.
+
+        Initially, the input array (a YASK grid, under the hood), at t=0 is (2D view):
+
+            0 1 2 3
+            0 1 2 3
+            0 1 2 3
+            0 1 2 3
+
+        Then, the Operator "flips" its content, and at timestep t=1 we get (2D view):
+
+            3 2 1 0
+            3 2 1 0
+            3 2 1 0
+            3 2 1 0
+        """
+        p = PointData(name='points', nt=1, npoint=4)
+        u = TimeData(name='yu4D', shape=(4, 4, 4), dimensions=(x, y, z), space_order=0)
+        for i in range(4):
+            for j in range(4):
+                for k in range(4):
+                    u.data[0, i, j, k] = k
+        ind = lambda i: p.indexed[0, i]
+        eqs = [Eq(p.indexed[0, 0], 3.), Eq(p.indexed[0, 1], 2.),
+               Eq(p.indexed[0, 2], 1.), Eq(p.indexed[0, 3], 0.),
+               Eq(u.indexed[t + 1, ind(x), ind(y), ind(z)], u.indexed[t, x, y, z])]
+        op = Operator(eqs, subs={t.spacing: 1})
+        op(yu4D=u, t=1)
+        assert 'run_solution' not in str(op)
+        assert all(np.all(u.data[1, :, :, i] == 3 - i) for i in range(4))


### PR DESCRIPTION
~NOT ready for merge yet, although we're basically there.~

Now we can execute through YASK any Devito kernels mixing sources/receivers-like loop nests (w/ indirect memory accesses) and parallel loops (ie, loops that can be "offloaded" to YASK).

In the generated code ...
... The offloadable loops are replaced by a function call to YASK
... All other loops remain "explicit" in the generated code, but array accesses are replaced with YASK grid accesses. This involves some shared pointer magic in the compiler and in the generated code.

Tests are also added