### PR TITLE
Travis setup for YASK testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,9 @@ matrix:
     - os: linux
       python: "2.7"
       env: DEVITO_ARCH=gcc-4.9 DEVITO_OPENMP=1 OMP_NUM_THREADS=2
+    - os: linux
+      python: "3.5"
+      env: DEVITO_ARCH=gcc-4.9 DEVITO_OPENMP=0 DEVITO_BACKEND=yask
   allow_failures:
     - os: osx
       python: "2.7"
@@ -62,6 +65,10 @@ install:
 
 before_script:
   - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
+  - if [[ $DEVITO_BACKEND == 'yask' ]]; then
+      conda install swig;
+      pip install git+https://github.com/opesci/yask.git@v2_alpha-setup-py;
+    fi
 
 script:
   - flake8 --builtins=ArgumentError .

--- a/.travis.yml
+++ b/.travis.yml
@@ -76,13 +76,18 @@ before_script:
 script:
   - flake8 --builtins=ArgumentError .
   - py.test -vs tests/
-  - DEVITO_BACKEND=foreign py.test -vs tests/test_operator.py -k TestForeign
-  - python examples/seismic/benchmark.py test -P tti -so 4 -a -d 20 20 20 -n 5
-  - python examples/seismic/benchmark.py test -P acoustic -a
-  - python examples/seismic/acoustic/acoustic_example.py --full
-  - python examples/seismic/acoustic/constant_example.py --full
-  - py.test -vs examples/seismic/tutorials
-  - py.test -vs examples/cfd
+
+  # Additional seismic operator tests
+  - if [[ $DEVITO_BACKEND != 'yask' ]]; then
+      DEVITO_BACKEND=foreign py.test -vs tests/test_operator.py -k TestForeign;
+      python examples/seismic/benchmark.py test -P tti -so 4 -a -d 20 20 20 -n 5;
+      python examples/seismic/benchmark.py test -P acoustic -a;
+      python examples/seismic/acoustic/acoustic_example.py --full;
+      python examples/seismic/acoustic/constant_example.py --full;
+    fi
+
+  - if [[ $DEVITO_BACKEND != 'yask' ]]; then py.test -vs examples/seismic/tutorials; fi
+  - if [[ $DEVITO_BACKEND != 'yask' ]]; then py.test -vs examples/cfd; fi
 
   # Docs generation and deployment
   - sphinx-apidoc -f -o docs/ examples

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,9 +65,12 @@ install:
 
 before_script:
   - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
+  # pip install git+https://github.com/opesci/yask.git@v2_alpha-setup-py;
   - if [[ $DEVITO_BACKEND == 'yask' ]]; then
-      conda install swig;
-      pip install git+https://github.com/opesci/yask.git@v2_alpha-setup-py;
+      conda install swig; cd ../;
+      git clone https://github.com/opesci/yask.git;
+      cd yask; git checkout v2_alpha;
+      make compiler && make compiler-api; pip install -e .; cd ../devito;
     fi
 
 script:

--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -43,7 +43,8 @@ class Compiler(GCCToolchain):
         * :data:`self.undefines`
     """
 
-    cpp_mapper = {'gcc': 'g++', 'clang': 'clang++', 'icc': 'icpc'}
+    cpp_mapper = {'gcc': 'g++', 'clang': 'clang++', 'icc': 'icpc',
+                  'gcc-4.9': 'g++-4.9', 'gcc-5': 'g++-5', 'gcc-6': 'g++-6'}
 
     fields = ['cc', 'ld']
 

--- a/devito/yask/__init__.py
+++ b/devito/yask/__init__.py
@@ -35,7 +35,7 @@ try:
     # Set directories for generated code
     path = os.environ['YASK_HOME']
 except KeyError:
-    exit("Missing YASK_HOME")
+    path = os.path.dirname(os.path.dirname(yc.__file__))
 
 # YASK conventions
 namespace = OrderedDict()

--- a/devito/yask/__init__.py
+++ b/devito/yask/__init__.py
@@ -24,7 +24,7 @@ def exit(emsg):
 
 log("Backend initialization...")
 try:
-    import yask_compiler as yc
+    from yask import compiler as yc
     # YASK compiler factories
     cfac = yc.yc_factory()
     nfac = yc.yc_node_factory()

--- a/devito/yask/wrappers.py
+++ b/devito/yask/wrappers.py
@@ -283,7 +283,7 @@ class YaskKernel(object):
 
         # Import the corresponding Python (SWIG-generated) module
         try:
-            yk = importlib.import_module(name)
+            yk = getattr(__import__('yask', fromlist=[name]), name)
         except ImportError:
             exit("Python YASK kernel bindings")
         try:

--- a/devito/yask/wrappers.py
+++ b/devito/yask/wrappers.py
@@ -268,13 +268,16 @@ class YaskKernel(object):
 
         # JIT-compile it
         try:
+            compiler = yask_configuration['compiler']
             opt_level = 1 if yask_configuration['develop-mode'] else 3
-            make(os.environ['YASK_HOME'], ['-j', 'YK_CXXOPT=-O%d' % opt_level,
-                                           # "EXTRA_MACROS=TRACE",
-                                           'YK_BASE=%s' % str(name),
-                                           'stencil=%s' % yc_soln.get_name(),
-                                           'arch=%s' % yask_configuration['arch'],
-                                           '-C', namespace['kernel-path'], 'api'])
+            make(namespace['path'], ['-j3', 'YK_CXX=%s' % compiler.cc,
+                                     'YK_CXXOPT=-O%d' % opt_level,
+                                     'mpi=0',  # Disable MPI for now
+                                     # "EXTRA_MACROS=TRACE",
+                                     'YK_BASE=%s' % str(name),
+                                     'stencil=%s' % yc_soln.get_name(),
+                                     'arch=%s' % yask_configuration['arch'],
+                                     '-C', namespace['kernel-path'], 'api'])
         except CompilationError:
             exit("Kernel solution compilation")
 

--- a/examples/seismic/plotting.py
+++ b/examples/seismic/plotting.py
@@ -1,11 +1,15 @@
 import numpy as np
-import matplotlib as mpl
-import matplotlib.pyplot as plt
-from matplotlib import cm
-from mpl_toolkits.axes_grid1 import make_axes_locatable
+try:
+    import matplotlib as mpl
+    import matplotlib.pyplot as plt
+    from matplotlib import cm
+    from mpl_toolkits.axes_grid1 import make_axes_locatable
 
-mpl.rc('font', size=16)
-mpl.rc('figure', figsize=(8, 6))
+    mpl.rc('font', size=16)
+    mpl.rc('figure', figsize=(8, 6))
+except:
+    plt = None
+    cm = None
 
 
 def plot_perturbation(model, model1, colorbar=True):

--- a/examples/seismic/source.py
+++ b/examples/seismic/source.py
@@ -3,7 +3,10 @@ from devito.pointdata import PointData
 from devito.logger import error
 
 import numpy as np
-import matplotlib.pyplot as plt
+try:
+    import matplotlib.pyplot as plt
+except:
+    plt = None
 
 __all__ = ['PointSource', 'Receiver', 'Shot', 'RickerSource', 'GaborSource']
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,10 +5,15 @@ import pytest
 from sympy import cos  # noqa
 
 from devito import Eq  # noqa
-from devito import Dimension, t, x, y, z, ConstantData, DenseData, FixedDimension
+from devito import (Dimension, t, x, y, z, ConstantData, DenseData,
+                    FixedDimension, configuration)
 from devito.interfaces import ScalarFunction, TensorFunction
 from devito.nodes import Iteration
 from devito.tools import as_tuple
+
+
+skipif_yask = pytest.mark.skipif(configuration['backend'] == 'yask',
+                                 reason="YASK testing is currently restricted")
 
 
 def scalarfunction(name):

--- a/tests/test_adjointA.py
+++ b/tests/test_adjointA.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pytest
 from numpy import linalg
+from conftest import skipif_yask
 
 from devito.logger import info
 from examples.seismic import demo_model, RickerSource, Receiver
@@ -13,6 +14,7 @@ presets = {
 }
 
 
+@skipif_yask
 @pytest.mark.parametrize('mkey, shape, time_order, space_order, nbpml', [
     # 2D tests with varying time and space orders
     ('layers', (60, 70), 2, 4, 10), ('layers', (60, 70), 2, 8, 10),

--- a/tests/test_adjointJ.py
+++ b/tests/test_adjointJ.py
@@ -1,12 +1,14 @@
 import numpy as np
 import pytest
 from numpy import linalg
+from conftest import skipif_yask
 
 from devito.logger import info
 from examples.seismic import demo_model, RickerSource, Receiver
 from examples.seismic.acoustic import AcousticWaveSolver
 
 
+@skipif_yask
 @pytest.mark.parametrize('space_order', [4, 8, 12])
 @pytest.mark.parametrize('shape', [(60, 70), (40, 50, 30)])
 def test_acousticJ(shape, space_order):

--- a/tests/test_autotuner.py
+++ b/tests/test_autotuner.py
@@ -9,6 +9,7 @@ except ImportError:
     from io import StringIO
 
 import pytest
+from conftest import skipif_yask
 
 import numpy as np
 
@@ -17,6 +18,7 @@ from devito.logger import logger, logging, set_log_level
 from devito.core.autotuning import options
 
 
+@skipif_yask
 @pytest.mark.parametrize("shape,expected", [
     ((30, 30), 12),
     ((30, 30, 30), 16)
@@ -60,6 +62,7 @@ def test_at_is_actually_working(shape, expected):
     set_log_level('INFO')
 
 
+@skipif_yask
 def test_timesteps_per_at_run():
     """
     Check that each autotuning run (ie with a given block shape) takes

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from conftest import skipif_yask
 from sympy import Derivative, simplify
 
 from devito import Grid, DenseData, TimeData, t, x, y, z
