### PR TITLE
yask: More fixes and change semantics of data.shape

### DIFF
--- a/devito/interfaces.py
+++ b/devito/interfaces.py
@@ -469,7 +469,7 @@ class DenseData(TensorData):
                 error("Creating symbolic data objects requries either"
                       "a 'shape' or 'dimensions' argument")
                 raise ValueError("Unknown symbol dimensions or shape")
-            _indices = [x, y, z]
+            _indices = (x, y, z)
             shape = kwargs.get('shape')
             if len(shape) <= 3:
                 dimensions = _indices[:len(shape)]

--- a/devito/yask/__init__.py
+++ b/devito/yask/__init__.py
@@ -37,8 +37,10 @@ except KeyError:
 
 # YASK conventions
 namespace = OrderedDict()
-namespace['kernel-hook'] = 'hook'
-namespace['kernel-real'] = 'kernel'
+namespace['jit-yc-hook'] = lambda i, j: 'devito_%s_yc_hook%d' % (i, j)
+namespace['jit-yk-hook'] = lambda i, j: 'devito_%s_yk_hook%d' % (i, j)
+namespace['jit-yc-soln'] = lambda i, j: 'devito_%s_yc_soln%d' % (i, j)
+namespace['jit-yk-soln'] = lambda i, j: 'devito_%s_yk_soln%d' % (i, j)
 namespace['kernel-filename'] = 'yask_stencil_code.hpp'
 namespace['path'] = path
 namespace['kernel-path'] = os.path.join(path, 'src', 'kernel')

--- a/devito/yask/interfaces.py
+++ b/devito/yask/interfaces.py
@@ -1,6 +1,5 @@
 import devito.interfaces as interfaces
 
-from devito.yask import exit
 from devito.yask.wrappers import contexts
 
 __all__ = ['ConstantData', 'DenseData', 'TimeData']
@@ -25,16 +24,11 @@ class DenseData(interfaces.DenseData):
         # This is exactly how Devito will work too once the Grid abstraction lands
 
         # Fetch the appropriate context
-        dimensions = tuple(i.name for i in self.indices)
-        context = contexts.fetch(dimensions, self.shape, self.dtype)
+        context = contexts.fetch(self.indices, self.shape, self.dtype)
 
-        # Only create a YaskGrid if the requested grid is dense
-        # TODO : following check fails if not using BufferedDimension ('time' != 't')
-        if dimensions in [context.dimensions, context.space_dimensions]:
-            self._data_object = context.make_grid(self.name, dimensions, self.shape,
-                                                  self.space_order, self.dtype)
-        else:
-            exit("Couldn't allocate YaskGrid.")
+        # TODO : the following will fail if not using a BufferedDimension,
+        # eg with save=True one gets /time/ instead /t/
+        self._data_object = context.make_grid(self)
 
     @property
     def _data_buffer(self):

--- a/devito/yask/interfaces.py
+++ b/devito/yask/interfaces.py
@@ -1,7 +1,7 @@
 import devito.interfaces as interfaces
 
 from devito.yask import exit
-from devito.yask.wrappers import yask_context
+from devito.yask.wrappers import contexts
 
 __all__ = ['ConstantData', 'DenseData', 'TimeData']
 
@@ -21,11 +21,14 @@ class DenseData(interfaces.DenseData):
     def _allocate_memory(self):
         """Allocate memory in terms of YASK grids."""
 
+        # TODO: YASK assumes that self.shape == "domain_size" (in YASK jargon)
+        # This is exactly how Devito will work too once the Grid abstraction lands
+
         # Fetch the appropriate context
-        context = yask_context(self.indices, self.shape, self.dtype, self.space_order)
+        dimensions = tuple(i.name for i in self.indices)
+        context = contexts.fetch(dimensions, self.shape, self.dtype)
 
         # Only create a YaskGrid if the requested grid is dense
