### PR TITLE
Turn `Constant` into a `Symbol`, not `Function`

### DIFF
--- a/devito/arguments.py
+++ b/devito/arguments.py
@@ -1,7 +1,6 @@
 import abc
 
 import numpy as np
-from sympy import Symbol
 from cached_property import cached_property
 
 from devito.exceptions import InvalidArgument
@@ -48,10 +47,6 @@ class Argument(object):
                 raise InvalidArgument("Unexpected data object %s" % type(self._value))
         except AttributeError:
             return self._value
-
-    @property
-    def as_symbol(self):
-        return Symbol(self.name)
 
     @property
     def ready(self):

--- a/devito/arguments.py
+++ b/devito/arguments.py
@@ -42,6 +42,8 @@ class Argument(object):
         try:
             if self._value.is_SymbolicFunction:
                 return self._value._data_buffer
+            elif self._value.is_Constant:
+                return self._value.data
             else:
                 raise InvalidArgument("Unexpected data object %s" % type(self._value))
         except AttributeError:

--- a/devito/dimension.py
+++ b/devito/dimension.py
@@ -1,10 +1,13 @@
-from sympy import Symbol
+import sympy
+from cached_property import cached_property
+
 from devito.arguments import DimensionArgProvider
+from devito.types import Symbol
 
 __all__ = ['Dimension', 'x', 'y', 'z', 't', 'p', 'd', 'time']
 
 
-class Dimension(Symbol, DimensionArgProvider):
+class Dimension(sympy.Symbol, DimensionArgProvider):
 
     is_Buffered = False
     is_Lowered = False
@@ -20,18 +23,18 @@ class Dimension(Symbol, DimensionArgProvider):
     """
 
     def __new__(cls, name, **kwargs):
-        newobj = Symbol.__new__(cls, name)
+        newobj = sympy.Symbol.__new__(cls, name)
         newobj.reverse = kwargs.get('reverse', False)
-        newobj.spacing = kwargs.get('spacing', Symbol('h_%s' % name))
+        newobj.spacing = kwargs.get('spacing', sympy.Symbol('h_%s' % name))
         return newobj
 
     def __str__(self):
         return self.name
 
-    @property
+    @cached_property
     def symbolic_size(self):
         """The symbolic size of this dimension."""
-        return self.rtargs[0].as_symbol
+        return Symbol(name=self.rtargs[0].name)
 
     @property
     def size(self):
@@ -65,7 +68,7 @@ class BufferedDimension(Dimension):
     """
 
     def __new__(cls, name, parent, **kwargs):
-        newobj = Symbol.__new__(cls, name)
+        newobj = sympy.Symbol.__new__(cls, name)
         assert isinstance(parent, Dimension)
         newobj.parent = parent
         newobj.modulo = kwargs.get('modulo', 2)
@@ -93,7 +96,7 @@ class LoweredDimension(Dimension):
     """
 
     def __new__(cls, name, buffered, offset, **kwargs):
-        newobj = Symbol.__new__(cls, name)
+        newobj = sympy.Symbol.__new__(cls, name)
         assert isinstance(buffered, BufferedDimension)
         newobj.buffered = buffered
         newobj.offset = offset
@@ -113,13 +116,13 @@ class LoweredDimension(Dimension):
 
 
 # Default dimensions for time
-time = Dimension('time', spacing=Symbol('s'))
+time = Dimension('time', spacing=sympy.Symbol('s'))
 t = BufferedDimension('t', parent=time)
 
 # Default dimensions for space
-x = SpaceDimension('x', spacing=Symbol('h_x'))
-y = SpaceDimension('y', spacing=Symbol('h_y'))
-z = SpaceDimension('z', spacing=Symbol('h_z'))
+x = SpaceDimension('x', spacing=sympy.Symbol('h_x'))
+y = SpaceDimension('y', spacing=sympy.Symbol('h_y'))
+z = SpaceDimension('z', spacing=sympy.Symbol('h_z'))
 
 d = Dimension('d')
 p = Dimension('p')

--- a/devito/dle/backends/basic.py
+++ b/devito/dle/backends/basic.py
@@ -105,7 +105,7 @@ class BasicRewriter(AbstractRewriter):
                         maybe_required.update(j.free_symbols)
                 required = filter_sorted(maybe_required - not_required,
                                          key=attrgetter('name'))
-                args.extend([(i.name, Scalar(name=i.name, dtype=np.int32))
+                args.extend([(i.name, Scalar(name=i.name, dtype=i.dtype))
                              for i in required])
 
                 call, params = zip(*args)

--- a/devito/function.py
+++ b/devito/function.py
@@ -10,7 +10,7 @@ from devito.memory import CMemory, first_touch
 from devito.cgen_utils import INT, FLOAT
 from devito.dimension import d, p, t, time, x, y, z
 from devito.arguments import ConstantArgProvider, TensorFunctionArgProvider
-from devito.types import SymbolicFunction, AbstractSymbol
+from devito.types import SymbolicFunction
 from devito.finite_difference import (centered, cross_derivative,
                                       first_derivative, left, right,
                                       second_derivative, generic_derivative,
@@ -44,26 +44,21 @@ Forward = TimeAxis('Forward')
 Backward = TimeAxis('Backward')
 
 
-class Constant(SymbolicFunction, ConstantArgProvider):
+class Constant(sympy.Symbol, ConstantArgProvider):
 
     """
