### PR TITLE
Switching to and fixing Python3.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,21 +14,21 @@ env:
 matrix:
   include:
     - os: linux
-      python: "2.7"
+      python: "3.6"
       env: DEVITO_ARCH=gcc-4.9 DEVITO_OPENMP=0
     - os: linux
-      python: "2.7"
+      python: "3.6"
       env: DEVITO_ARCH=gcc-5 DEVITO_OPENMP=0
     - os: linux
-      python: "3.5"
-      env: DEVITO_ARCH=gcc-4.9 DEVITO_OPENMP=0
-    - os: linux
-      python: "2.7"
+      python: "3.6"
       env: DEVITO_ARCH=gcc-4.9 DEVITO_OPENMP=1 OMP_NUM_THREADS=2
     - os: linux
-      python: "3.5"
+      python: "3.6"
       env: DEVITO_ARCH=gcc-4.9 DEVITO_OPENMP=0 DEVITO_BACKEND=yask
   allow_failures:
+    - os: linux
+      python: "2.7"
+      env: DEVITO_ARCH=gcc-4.9 DEVITO_OPENMP=0
     - os: osx
       python: "2.7"
       env: DEVITO_ARCH=clang DEVITO_OPENMP=0

--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -255,7 +255,7 @@ def make(loc, args):
     """
     Invoke ``make`` command from within ``loc`` with arguments ``args``.
     """
-    hash_key = sha1(loc + str(args).encode()).hexdigest()
+    hash_key = sha1((loc + str(args)).encode()).hexdigest()
     logfile = path.join(get_tmp_dir(), "%s.log" % hash_key)
     errfile = path.join(get_tmp_dir(), "%s.err" % hash_key)
 

--- a/devito/interfaces.py
+++ b/devito/interfaces.py
@@ -497,7 +497,7 @@ class DenseData(TensorData):
 
                 # Second derivative
                 dx2 = partial(generic_derivative, deriv_order=2, dim=dim,
-                              fd_order=self.space_order / 2)
+                              fd_order=int(self.space_order / 2))
                 setattr(self.__class__, 'd%s2' % dim.name,
                         property(dx2, 'Return the symbolic expression for '
                                  'the second derivative wrt. the '

--- a/devito/nodes.py
+++ b/devito/nodes.py
@@ -12,7 +12,7 @@ from devito.cgen_utils import ccode
 from devito.dse import as_symbol, retrieve_terminals
 from devito.interfaces import Indexed, Symbol
 from devito.stencil import Stencil
-from devito.tools import as_tuple, filter_ordered, flatten
+from devito.tools import as_tuple, filter_ordered, flatten, is_integer
 from devito.arguments import ArgumentProvider, Argument
 
 __all__ = ['Node', 'Block', 'Denormals', 'Expression', 'Function', 'FunCall',
@@ -398,12 +398,12 @@ class Iteration(Node):
         try:
             lower = int(self.limits[0]) - self.offsets[0]
         except (TypeError, ValueError):
-            if isinstance(start, int):
+            if is_integer(start):
                 lower = start - self.offsets[0]
         try:
             upper = int(self.limits[1]) - self.offsets[1]
         except (TypeError, ValueError):
-            if isinstance(finish, int):
+            if is_integer(finish):
                 upper = finish - self.offsets[1]
         return (lower, upper)
 

--- a/devito/tools.py
+++ b/devito/tools.py
@@ -38,6 +38,13 @@ def as_tuple(item, type=None, length=None):
     return t
 
 
+def is_integer(value):
+    """
+    A thorough instance comparison for all integer types.
+    """
+    return isinstance(value, int) or isinstance(value, np.integer)
+
+
 def grouper(iterable, n):
     """Split an interable into groups of size n, plus a reminder"""
     args = [iter(iterable)] * n

--- a/devito/yask/__init__.py
+++ b/devito/yask/__init__.py
@@ -24,7 +24,7 @@ def exit(emsg):
 
 log("Backend initialization...")
 try:
-    from yask import compiler as yc
+    import yask as yc
     # YASK compiler factories
     cfac = yc.yc_factory()
     nfac = yc.yc_node_factory()

--- a/devito/yask/utils.py
+++ b/devito/yask/utils.py
@@ -138,7 +138,7 @@ def convert_multislice(multislice, shape, offsets, mode='get'):
     assert len(shape) == len(cstart) == len(cstop) == len(offsets)
 
     # Shift by the specified offsets
-    cstart = [j + i for i, j in zip(offsets, cstart)]
-    cstop = [j + i for i, j in zip(offsets, cstop)]
+    cstart = [int(j + i) for i, j in zip(offsets, cstart)]
+    cstop = [int(j + i) for i, j in zip(offsets, cstop)]
 
     return cstart, cstop, cshape

--- a/devito/yask/wrappers.py
+++ b/devito/yask/wrappers.py
@@ -470,7 +470,7 @@ class ContextManager(OrderedDict):
                               if i != namespace['time-dim']])
 
         # A unique key for this context.
-        key = tuple([yask_configuration['isa'], dtype] + domain.items())
+        key = tuple([yask_configuration['isa'], dtype] + list(domain.items()))
 
         # Fetch or create a YaskContext
         if key in self:

--- a/devito/yask/wrappers.py
+++ b/devito/yask/wrappers.py
@@ -309,7 +309,7 @@ class YaskKernel(object):
 
         # Set up the solution domain size
         for k, v in domain.items():
-            self.soln.set_rank_domain_size(k, v)
+            self.soln.set_rank_domain_size(k, int(v))
 
     def new_grid(self, obj_name, grid_name, dimensions):
         """Create a new YASK grid."""

--- a/environment.yml
+++ b/environment.yml
@@ -3,6 +3,7 @@ channels:
   - defaults
   - conda-forge
 dependencies:
+  - python >=3.6
   - numpy >=1.11
   - sympy >=1.1
   - scipy


### PR DESCRIPTION
As it turns out our `python3` travis builder has been silently reverting to `python2.7` for some time, meaning a few small bugs have crept in. Since the old trick of separating the two environments doesn't seem to work any more, this PR will switch to Python-3.6 for testing exclusively. The Python version is now also hard-defined in the `environment.yml`. 