-        dimensions = tuple(i.name for i in self.indices)
         # TODO : following check fails if not using BufferedDimension ('time' != 't')
         if dimensions in [context.dimensions, context.space_dimensions]:
             self._data_object = context.make_grid(self.name, dimensions, self.shape,

--- a/devito/yask/operator.py
+++ b/devito/yask/operator.py
@@ -172,9 +172,9 @@ class Operator(OperatorRunnable):
 
         # Share the grids from the hook solution
         for kgrid in self.ksoln.grids:
-            hgrid = self.context.grids[kgrid.get_name()].grid
-            kgrid.share_storage(hgrid)
-            log("Shared storage from hook grid <%s>" % hgrid.get_name())
+            hgrid = self.context.grids[kgrid.get_name()]
+            hgrid.give_storage(kgrid)
+            log("Shared storage from hook grid <%s>" % hgrid.name)
 
         # Print some info about the solution.
         log("Stencil-solution '%s':" % self.ksoln.name)

--- a/devito/yask/operator.py
+++ b/devito/yask/operator.py
@@ -14,9 +14,9 @@ from devito.operator import OperatorRunnable, FunMeta
 from devito.tools import flatten
 from devito.visitors import IsPerfectIteration, Transformer
 
-from devito.yask import cfac, nfac, ofac, namespace, exit, yask_configuration
+from devito.yask import nfac, namespace, exit, yask_configuration
 from devito.yask.utils import make_grid_accesses, make_sharedptr_funcall
-from devito.yask.wrappers import YaskNullContext, YaskNullSolution, yask_context
+from devito.yask.wrappers import YaskNullContext, YaskNullSolution, contexts
 
 __all__ = ['Operator']
 
@@ -48,13 +48,6 @@ class Operator(OperatorRunnable):
 
         log("Specializing a Devito Operator for YASK...")
 
-        # Set up the YASK solution
-        ycsoln = cfac.new_solution(namespace['kernel-real'])
-
-        # Silence YASK
-        self.yask_compiler_output = ofac.new_string_output()
-        ycsoln.set_debug_output(self.yask_compiler_output)
-
         # Find offloadable Iteration/Expression trees
         offloadable = []
         for tree in retrieve_iteration_tree(nodes):
@@ -67,32 +60,35 @@ class Operator(OperatorRunnable):
                 # Don't know how to offload this Iteration/Expression to YASK
                 continue
             functions = flatten(i.functions for i in tree[-1].nodes)
-            keys = set([(i.indices, i.shape, i.dtype, i.space_order) for i in functions
-                        if i.is_TimeData])
+            keys = set((i.indices, i.shape, i.dtype) for i in functions if i.is_TimeData)
             if len(keys) == 0:
                 continue
             elif len(keys) > 1:
                 exit("Cannot handle Operators w/ heterogeneous grids")
-            dimensions, shape, dtype, space_order = keys.pop()
+            dimensions, shape, dtype = keys.pop()
             if len(dimensions) == len(tree) and\
                     all(i.dim == j for i, j in zip(tree, dimensions)):
                 # Detected a "full" Iteration/Expression tree (over both
                 # time and space dimensions)
-                offloadable.append((tree, dimensions, shape, dtype, space_order))
+                offloadable.append((tree, dimensions, shape, dtype))
 
         # Construct YASK ASTs given Devito expressions. New grids may be allocated.
         if len(offloadable) == 0:
             # No offloadable trees found
             self.context = YaskNullContext()
-            self.ksoln = YaskNullSolution()
+            self.yk_soln = YaskNullSolution()
             processed = nodes
             log("No offloadable trees found")
         elif len(offloadable) == 1:
             # Found *the* offloadable tree for this Operator
-            tree, dimensions, shape, dtype, space_order = offloadable[0]
-            self.context = yask_context(dimensions, shape, dtype, space_order)
+            tree, dimensions, shape, dtype = offloadable[0]
+            self.context = contexts.fetch(dimensions, shape, dtype)
 
-            transform = sympy2yask(self.context, ycsoln)
+            # Create a YASK compiler solution for this Operator
+            # Note: this can be dropped as soon as the kernel has been built
+            yc_soln = self.context.make_yc_solution(namespace['jit-yc-soln'])
+
+            transform = sympy2yask(self.context, yc_soln)
             try:
                 for i in tree[-1].nodes:
                     transform(i.expr)
@@ -105,25 +101,21 @@ class Operator(OperatorRunnable):
                 # Track this is an external function call
                 self.func_table[namespace['code-soln-run']] = FunMeta(None, False)
 
-                # Set necessary run-time parameters
-                ycsoln.set_step_dim_name(self.context.time_dimension)
-                ycsoln.set_domain_dim_names(self.context.space_dimensions)
-                ycsoln.set_element_bytes(4)
-
                 # JIT-compile the newly-created YASK kernel
-                self.ksoln = self.context.make_solution(ycsoln)
+                self.yk_soln = self.context.make_yk_solution(namespace['jit-yk-soln'],
+                                                             yc_soln)
 
                 # Now we must drop a pointer to the YASK solution down to C-land
                 parameters.append(Object(namespace['code-soln-name'],
                                          namespace['type-solution'],
-                                         self.ksoln.rawpointer))
+                                         self.yk_soln.rawpointer))
 
                 # Print some useful information about the newly constructed solution
                 log("Solution '%s' contains %d grid(s) and %d equation(s)." %
-                    (ycsoln.get_name(), ycsoln.get_num_grids(),
-                     ycsoln.get_num_equations()))
+                    (yc_soln.get_name(), yc_soln.get_num_grids(),
+                     yc_soln.get_num_equations()))
             except:
-                self.ksoln = YaskNullSolution()
+                self.yk_soln = YaskNullSolution()
                 processed = nodes
                 log("Unable to offload a candidate tree.")
         else:
@@ -171,26 +163,26 @@ class Operator(OperatorRunnable):
         arguments, dim_sizes = self.arguments(**kwargs)
 
         # Share the grids from the hook solution
-        for kgrid in self.ksoln.grids:
+        for kgrid in self.yk_soln.grids:
             hgrid = self.context.grids[kgrid.get_name()]
             hgrid.give_storage(kgrid)
             log("Shared storage from hook grid <%s>" % hgrid.name)
 
         # Print some info about the solution.
-        log("Stencil-solution '%s':" % self.ksoln.name)
+        log("Stencil-solution '%s':" % self.yk_soln.name)
         log("  Step dimension: %s" % self.context.time_dimension)
         log("  Domain dimensions: %s" % str(self.context.space_dimensions))
         log("  Grids:")
-        for grid in self.ksoln.grids:
+        for grid in self.yk_soln.grids:
             pad = str([grid.get_pad_size(i) for i in self.context.space_dimensions])
             log("    %s%s, pad=%s" % (grid.get_name(), str(grid.get_dim_names()), pad))
 
         # Required by YASK before running any stencils
-        self.ksoln.prepare()
+        self.yk_soln.prepare()
 
         if yask_configuration['python-exec']:
             log("Running YASK Operator through YASK...")
-            self.ksoln.run(dim_sizes[self.context.time_dimension])
+            self.yk_soln.run(dim_sizes[self.context.time_dimension])
         else:
             log("Running YASK Operator through Devito...")
             self.cfunction(*list(arguments.values()))
@@ -208,8 +200,8 @@ class Operator(OperatorRunnable):
         """
         if self._lib is None:
             # No need to recompile if a shared object has already been loaded.
-            if not isinstance(self.ksoln, YaskNullSolution):
-                self._compiler.libraries.append(self.ksoln.soname)
+            if not isinstance(self.yk_soln, YaskNullSolution):
+                self._compiler.libraries.append(self.yk_soln.soname)
             return jit_compile(self.ccode, self._compiler)
         else:
             return self._lib.name
@@ -221,9 +213,9 @@ class sympy2yask(object):
     necessay YASK grids.
     """
 
-    def __init__(self, context, soln):
+    def __init__(self, context, yc_soln):
         self.context = context
-        self.soln = soln
+        self.yc_soln = yc_soln
         self.mapper = {}
 
     def __call__(self, expr):
@@ -247,7 +239,7 @@ class sympy2yask(object):
                     function.data  # Create uninitialized grid (i.e., 0.0 everywhere)
                 if name not in self.mapper:
                     dimensions = self.context.grids[name].get_dim_names()
-                    self.mapper[name] = self.soln.new_grid(name, dimensions)
+                    self.mapper[name] = self.yc_soln.new_grid(name, dimensions)
                 indices = [int((i.origin if isinstance(i, LoweredDimension) else i) - j)
                            for i, j in zip(expr.indices, function.indices)]
                 return self.mapper[name].new_relative_grid_point(*indices)

--- a/devito/yask/wrappers.py
+++ b/devito/yask/wrappers.py
@@ -1,6 +1,8 @@
 import os
 import sys
 import importlib