-    Data object for constant values.
+    Symbol representing constant values in symbolic equations.
     """
 
     is_Constant = True
     is_Scalar = True
 
-    def __new__(cls, *args, **kwargs):
-        kwargs.update({'options': {'evaluate': False}})
-        return AbstractSymbol.__new__(cls, *args, **kwargs)
+    is_SymbolicFunction = False
 
     def __init__(self, *args, **kwargs):
-        if not self._cached():
-            self.name = kwargs.get('name')
-            self.shape = ()
-            self.indices = ()
-            self.dtype = kwargs.get('dtype', np.float32)
-            self._value = kwargs.get('value', 0.)
+        self.name = kwargs.get('name')
+        self.dtype = kwargs.get('dtype', np.float32)
+        self._value = kwargs.get('value', 0.)
 
     @property
     def data(self):
@@ -73,6 +68,17 @@ class Constant(SymbolicFunction, ConstantArgProvider):
     @data.setter
     def data(self, val):
         self._value = val
+
+    def indexify(self):
+        return self
+
+    @property
+    def base(self):
+        return self
+
+    @property
+    def function(self):
+        return self
 
 
 class TensorFunction(SymbolicFunction, TensorFunctionArgProvider):

--- a/devito/function.py
+++ b/devito/function.py
@@ -52,8 +52,6 @@ class Constant(AbstractSymbol, ConstantArgProvider):
     is_Constant = True
     is_Scalar = True
 
-    is_SymbolicFunction = False
-
     def __init__(self, *args, **kwargs):
         self.name = kwargs.get('name')
         self.dtype = kwargs.get('dtype', np.float32)

--- a/devito/function.py
+++ b/devito/function.py
@@ -1,6 +1,5 @@
 import numpy as np
 import sympy
-from sympy.abc import s
 from collections import OrderedDict
 from functools import partial
 
@@ -399,7 +398,7 @@ class TimeFunction(Function):
         i = int(self.time_order / 2) if self.time_order >= 2 else 1
         _t = self.indices[0]
 
-        return self.subs(_t, _t + i * s)
+        return self.subs(_t, _t + i * _t.spacing)
 
     @property
     def backward(self):
@@ -407,7 +406,7 @@ class TimeFunction(Function):
         i = int(self.time_order / 2) if self.time_order >= 2 else 1
         _t = self.indices[0]
 
-        return self.subs(_t, _t - i * s)
+        return self.subs(_t, _t - i * _t.spacing)
 
     @property
     def dt(self):
@@ -415,10 +414,10 @@ class TimeFunction(Function):
         _t = self.indices[0]
         if self.time_order == 1:
             # This hack is needed for the first-order diffusion test
-            indices = [_t, _t + s]
+            indices = [_t, _t + _t.spacing]
         else:
             width = int(self.time_order / 2)
-            indices = [(_t + i * s) for i in range(-width, width + 1)]
+            indices = [(_t + i * _t.spacing) for i in range(-width, width + 1)]
 
         return self.diff(_t).as_finite_difference(indices)
 
@@ -427,7 +426,7 @@ class TimeFunction(Function):
         """Symbol for the second derivative wrt the t dimension"""
         _t = self.indices[0]
         width_t = int(self.time_order / 2)
-        indt = [(_t + i * s) for i in range(-width_t, width_t + 1)]
+        indt = [(_t + i * _t.spacing) for i in range(-width_t, width_t + 1)]
 
         return self.diff(_t, _t).as_finite_difference(indt)
 

--- a/devito/function.py
+++ b/devito/function.py
@@ -10,7 +10,7 @@ from devito.memory import CMemory, first_touch
 from devito.cgen_utils import INT, FLOAT
 from devito.dimension import d, p, t, time, x, y, z
 from devito.arguments import ConstantArgProvider, TensorFunctionArgProvider
-from devito.types import SymbolicFunction
+from devito.types import SymbolicFunction, AbstractSymbol
 from devito.finite_difference import (centered, cross_derivative,
                                       first_derivative, left, right,
                                       second_derivative, generic_derivative,
@@ -44,7 +44,7 @@ Forward = TimeAxis('Forward')
 Backward = TimeAxis('Backward')
 
 
-class Constant(sympy.Symbol, ConstantArgProvider):
+class Constant(AbstractSymbol, ConstantArgProvider):
 
     """
     Symbol representing constant values in symbolic equations.

