### PR TITLE
Configuration: Fix dynamic OpenMP switch

### DIFF
--- a/devito/__init__.py
+++ b/devito/__init__.py
@@ -14,7 +14,7 @@ from devito.parameters import *  # noqa
 from devito.tools import *  # noqa
 from devito.dse import *  # noqa
 
-from devito.compiler import compiler_registry
+from devito.compiler import compiler_registry, GNUCompiler
 from devito.backends import backends_registry, init_backend
 
 
@@ -38,7 +38,11 @@ configuration.add('compiler', 'custom', list(compiler_registry),
 
 def _cast_and_update_compiler(val):
     # Force re-build the compiler
-    configuration['compiler'].__init__()
+    compiler = configuration['compiler']
+    if isinstance(compiler, GNUCompiler):
+        compiler.__init__(version=compiler.version)
+    else:
+        compiler.__init__()
     return bool(val)
 
 

--- a/devito/__init__.py
+++ b/devito/__init__.py
@@ -33,8 +33,16 @@ del get_versions
 
 # First add the compiler configuration option...
 configuration.add('compiler', 'custom', list(compiler_registry),
-                  lambda i: compiler_registry[i]())
-configuration.add('openmp', 0, [0, 1], lambda i: bool(i))
+                  callback=lambda i: compiler_registry[i]())
+
+
+def _cast_and_update_compiler(val):
+    # Force re-build the compiler
+    configuration['compiler'].__init__()
+    return bool(val)
+
+
+configuration.add('openmp', 0, [0, 1], callback=_cast_and_update_compiler)
 configuration.add('debug_compiler', 0, [0, 1], lambda i: bool(i))
 
 # ... then the backend configuration. The order is important since the

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -67,9 +67,9 @@ class TestArithmetic(object):
 
     @pytest.mark.parametrize('expr, result', [
         ('Eq(a, a + b + 5.)', 10.),
-        # ('Eq(a, b - a)', 1.),
-        # ('Eq(a, 4 * (b * a))', 24.),
-        # ('Eq(a, (6. / b) + (8. * a))', 18.),
+        ('Eq(a, b - a)', 1.),
+        ('Eq(a, 4 * (b * a))', 24.),
+        ('Eq(a, (6. / b) + (8. * a))', 18.),
     ])
     @pytest.mark.parametrize('mode', ['function'])
     def test_flat(self, expr, result, mode):


### PR DESCRIPTION
When setting the `openmp` option explicitly from Python, we need to re-initialise the `Compiler` object to update the linker flags, etc. **This now enable seamless switching between sequential and threaded mode in notebooks** via `configuration['openmp'] = True`!  @ggorman @FabioLuporini  

Also adding a small fix for a debug leftover that has crept in somehow.