+from glob import glob
+from subprocess import call
 from collections import OrderedDict
 
 from cached_property import cached_property
@@ -166,21 +168,27 @@ class YaskGrid(object):
         return self[:]
 
 
-class YaskSolution(object):
+class YaskKernel(object):
 
     """
-    A ``YaskSolution`` wraps a YASK solution.
+    A ``YaskKernel`` wraps a YASK kernel solution.
     """
 
-    def __init__(self, name, ycsoln):
+    def __init__(self, name, yc_soln, domain):
         """
         Write out a YASK kernel, build it using YASK's Makefiles,
         import the corresponding SWIG-generated Python module, and finally
         create a YASK kernel solution object.
 
-        :param name: Unique name of this YaskSolution.
-        :param ycsoln: YaskCompiler solution
+        :param name: Unique name of this YaskKernel.
+        :param yc_soln: YaskCompiler solution.
+        :param domain: A mapper from space dimensions to their domain size.
         """
+        self.name = name
+
+        # Shared object name
+        self.soname = "%s.%s.%s" % (name, yc_soln.get_name(), yask_configuration['arch'])
+
         # It's necessary to `clean` the YASK kernel directory *before*
         # writing out the first `yask_stencil_code.hpp`
         make(namespace['path'], ['-C', namespace['kernel-path'], 'clean'])
@@ -188,15 +196,15 @@ class YaskSolution(object):
         # Write out the stencil file
         if not os.path.exists(namespace['kernel-path-gen']):
             os.makedirs(namespace['kernel-path-gen'])
-        ycsoln.format(yask_configuration['isa'],
-                      ofac.new_file_output(namespace['kernel-output']))
+        yc_soln.format(yask_configuration['isa'],
+                       ofac.new_file_output(namespace['kernel-output']))
 
         # JIT-compile it
         try:
             make(os.environ['YASK_HOME'], ['-j', 'YK_CXXOPT=-O0',
                                            "EXTRA_MACROS=TRACE",
                                            'YK_BASE=%s' % str(name),
-                                           'stencil=%s' % ycsoln.get_name(),
+                                           'stencil=%s' % yc_soln.get_name(),
                                            '-C', namespace['kernel-path'], 'api'])
         except CompilationError:
             exit("Kernel solution compilation")
@@ -206,36 +214,30 @@ class YaskSolution(object):
             yk = importlib.import_module(name)
         except ImportError:
             exit("Python YASK kernel bindings")
+        try:
+            yk = reload(yk)
+        except NameError:
+            # Python 3.5 compatibility
+            yk = importlib.reload(yk)
 
         # Create the YASK solution object
         kfac = yk.yk_factory()
         self.env = kfac.new_env()
         self.soln = kfac.new_solution(self.env)
 
-        # MPI setup
-        self.set_num_ranks()
+        # MPI setup: simple rank configuration in 1st dim only.
+        # TODO: in production runs, the ranks would be distributed along all
+        # domain dimensions.
+        self.soln.set_num_ranks(self.soln.get_domain_dim_names()[0],
+                                self.env.get_num_ranks())
 
         # Redirect stdout/strerr to a string
         self.output = yk.yask_output_factory().new_string_output()
         self.soln.set_debug_output(self.output)
 
-        self.name = name
-
-        # Shared object name
-        self.soname = "%s.%s.%s" % (name, ycsoln.get_name(), yask_configuration['arch'])
-
-    def set_num_ranks(self):
-        """
-        Simple rank configuration in 1st dim only.
-
-        This is work-in-progress: in production runs, the ranks would be
-        distributed along all domain dimensions.
-        """
-        self.soln.set_num_ranks(self.space_dimensions[0], self.env.get_num_ranks())
-
-    def set_rank_domain_size(self, domain_sizes):
-        for i in self.soln.get_domain_dim_names():
-            self.soln.set_rank_domain_size(i, domain_sizes[i])
+        # Set up the solution domain size
+        for k, v in domain.items():
+            self.soln.set_rank_domain_size(k, v)
 
     def new_grid(self, name, dimensions):
         return self.soln.new_grid(name, *dimensions)
@@ -263,69 +265,47 @@ class YaskSolution(object):
         return ctypes.cast(int(self.soln), ctypes.c_void_p)
 
     def __repr__(self):