--- a/devito/types.py
+++ b/devito/types.py
@@ -282,10 +282,7 @@ class AbstractFunction(sympy.Function, CachedSymbol):
 
         subs = dict([(i.spacing, 1) for i in self.indices])
         indices = [a.subs(subs) for a in self.args]
-        if indices:
-            return Indexed(self.indexed, *indices)
-        else:
-            return Symbol(name=self.indexed.function.name)
+        return Indexed(self.indexed, *indices)
 
 
 class SymbolicData(AbstractFunction):
@@ -307,7 +304,7 @@ class SymbolicData(AbstractFunction):
         return
 
 
-class Scalar(SymbolicData, ScalarArgProvider):
+class Scalar(Symbol, ScalarArgProvider):
     """Symbolic object representing a scalar.
 
     :param name: Name of the symbol
@@ -318,10 +315,11 @@ class Scalar(SymbolicData, ScalarArgProvider):
 
     def __init__(self, *args, **kwargs):
         if not self._cached():
-            self.name = kwargs.get('name')
-            self.shape = ()
-            self.indices = ()
             self.dtype = kwargs.get('dtype', np.float32)
+
+    @property
+    def shape(self):
+        return ()
 
     @property
     def _mem_stack(self):

--- a/devito/types.py
+++ b/devito/types.py
@@ -42,9 +42,11 @@ class Basic(object):
 
     # Top hierarchy
     is_AbstractFunction = False
+    is_AbstractSymbol = False
     is_Object = False
 
     # Symbolic objects created internally by Devito
+    is_Symbol = False
     is_SymbolicData = False
     is_Scalar = False
     is_Array = False
@@ -101,6 +103,8 @@ class AbstractSymbol(sympy.Symbol, CachedSymbol):
     :class:`Function` objects and do not have any indexing dimensions.
     """
 
+    is_AbstractSymbol = True
+
     def __new__(cls, *args, **kwargs):
         options = kwargs.get('options', {})
         if cls in _SymbolCache:
@@ -123,6 +127,8 @@ class Symbol(AbstractSymbol):
 
     """A :class:`sympy.Symbol` capable of mimicking an :class:`sympy.Indexed`"""
 
+    is_Symbol = True
+
     def __init__(self, *args, **kwargs):
         if not self._cached():
             self.dtype = kwargs.get('dtype', np.int32)
@@ -137,6 +143,10 @@ class Symbol(AbstractSymbol):
 
     @property
     def indices(self):
+        return ()
+
+    @property
+    def shape(self):
         return ()
 
     @property
@@ -316,10 +326,6 @@ class Scalar(Symbol, ScalarArgProvider):
     def __init__(self, *args, **kwargs):
         if not self._cached():
             self.dtype = kwargs.get('dtype', np.float32)
-
-    @property
-    def shape(self):
-        return ()
 
     @property
     def _mem_stack(self):

--- a/devito/types.py
+++ b/devito/types.py
@@ -119,6 +119,34 @@ class AbstractSymbol(sympy.Symbol, CachedSymbol):
         return newobj
 
 
