### PR TITLE
ConstantData new_cls fix

### DIFF
--- a/devito/interfaces.py
+++ b/devito/interfaces.py
@@ -179,7 +179,8 @@ class AbstractSymbol(Function, CachedSymbol):
 
     def __new__(cls, *args, **kwargs):
         if cls in _SymbolCache:
-            newobj = Function.__new__(cls, *args)
+            options = kwargs.get('options', {})
+            newobj = Function.__new__(cls, *args, **options)
             newobj._cached_init()
         else:
             name = kwargs.get('name')


### PR DESCRIPTION
Tiny fix for `ConstantData` that was skipping `eval=false` in the `new options`.
Was making sympy solve fail.