### PR TITLE
Sparse generalization

### DIFF
--- a/devito/function.py
+++ b/devito/function.py
@@ -477,7 +477,7 @@ class SparseFunction(CompositeFunction):
     def __new__(cls, *args, **kwargs):
         nt = kwargs.get('nt')
         npoint = kwargs.get('npoint')
-        kwargs['shape'] = (nt, npoint) if nt>0 else (npoint, )
+        kwargs['shape'] = (nt, npoint) if nt > 0 else (npoint, )
 
         return Function.__new__(cls, *args, **kwargs)
 
@@ -575,7 +575,8 @@ class SparseFunction(CompositeFunction):
     def coordinate_indices(self):
         """Symbol for each grid index according to the coordinates"""
         return tuple([INT(sympy.Function('floor')(c / i.spacing))
-                      for c, i in zip(self.coordinate_symbols, self.coordinates_dimensions)])
+                      for c, i in zip(self.coordinate_symbols,
+                                      self.coordinates_dimensions)])
 
     @property
     def coordinate_bases(self):
@@ -668,8 +669,10 @@ class SparseFunction(CompositeFunction):
                 for b, vsub in zip(self.coefficients, idx_subs)]
 
     def assign(self, field, expr, offset=0, **kwargs):
-        """Symbol for injection of an expression onto a grid
-
+        """Symbol for assignment of an expression onto a grid
+        This function works at the symbolic level and will therefor not perform any
+        safety check. Assigned value may be overwritten if the points are
+        too close to each other.
         :param field: The grid field into which we inject.
         :param expr: The expression to inject.
         :param offset: Additional offset from the boundary for

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -149,16 +149,17 @@ def test_assign(shape, coords, npoints=9):
     spacing = a.data[tuple([1 for _ in shape])]
     a.data[:] = 0.
     p = points(ranges=coords, npoints=npoints)
-    p.data[:] = 1.0
+    p.data[:] = 1.
 
     expr = p.assign(a, p)
 
     Operator(expr, subs={x.spacing: spacing, y.spacing: spacing,
-                         z.spacing: spacing})(a=a, points=p)
+                         z.spacing: spacing})(a=a)
 
     indices = [slice(4, 5, 1) for _ in coords]
-    indices[0] = slice(1, -1, 1)
-    assert np.allclose(a.data[indices], 1., rtol=1.e-5)
+    indices[0] = slice(1, -2, 1)
+    print(a.data[indices])
+    assert np.allclose(a.data[indices], 1.0, rtol=1.e-5)
 
 
 @skipif_yask

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -3,7 +3,7 @@ import pytest
 from conftest import skipif_yask
 
 from devito.cgen_utils import FLOAT
-from devito import Grid, Operator, Function, SparseFunction, x, y, z
+from devito import Grid, Operator, Function, SparseFunction, TimeFunction, x, y, z
 
 
 @pytest.fixture
@@ -25,11 +25,21 @@ def unit_box(name='a', shape=(11, 11)):
     return a
 
 
-def points(ranges, npoints, name='points'):
+def time_unit_box(name='a', shape=(11, 11), nt=10):
+    """Create a field with value 0. to 1. in each dimension"""
+    grid = Grid(shape=shape)
+    a = TimeFunction(name=name, grid=grid, save=True, time_dim=nt)
+    dims = tuple([np.linspace(0., 1., d) for d in shape])
+    for i in range(nt):
+        a.data[i, :] = np.meshgrid(*dims)[1]
+    return a
+
+
+def points(ranges, npoints, name='points', nt=0):
     """Create a set of sparse points from a set of coordinate
     ranges for each spatial dimension.
     """
-    points = SparseFunction(name=name, nt=1, npoint=npoints, ndim=len(ranges))
+    points = SparseFunction(name=name, ntime=nt, npoint=npoints, ndim=len(ranges))
     for i, r in enumerate(ranges):
         points.coordinates.data[:, i] = np.linspace(r[0], r[1], npoints)
     return points
@@ -51,9 +61,30 @@ def test_interpolate(shape, coords, npoints=20):
 
     expr = p.interpolate(a)
     Operator(expr, subs={x.spacing: spacing, y.spacing: spacing,
-                         z.spacing: spacing})(a=a, time=1)
+                         z.spacing: spacing})(a=a)
 