+class Symbol(AbstractSymbol):
+
+    """A :class:`sympy.Symbol` capable of mimicking an :class:`sympy.Indexed`"""
+
+    def __init__(self, *args, **kwargs):
+        if not self._cached():
+            self.dtype = kwargs.get('dtype', np.int32)
+
+    @property
+    def base(self):
+        return self
+
+    @property
+    def function(self):
+        return self
+
+    @property
+    def indices(self):
+        return ()
+
+    @property
+    def symbolic_shape(self):
+        return ()
+
+    def indexify(self):
+        return self
+
+
 class AbstractFunction(sympy.Function, CachedSymbol):
     """Base class for data classes that provides symbolic behaviour.
 
@@ -257,7 +285,7 @@ class AbstractFunction(sympy.Function, CachedSymbol):
         if indices:
             return Indexed(self.indexed, *indices)
         else:
-            return Symbol(self.indexed)
+            return Symbol(name=self.indexed.function.name)
 
 
 class SymbolicData(AbstractFunction):
@@ -429,21 +457,6 @@ class IndexedData(sympy.IndexedBase):
         """
         indexed = super(IndexedData, self).__getitem__(indices, **kwargs)
         return Indexed(*indexed.args)
-
-
-class Symbol(sympy.Symbol):
-
-    """A :class:`sympy.Symbol` capable of mimicking an :class:`sympy.Indexed`"""
-
-    def __new__(cls, base):
-        obj = sympy.Symbol.__new__(cls, base.label.name)
-        obj.base = base
-        obj.indices = ()
-        obj.function = base.function
-        return obj
-
-    def func(self, *args):
-        return super(Symbol, self).func(self.base.func(*self.base.args))
 
 
 class Indexed(sympy.Indexed):

--- a/devito/types.py
+++ b/devito/types.py
@@ -33,15 +33,15 @@ class Basic(object):
                     |                                |
               CachedSymbol                         Object
                     |                       <see Object.__doc__>
-             AbstractSymbol
-    <see diagram in AbstractSymbol.__doc__>
+             AbstractFunction
+    <see diagram in AbstractFunction.__doc__>
 
     All derived :class:`Basic` objects may be emitted through code generation
     to create a just-in-time compilable kernel.
     """
 
     # Top hierarchy
-    is_AbstractSymbol = False
+    is_AbstractFunction = False
     is_Object = False
 
     # Symbolic objects created internally by Devito
@@ -94,7 +94,32 @@ class CachedSymbol(Basic):
         self.__dict__ = original().__dict__
 
 
-class AbstractSymbol(sympy.Function, CachedSymbol):
+class AbstractSymbol(sympy.Symbol, CachedSymbol):
+    """
+    Base class for dimension-free symbols that are cached by Devito,
+    in addition to SymPy caching. Note that these objects are not
+    :class:`Function` objects and do not have any indexing dimensions.
+    """
+
+    def __new__(cls, *args, **kwargs):
+        options = kwargs.get('options', {})
+        if cls in _SymbolCache:
+            newobj = sympy.Function.__new__(cls, *args, **options)
+            newobj._cached_init()
+        else:
+            name = kwargs.get('name')
+
+            # Create the new Function object and invoke __init__
+            newcls = cls._symbol_type(name)
+            newobj = sympy.Symbol.__new__(newcls, name, *args, **options)
+            newobj.__init__(*args, **kwargs)
+
+            # Store new instance in symbol cache
+            newcls._cache_put(newobj)
+        return newobj
+
+
+class AbstractFunction(sympy.Function, CachedSymbol):
     """Base class for data classes that provides symbolic behaviour.
 
     :param name: Symbolic name to give to the resulting function. Must
@@ -122,7 +147,7 @@ class AbstractSymbol(sympy.Function, CachedSymbol):
     This class is the root of the Devito data objects hierarchy, which
     is structured as follows.
 
-                             AbstractSymbol
+                             AbstractFunction
                                    |
                  -------------------------------------
                  |                                   |
