### PR TITLE
Examples cleanup

### DIFF
--- a/devito/interfaces.py
+++ b/devito/interfaces.py
@@ -631,7 +631,7 @@ class DenseData(TensorData):
 
     def laplace2(self, weight=1):
         """Symbol for the double laplacian wrt all spatial dimensions"""
-        order = self.space_order/2 + self.space_order/2 % 2
+        order = self.space_order/2
         first = sum([second_derivative(self, dim=d,
                                        order=order)
                      for d in self.indices[1:]])

--- a/examples/seismic/acoustic/operators.py
+++ b/examples/seismic/acoustic/operators.py
@@ -75,7 +75,7 @@ def ForwardOperator(model, source, receiver, time_order=2, space_order=4,
     # Create symbols for forward wavefield, source and receivers
     u = TimeData(name='u', shape=model.shape_domain, dtype=model.dtype,
                  save=save, time_dim=source.nt if save else None,
-                 time_order=time_order, space_order=space_order)
+                 time_order=2, space_order=space_order)
     src = PointSource(name='src', ntime=source.nt, ndim=source.ndim,
                       npoint=source.npoint)
     rec = Receiver(name='rec', ntime=receiver.nt, ndim=receiver.ndim,
@@ -115,7 +115,7 @@ def AdjointOperator(model, source, receiver, time_order=2, space_order=4, **kwar
     m, damp = model.m, model.damp
 
     v = TimeData(name='v', shape=model.shape_domain, save=False,
-                 time_order=time_order, space_order=space_order,
+                 time_order=2, space_order=space_order,
                  dtype=model.dtype)
     srca = PointSource(name='srca', ntime=source.nt, ndim=source.ndim,
                        npoint=source.npoint)
@@ -158,10 +158,10 @@ def GradientOperator(model, source, receiver, time_order=2, space_order=4, **kwa
     grad = DenseData(name='grad', shape=model.shape_domain,
                      dtype=model.dtype)
     u = TimeData(name='u', shape=model.shape_domain, save=True,
-                 time_dim=source.nt, time_order=time_order,
+                 time_dim=source.nt, time_order=2,
                  space_order=space_order, dtype=model.dtype)
     v = TimeData(name='v', shape=model.shape_domain, save=False,
-                 time_order=time_order, space_order=space_order,
+                 time_order=2, space_order=space_order,
                  dtype=model.dtype)
     rec = Receiver(name='rec', ntime=receiver.nt, ndim=receiver.ndim,
                    npoint=receiver.npoint)
@@ -210,10 +210,10 @@ def BornOperator(model, source, receiver, time_order=2, space_order=4, **kwargs)
 
     # Create wavefields and a dm field
     u = TimeData(name="u", shape=model.shape_domain, save=False,
-                 time_order=time_order, space_order=space_order,
+                 time_order=2, space_order=space_order,
                  dtype=model.dtype)
     U = TimeData(name="U", shape=model.shape_domain, save=False,
-                 time_order=time_order, space_order=space_order,
+                 time_order=2, space_order=space_order,
                  dtype=model.dtype)
     dm = DenseData(name="dm", shape=model.shape_domain,
                    dtype=model.dtype)

--- a/examples/seismic/acoustic/operators.py
+++ b/examples/seismic/acoustic/operators.py
@@ -14,7 +14,7 @@ def laplacian(field, time_order, m, s):
     :param field:  Symbolic TimeData object, solution to be computed
     :param time_order: time order
     :param m: square slowness
-    :param s: symbol of for the time-step
+    :param s: symbol for the time-step
     :return: H
     """
     if time_order == 2:
@@ -34,7 +34,7 @@ def iso_stencil(field, time_order, m, s, damp, **kwargs):
     :param field: Symbolic TimeData object, solution to be computed
     :param time_order: time order
     :param m: square slowness
-    :param s: symbol of for the time-step
+    :param s: symbol for the time-step
     :param damp: ABC dampening field (DenseData)
     :param kwargs: forwad/backward wave equation (sign of u.dt will change accordingly
     as well as the updated time-step (u.forwad or u.backward)

--- a/examples/seismic/acoustic/operators.py
+++ b/examples/seismic/acoustic/operators.py
@@ -47,7 +47,7 @@ def iso_stencil(field, time_order, m, s, damp, **kwargs):
     # Define time sep to be updated
     next = field.forward if kwargs.get('forward', True) else field.backward
     # Define PDE
-    eq = m * field.dt2 - H + kwargs.get('q', 0)
+    eq = m * field.dt2 - H - kwargs.get('q', 0)
     # Add dampening field according to the propagation direction
     eq += damp * field.dt if kwargs.get('forward', True) else -damp * field.dt
     # Solve the symbolic equation for the field to be updated

--- a/examples/seismic/acoustic/operators.py
+++ b/examples/seismic/acoustic/operators.py
@@ -11,7 +11,7 @@ def laplacian(field, time_order, m, s):
     order in time formulation, the 4th order time derivative is replaced by a
     double laplacian:
     H = (laplacian + s**2/12 laplacian(1/m*laplacian))
-    :param field:  Symbolic TimeData object, solution to be computed
+    :param field: Symbolic TimeData object, solution to be computed
     :param time_order: time order
     :param m: square slowness
     :param s: symbol for the time-step

--- a/examples/seismic/acoustic/operators.py
+++ b/examples/seismic/acoustic/operators.py
@@ -24,7 +24,6 @@ def laplacian(field, time_order, m, s):
     else:
         error("Unsupported time order %d, order has to be 2 or 4" %
               time_order)
-
     return field.laplace + s**2/12 * biharmonic
 
 

--- a/examples/seismic/acoustic/operators.py
+++ b/examples/seismic/acoustic/operators.py
@@ -114,8 +114,7 @@ def AdjointOperator(model, source, receiver, time_order=2, space_order=4, **kwar
     m, damp = model.m, model.damp
 
     v = TimeData(name='v', shape=model.shape_domain, save=False,
-                 time_order=2, space_order=space_order,
-                 dtype=model.dtype)
+                 time_order=2, space_order=space_order, dtype=model.dtype)
     srca = PointSource(name='srca', ntime=source.nt, ndim=source.ndim,
                        npoint=source.npoint)
     rec = Receiver(name='rec', ntime=receiver.nt, ndim=receiver.ndim,
@@ -209,13 +208,10 @@ def BornOperator(model, source, receiver, time_order=2, space_order=4, **kwargs)
 
     # Create wavefields and a dm field
     u = TimeData(name="u", shape=model.shape_domain, save=False,
-                 time_order=2, space_order=space_order,
-                 dtype=model.dtype)
+                 time_order=2, space_order=space_order, dtype=model.dtype)
     U = TimeData(name="U", shape=model.shape_domain, save=False,
-                 time_order=2, space_order=space_order,
-                 dtype=model.dtype)
-    dm = DenseData(name="dm", shape=model.shape_domain,
-                   dtype=model.dtype)
+                 time_order=2, space_order=space_order, dtype=model.dtype)
+    dm = DenseData(name="dm", shape=model.shape_domain, dtype=model.dtype)
 
     s = t.spacing
     # Get computational time-step value

--- a/examples/seismic/acoustic/operators.py
+++ b/examples/seismic/acoustic/operators.py
@@ -1,7 +1,61 @@
-from sympy import Eq
+from sympy import Eq, solve, Symbol
 
 from devito import Operator, Forward, Backward, DenseData, TimeData, time, t
+from devito.logger import error
 from examples.seismic import PointSource, Receiver
+
+
+def laplacian(field, time_order, m, s):
+    """
+    Spacial discretization for the isotropic acoustic wave equation. For a 4th
+    order in time formulation, the 4th order time derivative is replaced by a
+    double laplacian:
+    H = (laplacian + s**2/12 laplacian(1/m*laplacian))
+    :param field:  Symbolic TimeData object, solution to be computed
+    :param time_order: time order
+    :param m: square slowness
+    :param s: symbol of for the time-step
+    :return: H
+    """
+    if time_order == 2:
+        biharmonic = 0
+    elif time_order == 4:
+        biharmonic = field.laplace2(1/m)
+    else:
+        error("Unsupported time order %d, order has to be 2 or 4" %
+              time_order)
+
+    return field.laplace + s**2/12 * biharmonic
+
+
+def iso_stencil(field, time_order, m, s, damp, **kwargs):
+    """
+    Stencil for the acoustic isotropic wave-equation:
+    u.dt2 - H + damp*u.dt = 0
+    :param field: Symbolic TimeData object, solution to be computed
+    :param time_order: time order
+    :param m: square slowness
+    :param s: symbol of for the time-step
+    :param damp: ABC dampening field (DenseData)
+    :param kwargs: forwad/backward wave equation (sign of u.dt will change accordingly
+    as well as the updated time-step (u.forwad or u.backward)
+    :return: Stencil for the wave-equation
+    """
+
+    # Creat a temporary symbol for H to avoid expensive sympy solve
+    H = Symbol('H')
+    # Define time sep to be updated
+    next = field.forward if kwargs.get('forward', True) else field.backward
+    # Define PDE
+    eq = m * field.dt2 - H + kwargs.get('q', 0)
+    # Add dampening field according to the propagation direction
+    eq += damp * field.dt if kwargs.get('forward', True) else -damp * field.dt
+    # Solve the symbolic equation for the field to be updated
+    eq_time = solve(eq, next, rational=False, simplify=False)[0]
+    # Get the spacial FD
+    lap = laplacian(field, time_order, m, s)
+    # return the Stencil with H replaced by its symbolic expression
+    return [Eq(next, eq_time.subs({H: lap}))]
 
 
 def ForwardOperator(model, source, receiver, time_order=2, space_order=4,
@@ -27,23 +81,11 @@ def ForwardOperator(model, source, receiver, time_order=2, space_order=4,
     rec = Receiver(name='rec', ntime=receiver.nt, ndim=receiver.ndim,
                    npoint=receiver.npoint)
 
-    if time_order == 2:
-        biharmonic = 0
-        dt = model.critical_dt
-    else:
-        biharmonic = u.laplace2(1/m)
-        dt = 1.73 * model.critical_dt
-
-    # Derive both stencils from symbolic equation:
-    # Create the stencil by hand instead of calling numpy solve for speed purposes
-    # Simple linear solve of a u(t+dt) + b u(t) + c u(t-dt) = L for u(t+dt)
-
     s = t.spacing
+    # Get computational time-step value
+    dt = model.critical_dt * (1.73 if time_order == 4 else 1.0)
 
-    stencil = 1.0 / (2.0 * m + s * damp) * (
-        4.0 * m * u + (s * damp - 2.0 * m) * u.backward +
-        2.0 * s**2 * (u.laplace + s**2 / 12.0 * biharmonic))
-    eqn = [Eq(u.forward, stencil)]
+    eqn = iso_stencil(u, time_order, m, s, damp)
 
     # Construct expression to inject source values
     src_term = src.inject(field=u.forward, expr=src * dt**2 / m,
@@ -51,6 +93,7 @@ def ForwardOperator(model, source, receiver, time_order=2, space_order=4,
 
     # Create interpolation expression for receivers
     rec_term = rec.interpolate(expr=u, offset=model.nbpml)
+
     subs = dict([(t.spacing, dt)] + [(time.spacing, dt)] +
                 [(i.spacing, model.get_spacing()[j]) for i, j
                  in zip(u.indices[1:], range(len(model.shape)))])
@@ -80,19 +123,10 @@ def AdjointOperator(model, source, receiver, time_order=2, space_order=4, **kwar
                    npoint=receiver.npoint)
 
     s = t.spacing
+    # Get computational time-step value
+    dt = model.critical_dt * (1.73 if time_order == 4 else 1.0)
 
-    if time_order == 2:
-        biharmonic = 0
-        dt = model.critical_dt
-    else:
-        biharmonic = v.laplace2(1/m)
-        dt = 1.73 * model.critical_dt
-
-    # Derive both stencils from symbolic equation
-    stencil = 1.0 / (2.0 * m + s * damp) * (
-        4.0 * m * v + (s * damp - 2.0 * m) * v.forward +
-        2.0 * s**2 * (v.laplace + s**2 / 12.0 * biharmonic))
-    eqn = Eq(v.backward, stencil)
+    eqn = iso_stencil(v, time_order, m, s, damp, forward=False)
 
     # Construct expression to inject receiver values
     receivers = rec.inject(field=v.backward, expr=rec * dt**2 / m,
@@ -103,7 +137,7 @@ def AdjointOperator(model, source, receiver, time_order=2, space_order=4, **kwar
     subs = dict([(t.spacing, dt)] + [(time.spacing, dt)] +
                 [(i.spacing, model.get_spacing()[j]) for i, j
                  in zip(v.indices[1:], range(len(model.shape)))])
-    return Operator([eqn] + receivers + source_a,
+    return Operator(eqn + receivers + source_a,
                     subs=subs,
                     time_axis=Backward, name='Adjoint', **kwargs)
 
@@ -133,22 +167,16 @@ def GradientOperator(model, source, receiver, time_order=2, space_order=4, **kwa
                    npoint=receiver.npoint)
 
     s = t.spacing
+    # Get computational time-step value
+    dt = model.critical_dt * (1.73 if time_order == 4 else 1.0)
+
+    eqn = iso_stencil(v, time_order, m, s, damp, forward=False)
 
     if time_order == 2:
-        biharmonic = 0
-        dt = model.critical_dt
         gradient_update = Eq(grad, grad - u.dt2 * v)
     else:
-        biharmonic = v.laplace2(1/m)
-        biharmonicu = - u.laplace2(1/(m**2))
-        dt = 1.73 * model.critical_dt
-        gradient_update = Eq(grad, grad - (u.dt2 - s**2 / 12.0 * biharmonicu) * v)
-
-    # Derive stencil from symbolic equation
-    stencil = 1.0 / (2.0 * m + s * damp) * \
-        (4.0 * m * v + (s * damp - 2.0 * m) *
-         v.forward + 2.0 * s ** 2 * (v.laplace + s**2 / 12.0 * biharmonic))
-    eqn = Eq(v.backward, stencil)
+        gradient_update = Eq(grad, grad - (u.dt2 +
+                                           s**2 / 12.0 * u.laplace2(m**(-2))) * v)
 
     # Add expression for receiver injection
     receivers = rec.inject(field=v.backward, expr=rec * dt**2 / m,
@@ -157,7 +185,7 @@ def GradientOperator(model, source, receiver, time_order=2, space_order=4, **kwa
     subs = dict([(t.spacing, dt)] + [(time.spacing, dt)] +
                 [(i.spacing, model.get_spacing()[j]) for i, j
                  in zip(v.indices[1:], range(len(model.shape)))])
-    return Operator([eqn] + receivers + [gradient_update],
+    return Operator(eqn + receivers + [gradient_update],
                     subs=subs,
                     time_axis=Backward, name='Gradient', **kwargs)
 
@@ -190,28 +218,12 @@ def BornOperator(model, source, receiver, time_order=2, space_order=4, **kwargs)
     dm = DenseData(name="dm", shape=model.shape_domain,
                    dtype=model.dtype)
 
-    if time_order == 2:
-        biharmonicu = 0
-        biharmonicU = 0
-        dt = model.critical_dt
-    else:
-        biharmonicu = u.laplace2(1/m)
-        biharmonicU = U.laplace2(1/m)
-        dt = 1.73 * model.critical_dt
-
-    # Derive both stencils from symbolic equation
-    # first_eqn = m * u.dt2 - u.laplace + damp * u.dt
-    # second_eqn = m * U.dt2 - U.laplace - dm* u.dt2 + damp * U.dt
     s = t.spacing
-    stencil1 = 1.0 / (2.0 * m + s * damp) * \
-        (4.0 * m * u + (s * damp - 2.0 * m) *
-         u.backward + 2.0 * s ** 2 * (u.laplace + s**2 / 12.0 * biharmonicu))
-    stencil2 = 1.0 / (2.0 * m + s * damp) * \
-        (4.0 * m * U + (s * damp - 2.0 * m) *
-         U.backward + 2.0 * s ** 2 * (U.laplace +
-                                      s**2 / 12.0 * biharmonicU - dm * u.dt2))
-    eqn1 = Eq(u.forward, stencil1)
-    eqn2 = Eq(U.forward, stencil2)
+    # Get computational time-step value
+    dt = model.critical_dt * (1.73 if time_order == 4 else 1.0)
+
+    eqn1 = iso_stencil(u, time_order, m, s, damp)
+    eqn2 = iso_stencil(U, time_order, m, s, damp, q=-dm*u.dt2)
 
     # Add source term expression for u
     source = src.inject(field=u.forward, expr=src * dt**2 / m,
@@ -222,6 +234,6 @@ def BornOperator(model, source, receiver, time_order=2, space_order=4, **kwargs)
     subs = dict([(t.spacing, dt)] + [(time.spacing, dt)] +
                 [(i.spacing, model.get_spacing()[j]) for i, j
                  in zip(u.indices[1:], range(len(model.shape)))])
-    return Operator([eqn1] + source + [eqn2] + receivers,
+    return Operator(eqn1 + source + eqn2 + receivers,
                     subs=subs,
                     time_axis=Forward, name='Born', **kwargs)

--- a/examples/seismic/acoustic/wavesolver.py
+++ b/examples/seismic/acoustic/wavesolver.py
@@ -16,9 +16,10 @@ class AcousticWaveSolver(object):
     :param receiver: Sparse point symbol describing an array of receivers
     :param time_order: Order of the time-stepping scheme (default: 2, choices: 2,4)
                        time_order=4 will not implement a 4th order FD discretization
-                       of the time-derivative as it is unstable. It implement instead
+                       of the time-derivative as it is unstable. It implements instead
                        a 4th order accurate wave-equation with only second order
                        time derivative.
+                       http://www.hl107.math.msstate.edu/pdfs/rein/HighANM_final.pdf
     :param space_order: Order of the spatial stencil discretisation (default: 4)
 
     Note: space_order must always be greater than time_order

--- a/examples/seismic/acoustic/wavesolver.py
+++ b/examples/seismic/acoustic/wavesolver.py
@@ -1,5 +1,3 @@
-from cached_property import cached_property
-
 from devito import DenseData, TimeData, memoized
 from examples.seismic import PointSource, Receiver
 from examples.seismic.acoustic.operators import (
@@ -49,21 +47,21 @@ class AcousticWaveSolver(object):
                                receiver=self.receiver, time_order=self.time_order,
                                space_order=self.space_order, **self._kwargs)
 
-    @cached_property
+    @memoized
     def op_adj(self):
         """Cached operator for adjoint runs"""
         return AdjointOperator(self.model, save=False, source=self.source,
                                receiver=self.receiver, time_order=self.time_order,
                                space_order=self.space_order, **self._kwargs)
 
-    @cached_property
+    @memoized
     def op_grad(self):
         """Cached operator for gradient runs"""
         return GradientOperator(self.model, save=False, source=self.source,
                                 receiver=self.receiver, time_order=self.time_order,
                                 space_order=self.space_order, **self._kwargs)
 
-    @cached_property
+    @memoized
     def op_born(self):
         """Cached operator for born runs"""
         return BornOperator(self.model, save=False, source=self.source,
@@ -138,7 +136,7 @@ class AcousticWaveSolver(object):
             m = self.model.m
 
         # Execute operator and return wavefield and receiver data
-        summary = self.op_adj.apply(srca=srca, rec=rec, v=v, m=m, **kwargs)
+        summary = self.op_adj().apply(srca=srca, rec=rec, v=v, m=m, **kwargs)
         return srca, v, summary
 
     def gradient(self, rec, u, v=None, grad=None, m=None, **kwargs):
@@ -171,7 +169,7 @@ class AcousticWaveSolver(object):
         if m is None:
             m = m or self.model.m
 
-        summary = self.op_grad.apply(rec=rec, grad=grad, v=v, u=u, m=m, **kwargs)
+        summary = self.op_grad().apply(rec=rec, grad=grad, v=v, u=u, m=m, **kwargs)
         return grad, summary
 
     def born(self, dmin, src=None, rec=None, u=None, U=None, m=None, **kwargs):
@@ -209,5 +207,5 @@ class AcousticWaveSolver(object):
             m = self.model.m
 
         # Execute operator and return wavefield and receiver data
-        summary = self.op_born.apply(dm=dmin, u=u, U=U, src=src, rec=rec, m=m, **kwargs)
+        summary = self.op_born().apply(dm=dmin, u=u, U=U, src=src, rec=rec, m=m, **kwargs)
         return rec, u, U, summary

--- a/examples/seismic/acoustic/wavesolver.py
+++ b/examples/seismic/acoustic/wavesolver.py
@@ -38,8 +38,8 @@ class AcousticWaveSolver(object):
         # Cache compiler options
         self._kwargs = kwargs
 
-    @cached_property
-    def op_fwd(self, save):
+    @memoized
+    def op_fwd(self, save=False):
         """Cached operator for forward runs with buffered wavefield"""
         return ForwardOperator(self.model, save=save, source=self.source,
                                receiver=self.receiver, time_order=self.time_order,

--- a/examples/seismic/acoustic/wavesolver.py
+++ b/examples/seismic/acoustic/wavesolver.py
@@ -18,7 +18,8 @@ class AcousticWaveSolver(object):
                        time_order=4 will not implement a 4th order FD discretization
                        of the time-derivative as it is unstable. It implements instead
                        a 4th order accurate wave-equation with only second order
-                       time derivative.
+                       time derivative. Full derivation and explanation of the 4th order
+                       in time can be found at:
                        http://www.hl107.math.msstate.edu/pdfs/rein/HighANM_final.pdf
     :param space_order: Order of the spatial stencil discretisation (default: 4)
 
@@ -94,8 +95,7 @@ class AcousticWaveSolver(object):
         if u is None:
             u = TimeData(name='u', shape=self.model.shape_domain, save=save,
                          time_dim=self.source.nt if save else None,
-                         time_order=2,
-                         space_order=self.space_order,
+                         time_order=2, space_order=self.space_order,
                          dtype=self.model.dtype)
 
         # Pick m from model unless explicitly provided
@@ -127,9 +127,8 @@ class AcousticWaveSolver(object):
 
         # Create the adjoint wavefield if not provided
         if v is None:
-            v = TimeData(name='v', shape=self.model.shape_domain,
-                         save=False, time_order=2,
-                         space_order=self.space_order,
+            v = TimeData(name='v', shape=self.model.shape_domain, save=False,
+                         time_order=2, space_order=self.space_order,
                          dtype=self.model.dtype)
 
         # Pick m from model unless explicitly provided
@@ -162,8 +161,7 @@ class AcousticWaveSolver(object):
         # Create the forward wavefield
         if v is None:
             v = TimeData(name='v', shape=self.model.shape_domain, save=False,
-                         time_order=2,
-                         space_order=self.space_order,
+                         time_order=2, space_order=self.space_order,
                          dtype=self.model.dtype)
 
         # Pick m from model unless explicitly provided
@@ -195,13 +193,12 @@ class AcousticWaveSolver(object):
         # Create the forward wavefields u and U if not provided
         if u is None:
             u = TimeData(name='u', shape=self.model.shape_domain,
-                         save=False, time_order=2,
-                         space_order=self.space_order,
+                         save=False, time_order=2, space_order=self.space_order,
                          dtype=self.model.dtype)
         if U is None:
             U = TimeData(name='U', shape=self.model.shape_domain,
-                         save=False, time_order=2,
-                         space_order=self.space_order, dtype=self.model.dtype)
+                         save=False, time_order=2, space_order=self.space_order,
+                         dtype=self.model.dtype)
 
         # Pick m from model unless explicitly provided
         if m is None:

--- a/examples/seismic/acoustic/wavesolver.py
+++ b/examples/seismic/acoustic/wavesolver.py
@@ -17,7 +17,11 @@ class AcousticWaveSolver(object):
     :param model: Physical model with domain parameters
     :param source: Sparse point symbol providing the injected wave
     :param receiver: Sparse point symbol describing an array of receivers
-    :param time_order: Order of the time-stepping scheme (default: 2)
+    :param time_order: Order of the time-stepping scheme (default: 2, choices: 2,4)
+                       time_order=4 will not implement a 4th order FD discretization 
+                       of the time-derivative as it is unstable. It implement instead
+                       a 4th order accurate wave-equation with only second order
+                       time derivative.
     :param space_order: Order of the spatial stencil discretisation (default: 4)
 
     Note: space_order must always be greater than time_order
@@ -28,10 +32,7 @@ class AcousticWaveSolver(object):
         self.source = source
         self.receiver = receiver
 
-        self.time_order = 2
-        debug("Internal time_order set to 2, the kernel ran will be 4th"
-              "order for `time_order=4` but only requires a second order "
-              "finite-difference scheme in time")
+        self.time_order = time_order
         self.space_order = space_order
 
         # Time step can be \sqrt{3}=1.73 bigger with 4th order

--- a/examples/seismic/acoustic/wavesolver.py
+++ b/examples/seismic/acoustic/wavesolver.py
@@ -45,21 +45,21 @@ class AcousticWaveSolver(object):
                                receiver=self.receiver, time_order=self.time_order,
                                space_order=self.space_order, **self._kwargs)
 
-    @memoized
+    @cached_property
     def op_adj(self):
         """Cached operator for adjoint runs"""
         return AdjointOperator(self.model, save=False, source=self.source,
                                receiver=self.receiver, time_order=self.time_order,
                                space_order=self.space_order, **self._kwargs)
 
-    @memoized
+    @cached_property
     def op_grad(self):
         """Cached operator for gradient runs"""
         return GradientOperator(self.model, save=False, source=self.source,
                                 receiver=self.receiver, time_order=self.time_order,
                                 space_order=self.space_order, **self._kwargs)
 
-    @memoized
+    @cached_property
     def op_born(self):
         """Cached operator for born runs"""
         return BornOperator(self.model, save=False, source=self.source,

--- a/examples/seismic/acoustic/wavesolver.py
+++ b/examples/seismic/acoustic/wavesolver.py
@@ -1,7 +1,6 @@
 from cached_property import cached_property
 
 from devito import DenseData, TimeData, memoized
-from devito.logger import debug
 from examples.seismic import PointSource, Receiver
 from examples.seismic.acoustic.operators import (
     ForwardOperator, AdjointOperator, GradientOperator, BornOperator
@@ -18,7 +17,7 @@ class AcousticWaveSolver(object):
     :param source: Sparse point symbol providing the injected wave
     :param receiver: Sparse point symbol describing an array of receivers
     :param time_order: Order of the time-stepping scheme (default: 2, choices: 2,4)
-                       time_order=4 will not implement a 4th order FD discretization 
+                       time_order=4 will not implement a 4th order FD discretization
                        of the time-derivative as it is unstable. It implement instead
                        a 4th order accurate wave-equation with only second order
                        time derivative.
@@ -96,7 +95,7 @@ class AcousticWaveSolver(object):
         if u is None:
             u = TimeData(name='u', shape=self.model.shape_domain, save=save,
                          time_dim=self.source.nt if save else None,
-                         time_order=self.time_order,
+                         time_order=2,
                          space_order=self.space_order,
                          dtype=self.model.dtype)
 
@@ -130,7 +129,7 @@ class AcousticWaveSolver(object):
         # Create the adjoint wavefield if not provided
         if v is None:
             v = TimeData(name='v', shape=self.model.shape_domain,
-                         save=False, time_order=self.time_order,
+                         save=False, time_order=2,
                          space_order=self.space_order,
                          dtype=self.model.dtype)
 
@@ -164,7 +163,7 @@ class AcousticWaveSolver(object):
         # Create the forward wavefield
         if v is None:
             v = TimeData(name='v', shape=self.model.shape_domain, save=False,
-                         time_order=self.time_order,
+                         time_order=2,
                          space_order=self.space_order,
                          dtype=self.model.dtype)
 
@@ -197,12 +196,12 @@ class AcousticWaveSolver(object):
         # Create the forward wavefields u and U if not provided
         if u is None:
             u = TimeData(name='u', shape=self.model.shape_domain,
-                         save=False, time_order=self.time_order,
+                         save=False, time_order=2,
                          space_order=self.space_order,
                          dtype=self.model.dtype)
         if U is None:
             U = TimeData(name='U', shape=self.model.shape_domain,
-                         save=False, time_order=self.time_order,
+                         save=False, time_order=2,
                          space_order=self.space_order, dtype=self.model.dtype)
 
         # Pick m from model unless explicitly provided

--- a/examples/seismic/acoustic/wavesolver.py
+++ b/examples/seismic/acoustic/wavesolver.py
@@ -1,6 +1,7 @@
 from cached_property import cached_property
 
 from devito import DenseData, TimeData, memoized
+from devito.logger import debug
 from examples.seismic import PointSource, Receiver
 from examples.seismic.acoustic.operators import (
     ForwardOperator, AdjointOperator, GradientOperator, BornOperator
@@ -27,7 +28,10 @@ class AcousticWaveSolver(object):
         self.source = source
         self.receiver = receiver
 
-        self.time_order = time_order
+        self.time_order = 2
+        debug("Internal time_order set to 2, the kernel ran will be 4th"
+              "order for `time_order=4` but only requires a second order "
+              "finite-difference scheme in time")
         self.space_order = space_order
 
         # Time step can be \sqrt{3}=1.73 bigger with 4th order

--- a/examples/seismic/model.py
+++ b/examples/seismic/model.py
@@ -13,9 +13,27 @@ def demo_model(preset, **kwargs):
     Utility function to create preset :class:`Model` objects for
     demonstration and testing purposes. The particular presets are ::
 
-    * 'layer2D': Simple two-layer model with velocities 1.5 km/s
+    * `constant-isotropic` : Constant velocity (1.5km/sec) isotropic model
+    * `constant-tti` : Constant anisotropic model. Velocity is 1.5 km/sec and
+                      Thomsen parameters are epsilon=.3, delta=.2, theta = .7rad
+                      and phi=.35rad for 3D. 2d/3d is defined from the input shape
+    * 'layers-isotropic': Simple two-layer model with velocities 1.5 km/s
                  and 2.5 km/s in the top and bottom layer respectively.
-    * 'marmousi2D': Loads the 2D Marmousi data set from the given
+                 2d/3d is defined from the input shape
+    * 'layers-tti': Simple two-layer TTI model with velocities 1.5 km/s
+                    and 2.5 km/s in the top and bottom layer respectively.
+                    Thomsen parameters in the top layer are 0 and in the lower layer
+                    are epsilon=.3, delta=.2, theta = .5rad and phi=.1 rad for 3D.
+                    2d/3d is defined from the input shape
+    * 'circle-isotropic': Simple camembert model with velocities 1.5 km/s
+                 and 2.5 km/s in a circle at the center. 2D only.
+    * 'marmousi2d-isotropic': Loads the 2D Marmousi data set from the given
+                    filepath. Requires the ``opesci/data`` repository
+                    to be available on your machine.
+    * 'marmousi2d-tti': Loads the 2D Marmousi data set from the given
+                    filepath. Requires the ``opesci/data`` repository
+                    to be available on your machine.
+    * 'marmousi3d-tti': Loads the 2D Marmousi data set from the given
                     filepath. Requires the ``opesci/data`` repository
                     to be available on your machine.
     """

--- a/examples/seismic/tti/wavesolver.py
+++ b/examples/seismic/tti/wavesolver.py
@@ -72,15 +72,13 @@ class AnisotropicWaveSolver(object):
         if u is None:
             u = TimeData(name='u', shape=self.model.shape_domain, save=save,
                          time_dim=self.source.nt if save else None,
-                         time_order=self.time_order,
-                         space_order=self.space_order,
+                         time_order=self.time_order, space_order=self.space_order,
                          dtype=self.model.dtype)
         # Create the forward wavefield if not provided
         if v is None:
             v = TimeData(name='v', shape=self.model.shape_domain,
                          save=save, time_dim=self.source.nt if save else None,
-                         time_order=self.time_order,
-                         space_order=self.space_order,
+                         time_order=self.time_order, space_order=self.space_order,
                          dtype=self.model.dtype)
         # Pick m from model unless explicitly provided
         if m is None:

--- a/tests/test_adjointJ.py
+++ b/tests/test_adjointJ.py
@@ -62,4 +62,4 @@ def test_acousticJ(shape, space_order):
 
 
 if __name__ == "__main__":
-    test_acousticJ(dimensions=(60, 70), space_order=4)
+    test_acousticJ(shape=(60, 70), space_order=4)

--- a/tests/test_gradient.py
+++ b/tests/test_gradient.py
@@ -121,8 +121,9 @@ def test_gradientJ(shape, time_order, space_order):
     # Test slope of the  tests
     p1 = np.polyfit(np.log10(H), np.log10(error1), 1)
     p2 = np.polyfit(np.log10(H), np.log10(error2), 1)
-    info('1st order error, Phi(m0+dm)-Phi(m0): %s' % (p1))
-    info('2nd order error, Phi(m0+dm)-Phi(m0) - <J(m0)^T \delta d, dm>: %s' % (p2))
+    info('1st order error, Phi(m0+dm)-Phi(m0) with slope: %s compared to 1' % (p1[0]))
+    info('2nd order error, Phi(m0+dm)-Phi(m0) - <J(m0)^T \delta d, dm>with slope:'
+         ' %s comapred to 2' % (p2[0]))
     assert np.isclose(p1[0], 1.0, rtol=0.1)
     assert np.isclose(p2[0], 2.0, rtol=0.1)
 


### PR DESCRIPTION
Cleanup according to #358 

> have a single ArgumentParser, used by both acoustic and TTI and any other future seismic equations. Perhaps to be moved to a utils.py module under examples/seismic

Not sure about this one, it would make it easier to run/benchmark for us but will start to make the example inaccessible for a lot of users IMO. 

> Use memoization in acoustic, in the same way we did for TTI

Done


> Move legacy leftovers of the following sort to model:

This will end up in `if-else` somewhere anyway, not sure it should/where it sould be moved.

`demo_model` docstring updated