@@ -15,6 +16,7 @@ def grid(shape):
     return Grid(shape=shape)
 
 
+@skipif_yask
 @pytest.mark.parametrize('SymbolType, dimension', [
     (DenseData, x), (DenseData, y),
     (TimeData, x), (TimeData, y), (TimeData, t),
@@ -39,6 +41,7 @@ def test_stencil_derivative(grid, shape, SymbolType, dimension):
     assert(np.allclose(u_dxx.data, 66.6))
 
 
+@skipif_yask
 @pytest.mark.parametrize('SymbolType, derivative, dim', [
     (DenseData, 'dx2', 3), (DenseData, 'dy2', 3),
     (TimeData, 'dx2', 3), (TimeData, 'dy2', 3), (TimeData, 'dt', 2)
@@ -50,6 +53,7 @@ def test_preformed_derivatives(grid, SymbolType, derivative, dim):
     assert(len(expr.args) == dim)
 
 
+@skipif_yask
 @pytest.mark.parametrize('derivative, dimension', [
     ('dx', x), ('dy', y), ('dz', z)
 ])
@@ -71,6 +75,7 @@ def test_derivatives_space(derivative, dimension, order):
     assert(expr == s_expr)  # Exact equailty
 
 
+@skipif_yask
 @pytest.mark.parametrize('derivative, dimension', [
     ('dx2', x), ('dy2', y), ('dz2', z)
 ])

--- a/tests/test_dimension.py
+++ b/tests/test_dimension.py
@@ -1,8 +1,10 @@
 import devito
 import pytest
+from conftest import skipif_yask
 from devito import Grid, FixedDimension, DenseData, y
 
 
+@skipif_yask
 @pytest.mark.xfail
 def test_incorrect_usage():
     grid = Grid(shape=(10, 10))
@@ -11,6 +13,7 @@ def test_incorrect_usage():
     assert(devito.x in m.indices)
 
 
+@skipif_yask
 def test_correct_usage():
     myx = FixedDimension(name='x', size=10, spacing=devito.x.spacing)
     grid = Grid(shape=(10, 10), dimensions=(myx, y))

--- a/tests/test_dle.py
+++ b/tests/test_dle.py
@@ -4,6 +4,7 @@ from functools import reduce
 from operator import mul
 import numpy as np
 import pytest
+from conftest import skipif_yask
 from sympy import solve
 
 from conftest import EVAL
@@ -158,6 +159,7 @@ def _new_operator3(shape, time_order, **kwargs):
     return u.data[1, :], op
 
 
+@skipif_yask
 def test_create_elemental_functions_simple(simple_function):
     roots = [i[-1] for i in retrieve_iteration_tree(simple_function)]
     retagged = [i._rebuild(properties=tagger(0)) for i in roots]
@@ -202,6 +204,7 @@ void f_0(const int k_start, const int k_finish,"""
 }""")
 
 
+@skipif_yask
 def test_create_elemental_functions_complex(complex_function):
     roots = [i[-1] for i in retrieve_iteration_tree(complex_function)]
     retagged = [j._rebuild(properties=tagger(i)) for i, j in enumerate(roots)]
@@ -268,6 +271,7 @@ void f_2(const int q_start, const int q_finish,"""
 }""")
 
 
+@skipif_yask
 @pytest.mark.parametrize("blockinner,expected", [
     (False, 4),
     (True, 8)
@@ -298,6 +302,7 @@ def test_cache_blocking_structure(blockinner, expected):
         assert 'omp for' in outermost.pragmas[0].value
 
 
+@skipif_yask
 @pytest.mark.parametrize("shape", [(10,), (10, 45), (10, 31, 45)])
 @pytest.mark.parametrize("blockshape", [2, 7, (3, 3), (2, 9, 1)])
 @pytest.mark.parametrize("blockinner", [False, True])
@@ -310,6 +315,7 @@ def test_cache_blocking_no_time_loop(shape, blockshape, blockinner):
     assert np.equal(wo_blocking.data, w_blocking.data).all()
 
 
+@skipif_yask
 @pytest.mark.parametrize("shape", [(20, 33), (45, 31, 45)])
 @pytest.mark.parametrize("time_order", [2])
 @pytest.mark.parametrize("blockshape", [2, (13, 20), (11, 15, 23)])
@@ -323,6 +329,7 @@ def test_cache_blocking_time_loop(shape, time_order, blockshape, blockinner):
     assert np.equal(wo_blocking.data, w_blocking.data).all()
 
 
+@skipif_yask
 @pytest.mark.parametrize("shape,blockshape", [
     ((25, 25, 46), (None, None, None)),
     ((25, 25, 46), (7, None, None)),
@@ -346,6 +353,7 @@ def test_cache_blocking_edge_cases(shape, blockshape):
     assert np.equal(wo_blocking.data, w_blocking.data).all()
 
 
+@skipif_yask
 @pytest.mark.parametrize("shape,blockshape", [
     ((3, 3), (3, 4)),
     ((4, 4), (3, 4)),
@@ -370,6 +378,7 @@ def test_cache_blocking_edge_cases_highorder(shape, blockshape):
     assert np.equal(wo_blocking.data, w_blocking.data).all()
 
 
+@skipif_yask
 @pytest.mark.parametrize('exprs,expected', [
     # trivial 1D
     (['Eq(fa[x], fa[x] + fb[x])'],
@@ -428,6 +437,7 @@ def test_loops_ompized(fa, fb, fc, fd, t0, t1, t2, t3, exprs, expected, iters):
                 assert 'omp for' not in k.value
 
 
+@skipif_yask
 def test_loop_nofission(simple_function):
     old = Rewriter.thresholds['min_fission'], Rewriter.thresholds['max_fission']
     Rewriter.thresholds['max_fission'], Rewriter.thresholds['min_fission'] = 0, 1
@@ -447,6 +457,7 @@ def test_loop_nofission(simple_function):
     Rewriter.thresholds['min_fission'], Rewriter.thresholds['max_fission'] = old
 
 
+@skipif_yask
 def test_loop_fission(simple_function_fissionable):
     old = Rewriter.thresholds['min_fission'], Rewriter.thresholds['max_fission']
     Rewriter.thresholds['max_fission'], Rewriter.thresholds['min_fission'] = 0, 1
@@ -469,6 +480,7 @@ def test_loop_fission(simple_function_fissionable):
     Rewriter.thresholds['min_fission'], Rewriter.thresholds['max_fission'] = old
 
 
+@skipif_yask
 def test_padding(simple_function_with_paddable_arrays):
     handle = transform(simple_function_with_paddable_arrays, mode='padding')
     assert str(handle.nodes[0].ccode) == """\
@@ -494,6 +506,7 @@ for (int i = 0; i < 3; i += 1)
 }"""
 
 
+@skipif_yask
 @pytest.mark.parametrize("shape", [(41,), (20, 33), (45, 31, 45)])
 def test_composite_transformation(shape):
     wo_blocking, _ = _new_operator1(shape, dle='noop')

--- a/tests/test_dse.py
+++ b/tests/test_dse.py
@@ -2,6 +2,7 @@ from conftest import EVAL
 
 import numpy as np
 import pytest
+from conftest import skipif_yask
 
 from devito.dse import (clusterize, rewrite, xreplace_constrained, iq_timeinvariant,
                         iq_timevarying, estimate_cost, temporaries_graph,
@@ -51,6 +52,7 @@ def run_acoustic_forward(dse=None):
     return u, rec
 
 
+@skipif_yask
 def test_acoustic_rewrite_basic():
     ret1 = run_acoustic_forward(dse=None)
     ret2 = run_acoustic_forward(dse='basic')
@@ -100,6 +102,7 @@ def tti_nodse():
     return v, rec
 
 
+@skipif_yask
 def test_tti_clusters_to_graph():
     solver = tti_operator()
 
@@ -122,6 +125,7 @@ def test_tti_clusters_to_graph():
     assert all(v.reads or v.readby for v in graph.values())
 
 
+@skipif_yask
 def test_tti_rewrite_basic(tti_nodse):
     operator = tti_operator(dse='basic')
     rec, u, v, _ = operator.forward()
@@ -130,6 +134,7 @@ def test_tti_rewrite_basic(tti_nodse):
     assert np.allclose(tti_nodse[1].data, rec.data, atol=10e-3)
 
 
+@skipif_yask
 def test_tti_rewrite_advanced(tti_nodse):
     operator = tti_operator(dse='advanced')
     rec, u, v, _ = operator.forward()
@@ -138,6 +143,7 @@ def test_tti_rewrite_advanced(tti_nodse):
     assert np.allclose(tti_nodse[1].data, rec.data, atol=10e-1)
 
 
+@skipif_yask
 def test_tti_rewrite_speculative(tti_nodse):
     operator = tti_operator(dse='speculative')
     rec, u, v, _ = operator.forward()
@@ -146,6 +152,7 @@ def test_tti_rewrite_speculative(tti_nodse):
     assert np.allclose(tti_nodse[1].data, rec.data, atol=10e-1)
 
 
+@skipif_yask
 def test_tti_rewrite_aggressive(tti_nodse):
     operator = tti_operator(dse='aggressive')
     rec, u, v, _ = operator.forward()
@@ -154,6 +161,7 @@ def test_tti_rewrite_aggressive(tti_nodse):
     assert np.allclose(tti_nodse[1].data, rec.data, atol=10e-1)
 
 
+@skipif_yask
 @pytest.mark.parametrize('kernel,space_order,expected', [
     ('shifted', 8, 364), ('shifted', 16, 830),
     ('centered', 8, 170), ('centered', 16, 306)
@@ -166,6 +174,7 @@ def test_tti_rewrite_aggressive_opcounts(kernel, space_order, expected):
 
 # DSE manipulation
 
+@skipif_yask
 @pytest.mark.parametrize('exprs,expected', [
     # simple
     (['Eq(ti1, 4.)', 'Eq(ti0, 3.)', 'Eq(tu, ti0 + ti1 + 5.)'],
@@ -190,6 +199,7 @@ def test_xreplace_constrained_time_invariants(tu, tv, tw, ti0, ti1, t0, t1,
     assert all(str(i.rhs) == j for i, j in zip(found, expected))
 
 
+@skipif_yask
 @pytest.mark.parametrize('exprs,expected', [
     # simple
     (['Eq(ti0, 3.)', 'Eq(tv, 2.4)', 'Eq(tu, tv + 5. + ti0)'],
@@ -215,6 +225,7 @@ def test_xreplace_constrained_time_varying(tu, tv, tw, ti0, ti1, t0, t1,
     assert all(str(i.rhs) == j for i, j in zip(found, expected))
 
 
+@skipif_yask
 @pytest.mark.parametrize('exprs,expected', [
     # simple
     (['Eq(tu, (tv + tw + 5.)*(ti0 + ti1) + (t0 + t1)*(ti0 + ti1))'],
@@ -235,6 +246,7 @@ def test_common_subexprs_elimination(tu, tv, tw, ti0, ti1, t0, t1, exprs, expect
     assert all(str(i.rhs) == j for i, j in zip(processed, expected))
 
 
+@skipif_yask
 @pytest.mark.parametrize('exprs,expected', [
     (['Eq(t0, 3.)', 'Eq(t1, 7.)', 'Eq(ti0, t0*3. + 2.)', 'Eq(ti1, t1 + t0 + 1.5)',
       'Eq(tv, (ti0 + ti1)*t0)', 'Eq(tw, (ti0 + ti1)*t1)',
@@ -249,6 +261,7 @@ def test_graph_trace(tu, tv, tw, ti0, ti1, t0, t1, exprs, expected):
         assert set([j.lhs for j in g.trace(i)]) == mapper[i]
 
 
+@skipif_yask
 @pytest.mark.parametrize('exprs,expected', [
     # trivial
     (['Eq(t0, 1.)', 'Eq(t1, fa[x] + fb[x])'],
@@ -273,6 +286,7 @@ def test_graph_isindex(fa, fb, fc, t0, t1, t2, exprs, expected):
         assert g.is_index(k) == v
 
 
+@skipif_yask
 @pytest.mark.parametrize('exprs,expected', [
     # none (different distance)
     (['Eq(t0, fa[x] + fb[x])', 'Eq(t1, fa[x+1] + fb[x])'],
@@ -307,6 +321,7 @@ def test_collect_aliases(fa, fb, fc, fd, t0, t1, t2, t3, exprs, expected):
         assert (len(v.aliased) == 1 and mapper[k] is None) or v.anti_stencil == mapper[k]
 
 
+@skipif_yask
 @pytest.mark.parametrize('expr,expected', [
     ('Eq(t0, t1)', 0),
     ('Eq(t0, fa[x] + fb[x])', 1),

--- a/tests/test_finite_difference.py
+++ b/tests/test_finite_difference.py
@@ -1,10 +1,12 @@
 import numpy as np
 import pytest
+from conftest import skipif_yask
 from sympy import diff
 
 from devito import Grid, Eq, Operator, clear_cache, DenseData, x
 
 
+@skipif_yask
 @pytest.mark.parametrize('space_order', [2, 4, 6, 8, 10, 12, 14, 16, 18, 20])
 # Only test x and t as y and z are the same as x
 @pytest.mark.parametrize('derivative', ['dx', 'dxl', 'dxr', 'dx2'])

--- a/tests/test_gradient.py
+++ b/tests/test_gradient.py
@@ -1,12 +1,14 @@
 import numpy as np
 import pytest
 from numpy import linalg
+from conftest import skipif_yask
 
 from devito.logger import info
 from examples.seismic.acoustic.acoustic_example import smooth10, acoustic_setup as setup
 from examples.seismic import Receiver
 
 
+@skipif_yask
 @pytest.mark.parametrize('space_order', [4])
 @pytest.mark.parametrize('time_order', [2])
 @pytest.mark.parametrize('shape', [(70, 80)])
@@ -74,6 +76,7 @@ def test_gradientFWI(shape, time_order, space_order):
     assert np.isclose(p2[0], 2.0, rtol=0.1)
 
 
+@skipif_yask
 @pytest.mark.parametrize('space_order', [4])
 @pytest.mark.parametrize('time_order', [2])
 @pytest.mark.parametrize('shape', [(70, 80)])

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -2,7 +2,7 @@ from __future__ import absolute_import
 
 from collections import OrderedDict
 
-from conftest import EVAL, dims, dims_open
+from conftest import EVAL, dims, dims_open, skipif_yask
 
 import numpy as np
 import pytest
@@ -29,6 +29,7 @@ def symbol(name, dimensions, value=0., shape=(3, 5), mode='function'):
     return s.indexify() if mode == 'indexed' else s
 
 
+@skipif_yask
 class TestAPI(object):
 
     @classmethod
@@ -52,6 +53,7 @@ class TestAPI(object):
         assert 'a_dense[i] = 2.0F*constant + a_dense[i]' in str(op.ccode)
 
 
+@skipif_yask
 class TestArithmetic(object):
 
     @classmethod
@@ -187,6 +189,7 @@ class TestArithmetic(object):
         assert(np.allclose(a.data, 12.))
 
 
+@skipif_yask
 class TestAllocation(object):
 
     @classmethod
@@ -206,6 +209,7 @@ class TestAllocation(object):
         assert(np.array_equal(m.data, m2.data))
 
 
+@skipif_yask
 class TestArguments(object):
 
     @classmethod
@@ -318,6 +322,7 @@ class TestArguments(object):
         assert(np.array_equal(args[arg_name], np.asarray((new_coords,))))
 
 
+@skipif_yask
 class TestDeclarator(object):
 
     @classmethod
@@ -437,6 +442,7 @@ class TestDeclarator(object):
   return 0;""" in str(operator.ccode)
 
 
+@skipif_yask
 class TestLoopScheduler(object):
 
     def test_consistency_coupled_wo_ofs(self, tu, tv, ti0, t0, t1):
@@ -602,6 +608,7 @@ class TestLoopScheduler(object):
                            b.data[..., 2].reshape(-1), 0.))
 
 
+@skipif_yask
 @pytest.mark.skipif(configuration['backend'] != 'foreign',
                     reason="'foreign' wasn't selected as backend on startup")
 class TestForeign(object):

--- a/tests/test_point_data.py
+++ b/tests/test_point_data.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from conftest import skipif_yask
 
 from devito.cgen_utils import FLOAT
 from devito import Grid, Operator, DenseData, PointData, x, y, z
@@ -34,6 +35,7 @@ def points(ranges, npoints, name='points'):
     return points
 
 
+@skipif_yask
 @pytest.mark.parametrize('shape, coords', [
     ((11, 11), [(.05, .9), (.01, .8)]),
     ((11, 11, 11), [(.05, .9), (.01, .8), (0.07, 0.84)])
@@ -54,6 +56,7 @@ def test_interpolate(shape, coords, npoints=20):
     assert np.allclose(p.data[0, :], xcoords, rtol=1e-6)
 
 
+@skipif_yask
 @pytest.mark.parametrize('shape, coords, result', [
     ((11, 11), [(.05, .95), (.45, .45)], 1.),
     ((11, 11, 11), [(.05, .95), (.45, .45), (.45, .45)], 0.5)
@@ -77,6 +80,7 @@ def test_inject(shape, coords, result, npoints=19):
     assert np.allclose(a.data[indices], result, rtol=1.e-5)
 
 
+@skipif_yask
 @pytest.mark.parametrize('shape, coords, result', [
     ((11, 11), [(.05, .95), (.45, .45)], 1.),
     ((11, 11, 11), [(.05, .95), (.45, .45), (.45, .45)], 0.5)
@@ -101,6 +105,7 @@ def test_inject_from_field(shape, coords, result, npoints=19):
     assert np.allclose(a.data[indices], result, rtol=1.e-5)
 
 
+@skipif_yask
 @pytest.mark.parametrize('shape, coords', [
     ((11, 11), [(.05, .9), (.01, .8)]),
     ((11, 11, 11), [(.05, .9), (.01, .8), (0.07, 0.84)])

--- a/tests/test_save.py
+++ b/tests/test_save.py
@@ -1,5 +1,6 @@
 import numpy as np
 from sympy import solve, symbols
+from conftest import skipif_yask
 
 from devito import Grid, Eq, Operator, TimeData, Forward, x, y, time
 
@@ -45,5 +46,6 @@ def run_simulation(save=False, dx=0.01, dy=0.01, a=0.5, timesteps=100):
         return u.data[(timesteps+1) % 2, :]
 
 
+@skipif_yask
 def test_save():
     assert(np.array_equal(run_simulation(True), run_simulation()))

--- a/tests/test_symbol_caching.py
+++ b/tests/test_symbol_caching.py
@@ -2,11 +2,13 @@ import weakref
 
 import numpy as np
 import pytest
+from conftest import skipif_yask
 
 from devito import Grid, DenseData, TimeData, clear_cache
 from devito.interfaces import _SymbolCache
 
 
+@skipif_yask
 @pytest.mark.xfail(reason="New function instances currently don't cache")
 @pytest.mark.parametrize('FunctionType', [DenseData, TimeData])
 def test_cache_function_new(FunctionType):
@@ -18,6 +20,7 @@ def test_cache_function_new(FunctionType):
     assert np.allclose(u.data, u0.data)
 
 
+@skipif_yask
 @pytest.mark.parametrize('FunctionType', [DenseData, TimeData])
 def test_cache_function_same_indices(FunctionType):
     """Test caching of derived u[x, y] instance from derivative"""
@@ -29,6 +32,7 @@ def test_cache_function_same_indices(FunctionType):
     assert np.allclose(u.data, u0.data)
 
 
+@skipif_yask
 @pytest.mark.parametrize('FunctionType', [DenseData, TimeData])
 def test_cache_function_different_indices(FunctionType):
     """Test caching of u[x + h, y] instance from derivative"""
@@ -40,6 +44,7 @@ def test_cache_function_different_indices(FunctionType):
     assert np.allclose(u.data, u0.data)
 
 
+@skipif_yask
 def test_symbol_cache_aliasing():
     """Test to assert that our aiasing cache isn't defeated by sympys
     non-aliasing symbol cache.
@@ -80,6 +85,7 @@ def test_symbol_cache_aliasing():
     assert u_ref() is None
 
 
+@skipif_yask
 def test_symbol_cache_aliasing_reverse():
     """Test to assert that removing he original u[x, y] instance does
     not impede our alisaing cache or leaks memory.
@@ -114,6 +120,7 @@ def test_symbol_cache_aliasing_reverse():
     assert u_ref() is None
 
 
+@skipif_yask
 def test_clear_cache(nx=1000, ny=1000):
     clear_cache()
     cache_size = len(_SymbolCache)
@@ -129,6 +136,7 @@ def test_clear_cache(nx=1000, ny=1000):
         clear_cache()
 
 
+@skipif_yask
 def test_cache_after_indexification():
     """Test to assert that the SymPy cache retrieves the right Devito data object
     after indexification.

--- a/tests/test_timestepping.py
+++ b/tests/test_timestepping.py
@@ -1,6 +1,7 @@
 import numpy as np
 
 import pytest
+from conftest import skipif_yask
 
 from devito import Grid, Eq, Operator, Forward, Backward, TimeData, t
 
@@ -38,6 +39,7 @@ def d(grid):
                     time_dim=6, save=True)
 
 
+@skipif_yask
 def test_forward(a):
     a.data[0, :] = 1.
     Operator(Eq(a.forward, a + 1.))()
@@ -45,6 +47,7 @@ def test_forward(a):
         assert np.allclose(a.data[i, :], 1. + i, rtol=1.e-12)
 
 
+@skipif_yask
 def test_backward(b):
     b.data[-1, :] = 7.
     Operator(Eq(b.backward, b - 1.), time_axis=Backward)()
@@ -52,6 +55,7 @@ def test_backward(b):
         assert np.allclose(b.data[i, :], 2. + i, rtol=1.e-12)
 
 
+@skipif_yask
 def test_forward_unroll(a, c, nt=5):
     """Test forward time marching with a buffered and an unrolled t"""
     a.data[0, :] = 1.
@@ -63,6 +67,7 @@ def test_forward_unroll(a, c, nt=5):
         assert np.allclose(a.data[i, :], 1. + i, rtol=1.e-12)
 
 
+@skipif_yask
 def test_forward_backward(a, b, nt=5):
     """Test a forward operator followed by a backward marching one"""
     a.data[0, :] = 1.
@@ -76,6 +81,7 @@ def test_forward_backward(a, b, nt=5):
         assert np.allclose(b.data[i, :], 2. + i, rtol=1.e-12)
 
 
+@skipif_yask
 def test_forward_backward_overlapping(a, b, nt=5):
     """
     Test a forward operator followed by a backward one, but with
@@ -92,6 +98,7 @@ def test_forward_backward_overlapping(a, b, nt=5):
         assert np.allclose(b.data[i, :], 2. + i, rtol=1.e-12)
 
 
+@skipif_yask
 def test_loop_bounds_forward(d):
     """Test the automatic bound detection for forward time loops"""
     d.data[:] = 1.
@@ -103,6 +110,7 @@ def test_loop_bounds_forward(d):
         assert np.allclose(d.data[i, :], 1. + i, rtol=1.e-12)
 
 
+@skipif_yask
 def test_loop_bounds_backward(d):
     """Test the automatic bound detection for backward time loops"""
     d.data[:] = 1.

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,10 +1,12 @@
 import pytest
+from conftest import skipif_yask
 
 from sympy.abc import a, b, c, d, e
 
 from devito.tools import partial_order
 
 
+@skipif_yask
 @pytest.mark.parametrize('elements, expected', [
     ([[a, b, c], [c, d, e]], [a, b, c, d, e]),
     ([[e, d, c], [c, b, a]], [e, d, c, b, a]),

--- a/tests/test_tti.py
+++ b/tests/test_tti.py
@@ -1,5 +1,6 @@
 import numpy as np
 import pytest
+from conftest import skipif_yask
 from numpy import linalg
 
 from devito import TimeData
@@ -9,6 +10,7 @@ from examples.seismic.acoustic import AcousticWaveSolver
 from examples.seismic.tti import AnisotropicWaveSolver
 
 
+@skipif_yask
 @pytest.mark.parametrize('shape', [(120, 140), (120, 140, 150)])
 @pytest.mark.parametrize('space_order', [4, 8])
 def test_tti(shape, space_order):

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -1,5 +1,6 @@
 import cgen as c
 import pytest
+from conftest import skipif_yask
 
 from devito import Eq
 from devito.nodes import Block, Expression, Function
@@ -54,6 +55,7 @@ def block3(exprs, iters):
                      iters[4](exprs[3])])
 
 
+@skipif_yask
 def test_printAST(block1, block2, block3):
     str1 = printAST(block1)
     assert str1 in """
@@ -86,6 +88,7 @@ def test_printAST(block1, block2, block3):
 """
 
 
+@skipif_yask
 def test_create_cgen_tree(block1, block2, block3):
     assert str(Function('foo', block1, 'void', ()).ccode) == """\
 void foo()
@@ -141,6 +144,7 @@ void foo()
 }"""
 
 
+@skipif_yask
 def test_find_sections(exprs, block1, block2, block3):
     finder = FindSections()
 
@@ -167,6 +171,7 @@ def test_find_sections(exprs, block1, block2, block3):
     assert found[2][0].stencil == exprs[3].stencil
 
 
+@skipif_yask
 def test_is_perfect_iteration(block1, block2, block3):
     checker = IsPerfectIteration()
 
@@ -184,6 +189,7 @@ def test_is_perfect_iteration(block1, block2, block3):
     assert checker.visit(block3.nodes[2]) is True
 
 
+@skipif_yask
 def test_transformer_wrap(exprs, block1, block2, block3):
     """Basic transformer test that wraps an expression in comments"""
     line1 = '// This is the opening comment'
@@ -202,6 +208,7 @@ def test_transformer_wrap(exprs, block1, block2, block3):
         assert "a[i] = a[i] + b[i] + 5.0F;" in newcode
 
 
+@skipif_yask
 def test_transformer_replace(exprs, block1, block2, block3):
     """Basic transformer test that replaces an expression"""
     line1 = '// Replaced expression'
@@ -218,6 +225,7 @@ def test_transformer_replace(exprs, block1, block2, block3):
         assert "a[i0] = a[i0] + b[i0] + 5.0F;" not in newcode
 
 
+@skipif_yask
 def test_transformer_replace_function_body(block1, block2):
     """Create a Function and replace its body with another."""
     args = FindSymbols().visit(block1)
@@ -253,6 +261,7 @@ def test_transformer_replace_function_body(block1, block2):
 }"""
 
 
+@skipif_yask
 def test_transformer_add_replace(exprs, block2, block3):
     """Basic transformer test that adds one expression and replaces another"""
     line1 = '// Replaced expression'
@@ -273,6 +282,7 @@ def test_transformer_add_replace(exprs, block2, block3):
         assert "a[i0] = a[i0] + b[i0] + 5.0F;" not in newcode
 
 
+@skipif_yask
 def test_nested_transformer(exprs, iters, block2):
     """Unlike Transformer, based on BFS, a NestedTransformer applies transformations
     performing a DFS. This test simultaneously replace an inner expression and an
@@ -289,6 +299,7 @@ def test_nested_transformer(exprs, iters, block2):
       <Expression a[i] = 8.0*a[i] + 6.0/b[i]>"""
 
 
+@skipif_yask
 def test_merge_iterations_flat(exprs, iters):
     """Test outer loop merging on a simple two-level hierarchy:
 
@@ -310,6 +321,7 @@ def test_merge_iterations_flat(exprs, iters):
     <Expression a[i] = -a[i] + b[i]>"""
 
 
+@skipif_yask
 def test_merge_iterations_deep(exprs, iters):
     """Test outer loop merging on a deep hierarchy:
 
@@ -334,6 +346,7 @@ def test_merge_iterations_deep(exprs, iters):
     <Expression a[i] = -a[i] + b[i]>"""
 
 
+@skipif_yask
 def test_merge_iterations_nested(exprs, iters):
     """Test outer loop merging on a nested hierarchy that only exposes
     the second-level merge after the first level has been performed:

--- a/tests/test_yask.py
+++ b/tests/test_yask.py
@@ -2,7 +2,7 @@ import numpy as np
 
 import pytest  # noqa
 
-pexpect = pytest.importorskip('yask_compiler')  # Run only if YASK is available
+pexpect = pytest.importorskip('yask')  # Run only if YASK is available
 
 from devito import (Eq, Operator, DenseData, TimeData, PointData,
                     time, t, x, y, z, configuration, clear_cache)  # noqa


### PR DESCRIPTION
Depends on #364. 

This merge adds a dedicated YASK builder to our travis setup that pulls the current YASK development branch and executes a dedicated small test suite with it while skipping all other tests. This will allow us to gradually enable more of our regular test base on the YASK-backend as it develops.

One thing I note is that despite `-j3` the YASK compile times are quite severe, making the test suite quite slow;  but that might need to be addressed upstream.