-        return "YaskSolution [%s]" % self.name
+        return "YaskKernel [%s]" % self.name
 
 
 class YaskContext(object):
 
-    def __init__(self, name, dimensions, core, halo, dtype, hook):
+    def __init__(self, name, domain, dtype):
         """
         Proxy between Devito and YASK.
 
-        A YaskContext is required for any single kernel executed through YASK.
+        A YaskContext contains N YaskKernel and M YaskGrids.
+        Solutions and grids have in common the context domain. Grids, however, may
+        differ in the halo region, due to a different space order. The same grid
+        could be used in more than one of the N solutions.
 
         :param name: Unique name of the context.
-        :param dimensions: Context dimensions (may include time dimension).
-        :param core: Domain size along each dimension; includes time dimension.
-        :param halo: Halo size along each dimension.
+        :param domain: A mapper from space dimensions to their domain size.
         :param dtype: The data type used in kernels, as a NumPy dtype.
-        :param hook: "Fake" solution to track YASK grids.
         """
         self.name = name
-
-        self.dimensions = tuple(dimensions)
-        self.core = tuple(core)
-        self.halo = tuple(halo)
-
+        self.domain = domain
         self.dtype = dtype
-        self.hook = hook
 
         # All known solutions and grids in this context
         self.solutions = []
         self.grids = {}
 
+        # Build the hook kernel solution (wrapper) to create grids
+        yc_hook = self.make_yc_solution(namespace['jit-yc-hook'])
+        self.yk_hook = YaskKernel(namespace['jit-yk-hook'](name, 0), yc_hook, domain)
+
     @cached_property
     def space_dimensions(self):
-        return self.hook.space_dimensions
+        return tuple(self.yk_hook.space_dimensions)
 
     @cached_property
     def time_dimension(self):
-        return self.hook.time_dimension
+        return self.yk_hook.time_dimension
 
     @cached_property
-    def dim_core(self):
-        return OrderedDict([(i, j) for i, j in zip(self.dimensions, self.core)])
-
-    @cached_property
-    def dim_halo(self):
-        return OrderedDict([(i, j) for i, j in zip(self.dimensions, self.halo)])
-
-    @cached_property
-    def dim_shape(self):
-        return OrderedDict([(d, i + j*2) for d, i, j in
-                            zip(self.dimensions, self.core, self.halo)])
-
-    @cached_property
-    def domain_sizes(self):
-        ret = OrderedDict()
-        for k, v in self.dim_core.items():
-            if k in self.space_dimensions:
-                ret[k] = v
-        return ret
-
-    @cached_property
-    def shape(self):
-        return tuple(self.dim_shape.values())
+    def dimensions(self):
+        return (self.time_dimension,) + self.space_dimensions
 
     @property
     def nsolutions(self):
@@ -335,66 +315,97 @@ class YaskContext(object):
     def ngrids(self):
         return len(self.grids)
 
-    def make_grid(self, name, dimensions, shape, space_order, dtype):
+    def make_grid(self, name, dimensions, shape, radius, dtype):
         """
         Create and return a new :class:`YaskGrid`, which wraps a YASK grid.
-        """
-        # Set up the YASK grid
-        grid = self.hook.new_grid(name, dimensions)
-        for i in self.space_dimensions:
-            grid.set_halo_size(i, self.dim_halo[i])
-        if grid.is_dim_used(self.time_dimension):
-            grid.set_alloc_size(self.time_dimension, shape[0])
 
-        # Allocate memory immediately as the user may simply want to use it
+        Memory is allocated immediately.
+        """
         if name in self.grids:
-            log("Reusing pre-existing grid %s (reinitialized to 0.)" % name)
-            self.grids[name]._reset()
-        else:
-            log("Allocating YaskGrid for %s (%s)" % (name, str(shape)))
-            grid.alloc_storage()
-            self.grids[name] = YaskGrid(grid, dimensions, shape, self.halo, dtype)
+            exit("Grids must have unique name within a context")
+        log("Allocating YaskGrid for %s (%s)" % (name, str(shape)))
+        grid = self.yk_hook.new_grid(name, dimensions)
+        wrapper = YaskGrid(grid, shape, radius, dtype)
+        self.grids[name] = wrapper
+        return wrapper
 
-        return self.grids[name]
-
-    def make_solution(self, ycsoln):
+    def make_yc_solution(self, namer):
         """