-    assert np.allclose(p.data[0, :], xcoords, rtol=1e-6)
+    assert np.allclose(p.data[:], xcoords, rtol=1e-6)
+
+
+@skipif_yask
+@pytest.mark.parametrize('shape, coords', [
+    ((11, 11), [(.05, .9), (.01, .8)]),
+    ((11, 11, 11), [(.05, .9), (.01, .8), (0.07, 0.84)])
+])
+def test_interpolate_cumulative(shape, coords, npoints=20):
+    """Test generic point interpolation testing the x-coordinate of an
+    abitrary set of points going across the grid.
+    """
+    a = time_unit_box(shape=shape)
+    spacing = a.data[(0, ) + tuple([1 for _ in shape])]
+    p = points(coords, npoints=npoints)
+    xcoords = p.coordinates.data[:, 0]
+
+    expr = p.interpolate(expr=a, cumulative=True)
+    Operator(expr, subs={x.spacing: spacing, y.spacing: spacing,
+                         z.spacing: spacing})(a=a, time=10)
+
+    assert np.allclose(p.data[:], 10*xcoords, rtol=1e-6)
 
 
 @skipif_yask
@@ -107,6 +138,31 @@ def test_inject_from_field(shape, coords, result, npoints=19):
 
 @skipif_yask
 @pytest.mark.parametrize('shape, coords', [
+    ((11, 11), [(.1, .9), (.4, .4)]),
+    ((11, 11, 11), [(.1, .9), (.4, .4), (.4, .4)])
+])
+def test_assign(shape, coords, npoints=9):
+    """Test point value assignment with a set of points forming a line
+    through the middle of the grid.
+    """
+    a = unit_box(shape=shape)
+    spacing = a.data[tuple([1 for _ in shape])]
+    a.data[:] = 0.
+    p = points(ranges=coords, npoints=npoints)
+    p.data[:] = 1.0
+
+    expr = p.assign(a, p)
+
+    Operator(expr, subs={x.spacing: spacing, y.spacing: spacing,
+                         z.spacing: spacing})(a=a, points=p)
+
+    indices = [slice(4, 5, 1) for _ in coords]
+    indices[0] = slice(1, -1, 1)
+    assert np.allclose(a.data[indices], 1., rtol=1.e-5)
+
+
+@skipif_yask
+@pytest.mark.parametrize('shape, coords', [
     ((11, 11), [(.05, .9), (.01, .8)]),
     ((11, 11, 11), [(.05, .9), (.01, .8), (0.07, 0.84)])
 ])
@@ -126,7 +182,7 @@ def test_adjoint_inject_interpolate(shape, coords,
     p2 = points(name='points2', ranges=coords, npoints=npoints)
     expr2 = p2.interpolate(expr=c)
     Operator(expr + expr2, subs={x.spacing: spacing, y.spacing: spacing,
-                                 z.spacing: spacing})(a=a, c=c, time=1)
+                                 z.spacing: spacing})(a=a, c=c)
     # < P x, y > - < x, P^T y>
     # Px => p2
     # y => p
@@ -135,3 +191,7 @@ def test_adjoint_inject_interpolate(shape, coords,
     term1 = np.dot(p2.data.reshape(-1), p.data.reshape(-1))
     term2 = np.dot(c.data.reshape(-1), a.data.reshape(-1))
     assert np.isclose((term1-term2) / term1, 0., atol=1.e-6)
+
+
+if __name__ == "__main__":
+    test_assign((11, 11), [(.1, .9), (.4, .4)], npoints=9)

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -191,7 +191,3 @@ def test_adjoint_inject_interpolate(shape, coords,
     term1 = np.dot(p2.data.reshape(-1), p.data.reshape(-1))
     term2 = np.dot(c.data.reshape(-1), a.data.reshape(-1))
     assert np.isclose((term1-term2) / term1, 0., atol=1.e-6)
-
-
-if __name__ == "__main__":
-    test_assign((11, 11), [(.1, .9), (.4, .4)], npoints=9)


### PR DESCRIPTION
Attempt to generalize `SparseFunction`, Source/Rec are untouched as this ones are specific to the seismic setup.
This is open to discussion/naming, but this is needed as the current one has too many hard-coded issues.
Summary:
 - `time` is not mandatory anymore
 - `coordinates` can be associated with any dimension, and falls back to default if not (a coordinate is by definition a values along a dimension, not a magic number). 
- Extra function to assign instead of inject a value at point positions :**unsafe function are we cannot check at symbolic level if two values of the coordinate will assign to the same index of the wavefield**
- Extra options to take cumulative sum instead of current time value in interpolate
