### PR TITLE
Test op fix

### DIFF
--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -683,8 +683,7 @@ class TestLoopScheduler(object):
         are embedded within the same time loop.
         """
         grid = Grid(shape=shape, dimensions=dimensions, time_dimension=time)
-        a = TimeFunction(name='a', grid=grid, time_order=2,
-                         space_order=2)
+        a = TimeFunction(name='a', grid=grid, time_order=2, space_order=2)
         p_aux = Dimension(name='p_aux', size=10)
         b = Function(name='b', shape=shape + (10,), dimensions=dimensions + (p_aux,),
                      space_order=2)
@@ -738,8 +737,3 @@ class TestForeign(object):
         args['a'] = array
         op.cfunction(*list(args.values()))
         assert all(np.allclose(args['a'][i], i) for i in range(time_dim))
-
-
-if __name__ == "__main__":
-    tester = TestLoopScheduler()
-    tester.test_equations_mixed_densedata_timedata((11, 11), (x, y))

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -12,7 +12,6 @@ from devito import (clear_cache, Grid, Eq, Operator, Constant, Function,
 from devito.foreign import Operator as OperatorForeign
 from devito.dle import retrieve_iteration_tree
 from devito.ir.iet import IsPerfectIteration
-from devito.logger import set_log_level
 
 
 def dimify(dimensions):
@@ -683,7 +682,6 @@ class TestLoopScheduler(object):
         Test that equations using a mixture of Function and TimeFunction objects
         are embedded within the same time loop.
         """
-        set_log_level("DEBUG")
         grid = Grid(shape=shape, dimensions=dimensions, time_dimension=time)
         a = TimeFunction(name='a', grid=grid, time_order=2,
                          space_order=2)


### PR DESCRIPTION
Small test fix.

The test was actually failing but wasn't caught as only three time-steps were ran and the modulo was hiding it (modulo 3)

`a` needs to be reinitialized to get correct result.
