### PR TITLE
Travis: Get utility packages from conda-forge

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -1,6 +1,7 @@
 name: devito
 channels:
   - defaults
+  - conda-forge
 dependencies:
   - numpy >=1.11
   - sympy ==1.0
@@ -12,6 +13,9 @@ dependencies:
   - psutil>=5.1.0
   - sphinx
   - sphinx_rtd_theme
+  # Some utilities for the pip dependencies below
+  - pandocfilters
+  - scandir
   - pip:
     - "git+git://github.com/inducer/cgen"
     - "git+git://github.com/inducer/codepy"


### PR DESCRIPTION
This should get our trvis testing back online and green (he said hopefully). :wink: 