### PR TITLE
Enable dynamic backend switching

### DIFF
--- a/devito/__init__.py
+++ b/devito/__init__.py
@@ -42,6 +42,17 @@ configuration.add('debug_compiler', 0, [0, 1], lambda i: bool(i))
 configuration.add('backend', 'core', list(backends_registry),
                   callback=init_backend)
 
+# Set the Instruction Set Architecture (ISA)
+ISAs = [None, 'cpp', 'avx', 'avx2', 'avx512', 'knc']
+configuration.add('isa', None, ISAs)
+
+# Set the CPU architecture (only codename)
+PLATFORMs = [None, 'intel64', 'sandybridge', 'ivybridge', 'haswell',
+             'broadwell', 'skylake', 'knc', 'knl']
+# TODO: switch arch to actual architecture names; use the mapper in /YASK/
+configuration.add('platform', None, PLATFORMs)
+
+
 # Initialize the configuration, either from the environment or
 # defaults. This will also trigger the backend initialization
 init_configuration()

--- a/devito/__init__.py
+++ b/devito/__init__.py
@@ -4,7 +4,6 @@ import gc
 from sympy.core import cache
 
 from devito.base import *  # noqa
-from devito.backends import init_backend
 from devito.finite_difference import *  # noqa
 from devito.dimension import *  # noqa
 from devito.grid import *  # noqa
@@ -29,7 +28,6 @@ from ._version import get_versions  # noqa
 __version__ = get_versions()['version']
 del get_versions
 
-
-# Initialize the Devito backend
+# Initialize the configuration, which will also trigger
+# the backend initialization
 init_configuration()
-init_backend(configuration['backend'])

--- a/devito/__init__.py
+++ b/devito/__init__.py
@@ -14,6 +14,9 @@ from devito.parameters import *  # noqa
 from devito.tools import *  # noqa
 from devito.dse import *  # noqa
 
+from devito.compiler import compiler_registry
+from devito.backends import backends_registry, init_backend
+
 
 def clear_cache():
     cache.clear_cache()
@@ -28,6 +31,17 @@ from ._version import get_versions  # noqa
 __version__ = get_versions()['version']
 del get_versions
 
-# Initialize the configuration, which will also trigger
-# the backend initialization
+# First add the compiler configuration option...
+configuration.add('compiler', 'custom', list(compiler_registry),
+                  lambda i: compiler_registry[i]())
+configuration.add('openmp', 0, [0, 1], lambda i: bool(i))
+configuration.add('debug_compiler', 0, [0, 1], lambda i: bool(i))
+
+# ... then the backend configuration. The order is important since the
+# backend might depend on the compiler configuration.
+configuration.add('backend', 'core', list(backends_registry),
+                  callback=init_backend)
+
+# Initialize the configuration, either from the environment or
+# defaults. This will also trigger the backend initialization
 init_configuration()

--- a/devito/backends.py
+++ b/devito/backends.py
@@ -11,7 +11,6 @@ from sympy.core.function import FunctionClass
 
 from devito.exceptions import DevitoError
 from devito.logger import warning
-from devito.parameters import configuration
 
 backends = {}
 
@@ -142,6 +141,3 @@ def init_backend(backend):
         set_backend(backend)
     except (ImportError, RuntimeError):
         raise DevitoError("Couldn't initialize Devito.")
-
-
-configuration.add('backend', 'core', list(backends_registry), callback=init_backend)

--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -291,9 +291,3 @@ compiler_registry = {
     'intel-mic': IntelMICCompiler, 'mic': IntelMICCompiler,
     'intel-knl': IntelKNLCompiler, 'knl': IntelKNLCompiler,
 }
-
-
-configuration.add('compiler', 'custom', list(compiler_registry),
-                  lambda i: compiler_registry[i]())
-configuration.add('openmp', 0, [0, 1], lambda i: bool(i))
-configuration.add('debug_compiler', 0, [0, 1], lambda i: bool(i))

--- a/devito/parameters.py
+++ b/devito/parameters.py
@@ -2,12 +2,9 @@
 
 from collections import OrderedDict
 from os import environ