@@ -143,7 +168,7 @@ class AbstractSymbol(sympy.Function, CachedSymbol):
     computation, while the latter is created and managed internally by Devito.
     """
 
-    is_AbstractSymbol = True
+    is_AbstractFunction = True
 
     def __new__(cls, *args, **kwargs):
         if cls in _SymbolCache:
@@ -161,7 +186,7 @@ class AbstractSymbol(sympy.Function, CachedSymbol):
             newobj = sympy.Function.__new__(newcls, *args, **options)
             newobj.__init__(*args, **kwargs)
 
-            # All objects cached on the AbstractSymbol /newobj/ keep a reference
+            # All objects cached on the AbstractFunction /newobj/ keep a reference
             # to /newobj/ through the /function/ field. Thus, all indexified
             # object will point to /newobj/, the "actual Function".
             newobj.function = newobj
@@ -235,7 +260,7 @@ class AbstractSymbol(sympy.Function, CachedSymbol):
             return Symbol(self.indexed)
 
 
-class SymbolicData(AbstractSymbol):
+class SymbolicData(AbstractFunction):
 
     """
     A symbolic function object, created and managed directly by Devito.
@@ -248,7 +273,7 @@ class SymbolicData(AbstractSymbol):
 
     def __new__(cls, *args, **kwargs):
         kwargs.update({'options': {'evaluate': False}})
-        return AbstractSymbol.__new__(cls, *args, **kwargs)
+        return AbstractFunction.__new__(cls, *args, **kwargs)
 
     def update(self):
         return
@@ -337,7 +362,7 @@ class Array(SymbolicData, ArrayArgProvider):
         assert single_or([self._external, self._onstack, self._onheap])
 
 
-class SymbolicFunction(AbstractSymbol):
+class SymbolicFunction(AbstractFunction):
     """A symbolic object associated with data.
 
     Unlike :class:`SymbolicData` objects, the structure of a SymbolicFunction

--- a/devito/visitors.py
+++ b/devito/visitors.py
@@ -11,12 +11,12 @@ from collections import Iterable, OrderedDict, defaultdict
 from operator import attrgetter
 
 import cgen as c
-from sympy import Symbol
 
 from devito.cgen_utils import blankline, ccode
 from devito.dimension import LoweredDimension
 from devito.exceptions import VisitorException
 from devito.nodes import Iteration, Node, UnboundedIndex
+from devito.types import Symbol
 from devito.tools import as_tuple, filter_ordered, filter_sorted, flatten, ctypes_to_C
 
 
@@ -702,12 +702,12 @@ class ResolveIterationVariable(Transformer):
             # definition of buffered variables, eg. t+1 => t1
             init = []
             for i, off in enumerate(filter_ordered(offsets[o.dim])):
-                vname = Symbol("%s%d" % (o.dim.name, i))
+                vname = Symbol(name="%s%d" % (o.dim.name, i))
                 value = (o.dim.parent + off) % o.dim.modulo
                 init.append(UnboundedIndex(vname, value, value))
                 subs[o.dim + off] = LoweredDimension(vname.name, o.dim, off)
             # Always lower to symbol
-            subs[o.dim.parent] = Symbol(o.dim.parent.name)
+            subs[o.dim.parent] = Symbol(name=o.dim.parent.name)
             return o._rebuild(index=o.dim.parent.name, uindices=init)
         else:
             return o._rebuild(*nodes)


### PR DESCRIPTION
First part of an internal data type shake up that should make `Constant` objects more compatible with the various backends. The primary idea is to
* Split our internal caching data types into `Function`s, symbols representing tensor/array data that carry indices, and `Symbol`s, dimension-free, scalar symbols.
* By providing `AbstractSymbol` in addition to `AbstractFunction`, we can now add our internal `Symbol` types (spacing symbols, iteration size variables, etc.) to our caching hierachy, but also better emulate the expected meta-data of functions. This means:
  * We now have to initialise them as `Symbol(name='symbols_name')`, and `s0 = Symbol(name='s'); s1 = Symbol(name='s')` don't cache anymore.
  * We can provide all the meta-data expected of functions, eg. `dtype`, `indices`, etc...
* Turn `Constant` into a `Symbol`, not `Function`. This is notationally nicer and more intuitive, and allows the DSE to effectively treat it as a `Function`.

Note that the final point is the aim of the game here, as this PR prepares things for generic grids, where we don't necessarily have to substitute spacing symbols.

Please also note that we can probably convert `Dimension` types to the new `AbstractSymbol` types, but we might want to leave that for another PR. 