-        Create and return a new :class:`YaskSolution` using ``self`` as context
-        and ``ycsoln`` as YASK compiler ("stencil") solution.
+        Create and return a YASK compiler solution object.
         """
-        soln = YaskSolution('%s_soln%d' % (self.name, self.nsolutions), ycsoln)
+        yc_soln = cfac.new_solution(namer(self.name, self.nsolutions))
+        yc_soln.set_debug_output(ofac.new_null_output())
+        yc_soln.set_step_dim_name(namespace['time-dim'])
+        yc_soln.set_domain_dim_names(*list(self.domain))
+        yc_soln.set_element_bytes(self.dtype().itemsize)
+        return yc_soln
 
-        # Setup soln's domains
-        soln.set_rank_domain_size(self.domain_sizes)
-
-        # Setup soln's grids using the hook solution
-        for sgrid in soln.grids:
-            name = sgrid.get_name()
-            try:
-                hgrid = self.grids[name]
-            except KeyError:
-                exit("Unknown grid %s" % name)
-            # Halo in the space dimensions
-            for i in self.space_dimensions:
-                sgrid.set_halo_size(i, hgrid.get_halo_size(i))
-            # Extent of the time dimension
-            if sgrid.is_dim_used(self.time_dimension):
-                sgrid.set_alloc_size(self.time_dimension,
-                                     hgrid.get_alloc_size(self.time_dimension))
-
+    def make_yk_solution(self, namer, yc_soln):
+        """
+        Create and return a new :class:`YaskKernel` using ``self`` as context
+        and ``yc_soln`` as YASK compiler ("stencil") solution.
+        """
+        soln = YaskKernel(namer(self.name, self.nsolutions), yc_soln, self.domain)
         self.solutions.append(soln)
-
         return soln
 
     def __repr__(self):
-        return ("YaskContext [%s]\n"
-                "- core: %s\n"
-                "- halo: %s\n"
-                "- grids: %s\n"
-                "- solns: %s\n") % (self.name, str(self.dim_core), str(self.dim_halo),
-                                    ', '.join([str(i) for i in list(self.grids)]),
-                                    ', '.join([i.name for i in list(self.solutions)]))
+        return ("YaskContext: %s\n"
+                "- domain: %s\n"
+                "- grids: [%s]\n"
+                "- solns: [%s]\n") % (self.name, str(self.domain),
+                                      ', '.join([i for i in list(self.grids)]),
+                                      ', '.join([i.name for i in self.solutions]))
 
+
+class ContextManager(OrderedDict):
+
+    def __init__(self, *args, **kwargs):
+        super(ContextManager, self).__init__(*args, **kwargs)
+        self.ncontexts = 0
+
+    def dump(self):
+        """
+        Drop all known contexts and clean up lib directory.
+        """
+        self.clear()
+        call(['rm', '-f'] + glob(os.path.join(namespace['path'], 'lib', '*devito*')))
+        call(['rm', '-f'] + glob(os.path.join(namespace['path'], 'lib', '*hook*')))
+
+    def fetch(self, dimensions, shape, dtype):
+        """
+        Fetch the :class:`YaskContext` in ``self`` uniquely identified by
+        ``dimensions``, ``shape``, and ``dtype``. Create a new (empty)
+        :class:`YaskContext` on miss.
+        """
+        # Sanity checks
+        assert len(dimensions) == len(shape)
+        dimensions = [str(i) for i in dimensions]
+        if set(dimensions) < {'x', 'y', 'z'}:
+            exit("Need a DenseData[x,y,z] for initialization")
+
+        # The time dimension is dropped as implicit to the context
+        domain = OrderedDict([(i, j) for i, j in zip(dimensions, shape)
+                              if i != namespace['time-dim']])
+
+        # A unique key for this context.
+        key = tuple([dtype] + domain.items())
+
+        # Fetch or create a YaskContext
+        if key in self:
+            log("Fetched existing context from cache")
+        else:
+            self[key] = YaskContext('ctx%d' % self.ncontexts, domain, dtype)
+            self.ncontexts += 1
+            log("Context successfully created!")
+        return self[key]
+
+
+contexts = ContextManager()
+"""All known YASK contexts."""
+
+
+# Helpers
 
 class YaskNullSolution(object):
 
@@ -425,63 +436,3 @@ class YaskNullContext(object):
     @property
     def time_dimension(self):
         return '?'
-
-
-contexts = OrderedDict()
-"""All known YASK contexts."""
-
-
-def yask_context(dimensions, shape, dtype, space_order):
-    """
-    Create a new :class:`YaskContext`, or retrieve an existing one with same
-    ``dimensions``, ``shape``, ``dtype``, and ``space_order``.
-    """
-
-    key = (dimensions, shape, dtype, space_order)
-    if key in contexts:
-        return contexts[key]
-
-    log("Creating new context...")
-
-    assert len(dimensions) == len(shape)
-
-    # Create a new stencil solution
-    soln = cfac.new_solution(namespace['kernel-hook'])
-
-    # Silence YASK
-    soln.set_debug_output(ofac.new_null_output())
-
-    # Setup hook solution builder
-    soln.set_step_dim_name(namespace['time-dim'])
-    dimensions = [str(i) for i in dimensions]
-    if set(dimensions) < {'x', 'y', 'z'}:
-        exit("Need a DenseData[x,y,z] for initialization")
-    # TODO: YASK only accepts x,y,z
-    soln.set_domain_dim_names(*[i for i in dimensions if i != namespace['time-dim']])
-
-    # Number of bytes in each FP value
-    soln.set_element_bytes(dtype().itemsize)
-
-    # Create hook solution, JIT-ting the corresponding YASK kernel
-    hook = YaskSolution(namespace['kernel-hook'], soln)
-
-    # Setup hook solution
-    # TODO: This will probably require using NBPML
-    core = []
-    halo = []
-    for i, j in zip(dimensions, shape):
-        if namespace['time-dim'] != i:
-            # Padding only meaningful in space dimensions
-            halo.append(space_order)
-            core.append(j - space_order*2)
-        else:
-            halo.append(0)
-            core.append(j)
-    hook.set_rank_domain_size(dict(zip(dimensions, core)))
-
-    contexts[key] = YaskContext('devito_ctx%d' % len(contexts),
-                                dimensions, core, halo, dtype, hook)
-
-    log("Context successfully created!")
-
-    return contexts[key]

--- a/devito/yask/wrappers.py
+++ b/devito/yask/wrappers.py
@@ -130,6 +130,10 @@ class YaskGrid(object):
         return self.grid.get_name()
 
     @property
+    def dimensions(self):
+        return self.grid.get_dim_names()
+
+    @property
     def ndpointer(self):
         """Return a :class:`numpy.ndarray` view of the grid content."""
         ctype = numpy_to_ctypes(self.dtype)
@@ -143,6 +147,17 @@ class YaskGrid(object):
     @property
     def rawpointer(self):
         return ctypes.cast(int(self.grid), ctypes.c_void_p)
+
+    def give_storage(self, target):
+        """
+        Share self's storage with ``target``.
+        """
+        for i in self.dimensions:
+            if i == namespace['time-dim']:
+                target.set_alloc_size(i, self.get_alloc_size(i))
+            else:
+                target.set_halo_size(i, self.get_halo_size(i))
+        target.share_storage(self.grid)
 
     def view(self):
         """


### PR DESCRIPTION
Two critical fixes in the **YASK backend**:

- The following is now supported, as expected in Devito:
```
u0 = TimeData(name='u', shape=S, dimensions=D, ...)
u1 = TimeData(name='u', shape=S, dimensions=D, ...)
``` 
Clearly u0 and u1 cannot be used in the same Operator. Previously, attempting to create two shared object with same name/shape/dimensions would have raised an error

- A data object shape now corresponds to the "domain size"; the halo, inferred from ``space_order``, is "constructed" on top of the shape, not by removing inner points. This matches the YASK behavior. This represents an API divergence points w.r.t. the default backend. However, we expect the default backend to adopt this semantics as well in the (close) future, in particular when the Grid abstraction will become available. The reasons why this was necessary have been discussed at length offline (Slack #yask and #general channels).

There's also some refactoring going on with this PR. 

Again, this PR has many changes because the YASK backend is still a prototype, which is continuously evolving. Once the YASK backend will be released, PRs will go back being more sane.