-from subprocess import PIPE, Popen
-
-import cpuinfo
 
 __all__ = ['configuration', 'init_configuration', 'print_defaults', 'print_state',
-           'add_sub_configuration', 'infer_cpu']
+           'add_sub_configuration']
 
 # Be EXTREMELY careful when writing to a Parameters dictionary
 # Read here for reference: http://wiki.c2.com/?GlobalVariablesAreBad
@@ -100,17 +97,6 @@ env_vars_mapper = {
 configuration = Parameters("Devito-Configuration")
 """The Devito configuration parameters."""
 
-# Set the Instruction Set Architecture (ISA)
-default_isa = 'cpp'
-ISAs = [None, 'cpp', 'avx', 'avx2', 'avx512', 'knc']
-configuration.add('isa', None, ISAs)
-# Set the CPU architecture (only codename)
-default_platform = 'intel64'
-PLATFORMs = [None, 'intel64', 'sandybridge', 'ivybridge', 'haswell',
-             'broadwell', 'skylake', 'knc', 'knl']
-# TODO: switch arch to actual architecture names; use the mapper in /YASK/
-configuration.add('platform', None, PLATFORMs)
-
 
 def init_configuration(configuration=configuration, env_vars_mapper=env_vars_mapper):
     # Populate /configuration/ with user-provided options
@@ -177,38 +163,3 @@ def print_state():
     from devito.logger import info
     for k, v in configuration.items():
         info('%s: %s' % (k, v))
-
-
-def infer_cpu():
-    """
-    Detect the highest Instruction Set Architecture and the platform
-    codename using cpu flags and/or leveraging other tools. Return default
-    values if the detection procedure was unsuccesful.
-    """
-    info = cpuinfo.get_cpu_info()
-    # ISA
-    isa = default_isa
-    for i in reversed(ISAs):
-        if i in info['flags']:
-            isa = i
-            break
-    # Platform
-    try:
-        # First, try leveraging `gcc`
-        p1 = Popen(['gcc', '-march=native', '-Q', '--help=target'], stdout=PIPE)
-        p2 = Popen(['grep', 'march'], stdin=p1.stdout, stdout=PIPE)
-        p1.stdout.close()  # Allow p1 to receive a SIGPIPE if p2 exits.
-        output, _ = p2.communicate()
-        platform = output.decode("utf-8").split()[1]
-    except:
-        # Then, try infer from the brand name, otherwise fallback to default
-        try:
-            mapper = {'v3': 'haswell', 'v4': 'broadwell', 'v5': 'skylake'}
-            cpu_iteration = info['brand'].split()[4]
-            platform = mapper[cpu_iteration]
-        except:
-            platform = None
-    # Is it a known platform?
-    if platform not in PLATFORMs:
-        platform = default_platform
-    return isa, platform

--- a/devito/parameters.py
+++ b/devito/parameters.py
@@ -100,7 +100,6 @@ env_vars_mapper = {
 configuration = Parameters("Devito-Configuration")
 """The Devito configuration parameters."""
 
-configuration.add('travis_test', 0, [0, 1], lambda i: bool(i))
 # Set the Instruction Set Architecture (ISA)
 default_isa = 'cpp'
 ISAs = [None, 'cpp', 'avx', 'avx2', 'avx512', 'knc']

--- a/devito/yask/__init__.py
+++ b/devito/yask/__init__.py
@@ -9,8 +9,8 @@ import os
 from devito import configuration
 from devito.exceptions import InvalidOperator
 from devito.logger import yask as log
-from devito.parameters import Parameters, add_sub_configuration, infer_cpu
-from devito.tools import ctypes_pointer
+from devito.parameters import Parameters, add_sub_configuration
+from devito.tools import ctypes_pointer, infer_cpu
 
 
 def exit(emsg):

--- a/environment.yml
+++ b/environment.yml
@@ -6,6 +6,7 @@ dependencies:
   - python>=3.6
   - numpy>=1.11
   - sympy==1.1
+  - cgen
   - scipy
   - matplotlib
   - pytest
@@ -16,6 +17,5 @@ dependencies:
   - sphinx
   - sphinx_rtd_theme
   - pip:
-    - "git+https://github.com/inducer/cgen"
     - "git+https://github.com/inducer/codepy"
     - py-cpuinfo


### PR DESCRIPTION
Shuffles the configuration options around a little to enable us to switch to the YASK backend dynamically from within a single Python interpreter - for example an Azure notebook session.