### PR TITLE
Staggered grid allocation

### DIFF
--- a/devito/function.py
+++ b/devito/function.py
@@ -301,6 +301,16 @@ class Function(TensorFunction):
         return sum([second_derivative(first * weight, dim=d, order=order)
                     for d in self.space_dimensions])
 
+    @property
+    def symbolic_shape(self):
+        """
+        Return the symbolic shape of the object. This is simply the
+        appropriate combination of symbolic dimension sizes shifted
+        according to the ``staggered`` mask.
+        """
+        return tuple(i.symbolic_size - s for i, s in
+                     zip(self.indices, self.staggered))
+
 
 class TimeFunction(Function):
     """

--- a/devito/function.py
+++ b/devito/function.py
@@ -319,6 +319,7 @@ class TimeFunction(Function):
     :param name: Name of the resulting :class:`sympy.Function` symbol
     :param grid: :class:`Grid` object from which to infer the data shape
                  and :class:`Dimension` indices.
+    :param staggered: (Optional) tuple containing staggering offsets.
     :param dtype: (Optional) data type of the buffered data
     :param save: Save the intermediate results to the data buffer. Defaults
                  to `False`, indicating the use of alternating buffers.
@@ -379,8 +380,13 @@ class TimeFunction(Function):
         """
         Full allocated shape of the data associated with this :class:`TimeFunction`.
         """
-        tsize = self.time_dim if self.save else self.time_order + 1
-        return (tsize, ) + self.shape_domain
+        if self.save:
+            tsize = self.time_dim - self.staggered[0]
+        else:
+            tsize = self.time_order + 1
+        shape_domain = tuple(i - s for i, s in zip(self.shape_domain,
+                                                   self.staggered[1:]))
+        return (tsize, ) + shape_domain
 
     def initialize(self):
         if self.initializer is not None:

--- a/devito/function.py
+++ b/devito/function.py
@@ -140,6 +140,10 @@ class Function(TensorFunction):
             self.indices = self._indices(**kwargs)
             self.staggered = kwargs.get('staggered',
                                         tuple(0 for _ in self.indices))
+            if len(self.staggered) != len(self.indices):
+                error("Staggering argument needs %s entries for indices %s"
+                      % (len(self.indices), self.indices))
+                raise ValueError("Insufficient staggered entries")
 
             self.space_order = kwargs.get('space_order', 1)
             self.initializer = kwargs.get('initializer', None)

--- a/devito/function.py
+++ b/devito/function.py
@@ -136,66 +136,72 @@ class Function(TensorFunction):
             self._first_touch = kwargs.get('first_touch', configuration['first_touch'])
             self._data_object = None
 
-            # Dynamically create notational shortcuts for space derivatives
-            for dim in self.space_dimensions:
-                # First derivative, centred
-                dx = partial(first_derivative, order=self.space_order,
-                             dim=dim, side=centered)
-                setattr(self.__class__, 'd%s' % dim.name,
-                        property(dx, 'Return the symbolic expression for '
-                                 'the centered first derivative wrt. '
-                                 'the %s dimension' % dim.name))
+            # Dynamically add derivative short-cuts
+            self._initialize_derivatives()
 
-                # First derivative, left
-                dxl = partial(first_derivative, order=self.space_order,
-                              dim=dim, side=left)
-                setattr(self.__class__, 'd%sl' % dim.name,
-                        property(dxl, 'Return the symbolic expression for '
-                                 'the left-sided first derivative wrt. '
-                                 'the %s dimension' % dim.name))
+    def _initialize_derivatives(self):
+        """
+        Dynamically create notational shortcuts for space derivatives.
+        """
+        for dim in self.space_dimensions:
+            # First derivative, centred
+            dx = partial(first_derivative, order=self.space_order,
+                         dim=dim, side=centered)
+            setattr(self.__class__, 'd%s' % dim.name,
+                    property(dx, 'Return the symbolic expression for '
+                             'the centered first derivative wrt. '
+                             'the %s dimension' % dim.name))
 
-                # First derivative, right
-                dxr = partial(first_derivative, order=self.space_order,
-                              dim=dim, side=right)
-                setattr(self.__class__, 'd%sr' % dim.name,
-                        property(dxr, 'Return the symbolic expression for '
-                                 'the right-sided first derivative wrt. '
-                                 'the %s dimension' % dim.name))
+            # First derivative, left
+            dxl = partial(first_derivative, order=self.space_order,
+                          dim=dim, side=left)
+            setattr(self.__class__, 'd%sl' % dim.name,
+                    property(dxl, 'Return the symbolic expression for '
+                             'the left-sided first derivative wrt. '
+                             'the %s dimension' % dim.name))
 
-                # Second derivative
-                dx2 = partial(generic_derivative, deriv_order=2, dim=dim,
-                              fd_order=int(self.space_order / 2))
-                setattr(self.__class__, 'd%s2' % dim.name,
-                        property(dx2, 'Return the symbolic expression for '
-                                 'the second derivative wrt. the '
-                                 '%s dimension' % dim.name))
+            # First derivative, right
+            dxr = partial(first_derivative, order=self.space_order,
+                          dim=dim, side=right)
+            setattr(self.__class__, 'd%sr' % dim.name,
+                    property(dxr, 'Return the symbolic expression for '
+                             'the right-sided first derivative wrt. '
+                             'the %s dimension' % dim.name))
 
-                # Fourth derivative
-                dx4 = partial(generic_derivative, deriv_order=4, dim=dim,
-                              fd_order=max(int(self.space_order / 2), 2))
-                setattr(self.__class__, 'd%s4' % dim.name,
-                        property(dx4, 'Return the symbolic expression for '
-                                 'the fourth derivative wrt. the '
-                                 '%s dimension' % dim.name))
+            # Second derivative
+            dx2 = partial(generic_derivative, deriv_order=2, dim=dim,
+                          fd_order=int(self.space_order / 2))
+            setattr(self.__class__, 'd%s2' % dim.name,
+                    property(dx2, 'Return the symbolic expression for '
+                             'the second derivative wrt. the '
+                             '%s dimension' % dim.name))
 
-                for dim2 in self.space_dimensions:
-                    # First cross derivative
-                    dxy = partial(cross_derivative, order=self.space_order,
-                                  dims=(dim, dim2))
-                    setattr(self.__class__, 'd%s%s' % (dim.name, dim2.name),
-                            property(dxy, 'Return the symbolic expression for '
-                                     'the first cross derivative wrt. the '
-                                     '%s and %s dimensions' %
-                                     (dim.name, dim2.name)))
+            # Fourth derivative
+            dx4 = partial(generic_derivative, deriv_order=4, dim=dim,
+                          fd_order=max(int(self.space_order / 2), 2))
+            setattr(self.__class__, 'd%s4' % dim.name,
+                    property(dx4, 'Return the symbolic expression for '
+                             'the fourth derivative wrt. the '
+                             '%s dimension' % dim.name))
 
-                    # Second cross derivative
-                    dx2y2 = partial(second_cross_derivative, dims=(dim, dim2),
-                                    order=self.space_order)
-                    setattr(self.__class__, 'd%s2%s2' % (dim.name, dim2.name),
-                            property(dx2y2, 'Return the symbolic expression for '
-                                     'the second cross derivative wrt. the '
-                                     '%s and %s dimensions' %
-                                     (dim.name, dim2.name)))
+            for dim2 in self.space_dimensions:
+                # First cross derivative
+                dxy = partial(cross_derivative, order=self.space_order,
+                              dims=(dim, dim2))
+                setattr(self.__class__, 'd%s%s' % (dim.name, dim2.name),
+                        property(dxy, 'Return the symbolic expression for '
+                                 'the first cross derivative wrt. the '
+                                 '%s and %s dimensions' %
+                                 (dim.name, dim2.name)))
+
+                # Second cross derivative
+                dx2y2 = partial(second_cross_derivative, dims=(dim, dim2),
+                                order=self.space_order)
+                setattr(self.__class__, 'd%s2%s2' % (dim.name, dim2.name),
+                        property(dx2y2, 'Return the symbolic expression for '
+                                 'the second cross derivative wrt. the '
+                                 '%s and %s dimensions' %
+                                 (dim.name, dim2.name)))
 
     @classmethod
     def _indices(cls, **kwargs):

--- a/devito/profiling.py
+++ b/devito/profiling.py
@@ -160,7 +160,8 @@ class Profiler(object):
                                itershape, datashape)
 
         # Rename the most time consuming section as 'main'
-        summary['main'] = summary.pop(max(summary, key=summary.get))
+        if len(summary) > 0:
+            summary['main'] = summary.pop(max(summary, key=summary.get))
 
         return summary
 

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -213,7 +213,6 @@ class TestAllocation(object):
         assert(np.allclose(m2.data, 0))
         assert(np.array_equal(m.data, m2.data))
 
-
     @pytest.mark.parametrize('staggered', [
         (0, 0), (0, 1), (1, 0), (1, 1),
         (0, 0, 0), (1, 0, 0), (0, 1, 0), (0, 0, 1),
@@ -223,13 +222,18 @@ class TestAllocation(object):
         """
         Test the "deformed" allocation for staggered functions
         """
-        grid = Grid(shape=tuple(21 for _ in staggered))
+        grid = Grid(shape=tuple(11 for _ in staggered))
         f = Function(name='f', grid=grid, staggered=staggered)
-        # Ensure correct shape was allocated
-        assert f.data.shape == tuple(21-i for i in staggered)
+        assert f.data.shape == tuple(11-i for i in staggered)
+        # Add a non-staggered field to ensure that the auto-derived
+        # dimension size arguments are at maximum
+        g = Function(name='g', grid=grid)
         # Test insertion into a central point
-        Operator(Eq(f.indexed[tuple(10 for _ in staggered)], 2.))()
-        assert f.data[10, 10] == 2.
+        index = tuple(5 for _ in staggered)
+        set_f = Eq(f.indexed[index], 2.)
+        set_g = Eq(g.indexed[index], 3.)
+        Operator([set_f, set_g])()
+        assert f.data[index] == 2.
 
 
 @skipif_yask

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -214,6 +214,24 @@ class TestAllocation(object):
         assert(np.array_equal(m.data, m2.data))
 
 
+    @pytest.mark.parametrize('staggered', [
+        (0, 0), (0, 1), (1, 0), (1, 1),
+        (0, 0, 0), (1, 0, 0), (0, 1, 0), (0, 0, 1),
+        (1, 1, 0), (1, 0, 1), (0, 1, 1), (1, 1, 1),
+    ])
+    def test_staggered(self, staggered):
+        """
+        Test the "deformed" allocation for staggered functions
+        """
+        grid = Grid(shape=tuple(21 for _ in staggered))
+        f = Function(name='f', grid=grid, staggered=staggered)
+        # Ensure correct shape was allocated
+        assert f.data.shape == tuple(21-i for i in staggered)
+        # Test insertion into a central point
+        Operator(Eq(f.indexed[tuple(10 for _ in staggered)], 2.))()
+        assert f.data[10, 10] == 2.
+
+
 @skipif_yask
 class TestArguments(object):
 

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -235,6 +235,29 @@ class TestAllocation(object):
         Operator([set_f, set_g])()
         assert f.data[index] == 2.
 
+    @pytest.mark.parametrize('staggered', [
+        (0, 0, 0), (0, 0, 1), (0, 1, 0), (0, 1, 1),
+        (0, 0, 0), (0, 1, 0, 0), (0, 0, 1, 0), (0, 0, 0, 1),
+        (0, 1, 1, 0), (0, 1, 0, 1), (0, 0, 1, 1), (0, 1, 1, 1),
+    ])
+    def test_staggered_time(self, staggered):
+        """
+        Test the "deformed" allocation for staggered functions
+        """
+        grid = Grid(shape=tuple(11 for _ in staggered[1:]))
+        f = TimeFunction(name='f', grid=grid, staggered=staggered)
+        # from IPython import embed; embed()
+        assert f.data.shape[1:] == tuple(11-i for i in staggered[1:])
+        # Add a non-staggered field to ensure that the auto-derived
+        # dimension size arguments are at maximum
+        g = TimeFunction(name='g', grid=grid)
+        # Test insertion into a central point
+        index = tuple([0] + [5 for _ in staggered[1:]])
+        set_f = Eq(f.indexed[index], 2.)
+        set_g = Eq(g.indexed[index], 3.)
+        Operator([set_f, set_g])()
+        assert f.data[index] == 2.
+
 
 @skipif_yask
 class TestArguments(object):


### PR DESCRIPTION
This PR adds a new `staggered` keyword to `Function` and `TimeFunction` objects that adjusts the data shape and the casts in the generated code according to staggering offsets. That means that, for example, a 2D `Function` staggered in `y` (`staggered=(0, 1)` stores DoFs on the side-edges and allocates a shape of `nx, ny-1`.

Note: **This does not affect any symbolics for staggered grids or derivatives. I'm still playing with that!**