### PR TITLE
ir: Introduce new data dependence analysis engine

### DIFF
--- a/devito/dse/backends/advanced.py
+++ b/devito/dse/backends/advanced.py
@@ -155,7 +155,7 @@ class AdvancedRewriter(BasicRewriter):
             stencils.append(stencil)
 
         # Create the alias clusters
-        alias_clusters = clusterize(expressions, stencils, indices)
+        alias_clusters = clusterize(expressions, stencils)
         alias_clusters = sorted(alias_clusters, key=lambda i: i.is_dense)
 
         # Switch temporaries in the expression trees

--- a/devito/dse/backends/speculative.py
+++ b/devito/dse/backends/speculative.py
@@ -1,4 +1,3 @@
-from devito.ir.clusters import merge
 from devito.dse.backends import AdvancedRewriter, dse_pass
 from devito.symbolics import (estimate_cost, xreplace_constrained,
                               iq_timevarying, q_leaf, q_sum_of_product, q_terminalop)
@@ -31,10 +30,6 @@ class SpeculativeRewriter(AdvancedRewriter):
 
 
 class AggressiveRewriter(SpeculativeRewriter):
-
-    def run(self, cluster):
-        clusters = super(AggressiveRewriter, self).run(cluster)
-        return merge(clusters)
 
     def _pipeline(self, state):
         """Three CSRE phases, progressively searching for less structure."""

--- a/devito/dse/backends/speculative.py
+++ b/devito/dse/backends/speculative.py
@@ -1,4 +1,4 @@
-from devito.ir.clusters import optimize
+from devito.ir.clusters import merge
 from devito.dse.backends import AdvancedRewriter, dse_pass
 from devito.symbolics import (estimate_cost, xreplace_constrained,
                               iq_timevarying, q_leaf, q_sum_of_product, q_terminalop)
@@ -34,8 +34,7 @@ class AggressiveRewriter(SpeculativeRewriter):
 
     def run(self, cluster):
         clusters = super(AggressiveRewriter, self).run(cluster)
-        clusters = optimize(clusters)
-        return clusters
+        return merge(clusters)
 
     def _pipeline(self, state):
         """Three CSRE phases, progressively searching for less structure."""

--- a/devito/dse/transformer.py
+++ b/devito/dse/transformer.py
@@ -1,5 +1,6 @@
 from __future__ import absolute_import
 
+from devito.ir.clusters import ClusterGroup, groupby
 from devito.dse.backends import (BasicRewriter, AdvancedRewriter, SpeculativeRewriter,
                                  AggressiveRewriter, CustomRewriter)
 from devito.exceptions import DSEException
@@ -50,7 +51,7 @@ def rewrite(clusters, mode='advanced'):
     if mode is None or mode == 'noop':
         return clusters
 
-    processed = []
+    processed = ClusterGroup()
     for cluster in clusters:
         if cluster.is_dense:
             if mode in modes:
@@ -66,4 +67,5 @@ def rewrite(clusters, mode='advanced'):
             # pointless to expose loop-redundancies when the iteration space
             # only consists of a few points
             processed.extend(BasicRewriter(False).run(cluster))
-    return processed
+
+    return groupby(processed)

--- a/devito/ir/clusters/__init__.py
+++ b/devito/ir/clusters/__init__.py
@@ -1,1 +1,2 @@
+from devito.ir.clusters.cluster import *  # noqa
 from devito.ir.clusters.algorithms import *  # noqa

--- a/devito/ir/clusters/algorithms.py
+++ b/devito/ir/clusters/algorithms.py
@@ -25,8 +25,8 @@ def groupby(clusters):
         for candidate in reversed(list(processed)):
             # Check all data dependences relevant for cluster fusion
             scope = Scope(exprs=candidate.exprs + c.exprs)
-            anti = scope.d_anti.carried() - scope.d_anti.indirect()
-            flow = scope.d_flow - (scope.d_flow.inplace() + scope.d_flow.indirect())
+            anti = scope.d_anti.carried() - scope.d_anti.increment
+            flow = scope.d_flow - (scope.d_flow.inplace() + scope.d_flow.increment)
             funcs = [i.function for i in anti]
             if candidate.stencil == c.stencil and\
                     all(is_local(i, candidate, c, clusters) for i in funcs):

--- a/devito/ir/clusters/cluster.py
+++ b/devito/ir/clusters/cluster.py
@@ -21,7 +21,7 @@ class Cluster(object):
     def __init__(self, exprs, stencil, atomics=None):
         self.trace = TemporariesGraph(exprs)
         self.stencil = stencil
-        self.atomics = as_tuple(atomics)
+        self._atomics = as_tuple(atomics)
 
     @property
     def exprs(self):
@@ -42,6 +42,14 @@ class Cluster(object):
     @property
     def is_sparse(self):
         return not self.is_dense
+
+    @property
+    def atomics(self):
+        return self._atomics
+
+    @atomics.setter
+    def atomics(self, val):
+        self._atomics = as_tuple(val)
 
     def rebuild(self, exprs):
         """

--- a/devito/ir/clusters/cluster.py
+++ b/devito/ir/clusters/cluster.py
@@ -1,31 +1,46 @@
+from collections import defaultdict
+
+from cached_property import cached_property
+
 from devito.ir.dfg import TemporariesGraph
 from devito.tools import as_tuple
 
+__all__ = ["Cluster", "ClusterGroup"]
 
-class Cluster(object):
+
+class PartialCluster(object):
 
     """
-    A Cluster is an ordered sequence of expressions that are necessary to
-    compute a tensor, plus the tensor expression itself.
+    A PartialCluster is an ordered sequence of expressions that result in the
+    computation of a tensor, plus the tensor expression itself.
 
-    A Cluster is associated with a stencil, which tracks what neighboring points
-    are required, along each dimension, to compute an entry in the tensor.
-
-    The parameter ``atomics`` allows to specify dimensions (a subset of those
-    appearing in ``stencil``) along which a Cluster cannot be fused with
-    other clusters. This is for example useful when a Cluster is evaluating
-    a tensor temporary, whose values must all be updated before being accessed
-    in the subsequent clusters.
+    PartialClusters are mutable -- in particular, their stencil as well as
+    the embedded sequence of expressions are subjected to modifications.
     """
 
-    def __init__(self, exprs, stencil, atomics=None):
-        self.trace = TemporariesGraph(exprs)
-        self.stencil = stencil
-        self._atomics = as_tuple(atomics)
+    def __init__(self, exprs, stencil):
+        """
+        Initialize a PartialCluster.
+
+        :param exprs: The ordered sequence of expressions computing a tensor.
+        :param stencil: An object of type :class:`Stencil`, which provides
+                        information about the points accessed along each dimension
+                        to compute the output tensor.
+        """
+        self._exprs = list(exprs)
+        self._stencil = stencil
 
     @property
     def exprs(self):
-        return list(self.trace.values())
+        return self._exprs
+
+    @property
+    def stencil(self):
+        return self._stencil
+
+    @property
+    def trace(self):
+        return TemporariesGraph(self.exprs)
 
     @property
     def unknown(self):
@@ -35,6 +50,34 @@ class Cluster(object):
     def tensors(self):
         return self.trace.tensors
 
+    @exprs.setter
+    def exprs(self, val):
+        self._exprs = val
+
+    @stencil.setter
+    def stencil(self, val):
+        self._stencil = val
+
+    def squash(self, other):
+        """Concatenate the expressions in ``other`` to those in ``self``.
+        ``self`` and ``other`` must have same ``stencil``. Duplicate
+        expressions are dropped."""
+        assert self.stencil == other.stencil
+        self.exprs.extend([i for i in other.exprs if i not in self.exprs])
+
+
+class Cluster(PartialCluster):
+
+    """A Cluster is an immutable PartialCluster."""
+
+    def __init__(self, exprs, stencil):
+        self._exprs = as_tuple(exprs)
+        self._stencil = stencil.frozen
+
+    @cached_property
+    def trace(self):
+        return TemporariesGraph(self.exprs)
+
     @property
     def is_dense(self):
         return self.trace.space_indices and not self.trace.time_invariant()
@@ -43,16 +86,54 @@ class Cluster(object):
     def is_sparse(self):
         return not self.is_dense
 
-    @property
-    def atomics(self):
-        return self._atomics
-
-    @atomics.setter
-    def atomics(self, val):
-        self._atomics = as_tuple(val)
-
     def rebuild(self, exprs):
         """
         Build a new cluster with expressions ``exprs`` having same stencil as ``self``.
         """
-        return Cluster(exprs, self.stencil, self.atomics)
+        return Cluster(exprs, self.stencil)
+
+    @PartialCluster.exprs.setter
+    def exprs(self, val):
+        raise AttributeError
+
+    @PartialCluster.stencil.setter
+    def stencil(self, val):
+        raise AttributeError
+
+    def squash(self, other):
+        raise AttributeError
+
+
+class ClusterGroup(list):
+
+    def __init__(self, *clusters):
+        """
+        An iterable of Clusters, which also tracks the atomic dimensions
+        of each of its elements; that is, those dimensions that a Cluster
+        cannot share with an adjacent cluster, to honor data dependences.
+        """
+        super(ClusterGroup, self).__init__(*clusters)
+        self.atomics = defaultdict(set)
+
+    def unfreeze(self):
+        """
+        Return a new ClusterGroup in which all of ``self``'s Clusters have
+        been promoted to PartialClusters. The ``atomics`` information is lost.
+        """
+        return ClusterGroup([PartialCluster(i.exprs, i.stencil)
+                             if isinstance(i, Cluster) else i for i in self])
+
+    def freeze(self):
+        """
+        Return a new ClusterGroup in which all of ``self``'s PartialClusters
+        have been turned into actual Clusters.
+        """
+        clusters = ClusterGroup()
+        for i in self:
+            if isinstance(i, PartialCluster):
+                cluster = Cluster(i.exprs, i.stencil)
+                clusters.append(cluster)
+                clusters.atomics[cluster] = self.atomics[i]
+            else:
+                clusters.append(i)
+        return clusters

--- a/devito/ir/clusters/cluster.py
+++ b/devito/ir/clusters/cluster.py
@@ -18,14 +18,14 @@ class Cluster(object):
     in the subsequent clusters.
     """
 
-    def __init__(self, exprs, stencil, atomics):
+    def __init__(self, exprs, stencil, atomics=None):
         self.trace = TemporariesGraph(exprs)
         self.stencil = stencil
         self.atomics = as_tuple(atomics)
 
     @property
     def exprs(self):
-        return self.trace.values()
+        return list(self.trace.values())
 
     @property
     def unknown(self):

--- a/devito/ir/iet/analysis.py
+++ b/devito/ir/iet/analysis.py
@@ -1,188 +1,165 @@
 """
 A collection of algorithms to analyze and decorate :class:`Iteration` in an
 Iteration/Expression tree. Decoration comes in the form of :class:`IterationProperty`
-objects, attached to nodes in the Iteration/Expression tree.
-
-The current implementation is based on simplistic analysis of Iteration/Expression
-trees. A better implementation would use a control flow graph, perhaps derived
-the Iteration/Expression tree itself. An ever better implementation would use
-a library such as ISL (the Integer Set Library).
+objects, attached to Iterations in the Iteration/Expression tree. The algorithms
+perform actual data dependence analysis.
 """
 
 from collections import OrderedDict
+from functools import cmp_to_key
 
 from devito.ir.iet import (Iteration, SEQUENTIAL, PARALLEL, VECTOR, WRAPPABLE,
-                           FindSections, IsPerfectIteration, NestedTransformer)
-from devito.symbolics import as_symbol
-from devito.tools import as_tuple, flatten
+                           MapIteration, NestedTransformer, retrieve_iteration_tree)
+from devito.ir.support import Scope
+from devito.tools import as_tuple
 
 __all__ = ['analyze_iterations']
 
 
-def analyze_iterations(nodes):
+class Analysis(object):
+
+    _cache = {}
+
+    def __new__(cls, iet):
+        if iet in Analysis._cache:
+            return Analysis._cache[iet]
+        else:
+            obj = super(Analysis, cls).__new__(cls)
+            obj.__init__(iet)
+            Analysis._cache[iet] = obj
+            return obj
+
+    def __init__(self, iet):
+        self.iet = iet
+        self.properties = OrderedDict()
+
+        self.trees = retrieve_iteration_tree(iet)
+        self.scopes = OrderedDict([(k, Scope([i.expr for i in v]))
+                                   for k, v in MapIteration().visit(iet).items()])
+
+    def update(self, properties):
+        for k, v in properties.items():
+            self.properties.setdefault(k, []).append(v)
+
+
+def propertizer(func):
+    def wrapper(arg):
+        analysis = Analysis(arg) if not isinstance(arg, Analysis) else arg
+        func(analysis)
+        return analysis
+    return wrapper
+
+
+def analyze_iterations(iet):
     """
     Attach :class:`IterationProperty` to :class:`Iteration` objects within
     ``nodes``. The recognized IterationProperty decorators are listed in
     ``nodes.IterationProperty._KNOWN``.
     """
-    sections = FindSections().visit(nodes)
+    analysis = mark_parallel(iet)
+    analysis = mark_vectorizable(analysis)
+    analysis = mark_wrappable(analysis)
 
-    # Local analysis: detect Iteration properties, inspecting trees in isolation
+    # Decorate the Iteration/Expression tree with the found properties
     mapper = OrderedDict()
-    for tree, exprs in sections.items():
-        deps_graph = compute_dependency_graph(exprs)
-
-        mapper = detect_fully_parallel(tree, deps_graph, mapper)
-        mapper = detect_outermost_parallel(tree, deps_graph, mapper)
-        mapper = detect_outermost_sequential_inner_parallel(tree, deps_graph, mapper)
-        mapper = detect_innermost_unitstride(tree, deps_graph, mapper)
-        mapper = detect_wrappable_iterations(tree, deps_graph, mapper)
-
-    # Global analysis
-    for k, v in list(mapper.items()):
+    for k, v in list(analysis.properties.items()):
         args = k.args
-        # SEQUENTIAL kills PARALLEL
-        properties = [i for i in v if i != PARALLEL] if SEQUENTIAL in v else v
-        properties = as_tuple(args.pop('properties')) + as_tuple(properties)
+        properties = as_tuple(args.pop('properties')) + as_tuple(v)
         mapper[k] = Iteration(properties=properties, **args)
-
-    # Store the discovered properties in the Iteration/Expression tree
-    processed = NestedTransformer(mapper).visit(nodes)
+    processed = NestedTransformer(mapper).visit(iet)
 
     return processed
 
 
-def compute_dependency_graph(exprs):
-    """
-    Given an ordered list of :class:`Expression`, build a mapper from lvalues
-    to reads occurring in the rvalues.
-    """
-    deps_graph = OrderedDict()
-    writes = [e.output for e in exprs if e.is_tensor]
-    for i in writes:
-        for e in exprs:
-            i_reads = [j for j in e.reads if as_symbol(i) == as_symbol(j)]
-            deps_graph.setdefault(i, []).extend(i_reads)
-    return deps_graph
+@propertizer
+def mark_parallel(analysis):
+    """Update the ``analysis`` detecting the ``SEQUENTIAL`` and ``PARALLEL``
+    Iterations within ``analysis.iet``."""
+    properties = OrderedDict()
+    for tree in analysis.trees:
+        for depth, i in enumerate(tree):
+            if i in properties:
+                continue
+            dims = [j.dim for j in tree[:depth + 1]]
+            # The i-th Iteration is PARALLEL if for all dependences (d_1, ..., d_n):
+            # (d_1, ..., d_{i-1}) > 0, OR
+            # (d_1, ..., d_i) = 0
+            is_sequential = False
+            for dep in analysis.scopes[i].d_all:
+                if not ((dims[:-1] and any(dep.is_carried(d) for d in dims[:-1])) or
+                        all(dep.is_independent(d) for d in dims)):
+                    is_sequential = True
+                    break
+            properties[i] = SEQUENTIAL if is_sequential else PARALLEL
+    analysis.update(properties)
 
 
-def detect_fully_parallel(tree, deps_graph, mapper=None):
-    """
-    Update ``mapper``, a dictionary from :class:`Iteration`s to
-    :class:`IterationProperty`s, by annotating nested, fully-parallel Iterations.
-    """
-    if mapper is None:
-        mapper = OrderedDict()
-    is_FP = True
-    for k, v in deps_graph.items():
-        is_FP &= all(k.indices == i.indices for i in v)
-    if is_FP:
+@propertizer
+def mark_vectorizable(analysis):
+    """Update the ``analysis`` detecting the ``VECTOR`` Iterations within
+    ``analysis.iet``. An Iteration is VECTOR iff:
+
+        * it's the innermost in an Iteration tree, AND
+        * it's got at least an outer PARALLEL Iteration, AND
+        * it's been marked as PARALLEL or all the accesses along its dimension
+          are unit-strided.
+        """
+    for tree in analysis.trees:
+        if len(tree) == 1:
+            continue
+        else:
+            outer, innermost = tree[-2], tree[-1]
+            if PARALLEL not in analysis.properties.get(outer, []):
+                continue
+            elif PARALLEL in analysis.properties.get(innermost, []):
+                analysis.properties[innermost].append(VECTOR)
+            else:
+                accesses = analysis.scopes[innermost].accesses
+                if not accesses:
+                    continue
+                if all(accesses[0][innermost.dim] == i[innermost.dim] for i in accesses):
+                    analysis.update({innermost: VECTOR})
+
+
+@propertizer
+def mark_wrappable(analysis):
+    """Update the ``analysis`` detecting the ``WRAPPABLE`` Iterations within
+    ``analysis.iet``."""
+    # All potential WRAPPABLEs are Stepping dimensions
+    stepper = None
+    for iteration in analysis.scopes:
+        if not iteration.dim.is_Stepping:
+            continue
+        stepper = iteration
+    if not stepper:
+        return
+    stepping = stepper.dim
+    accesses = [i for i in analysis.scopes[stepper].accesses if stepping in i.findices]
+    if not accesses:
+        return
+    # Pick the /back/ and /front/ slots accessed
+    try:
+        accesses = sorted(accesses, key=cmp_to_key(lambda i, j: i.distance(j, stepping)))
+        back, front = accesses[0][stepping], accesses[-1][stepping]
+    except TypeError:
+        return
+    if back == front:
+        return
+    # Finally check that all data dependences would be honored by using the
+    # /front/ index function in place of the /back/ index function
+    for tree in analysis.trees:
         for i in tree:
-            mapper.setdefault(i, []).append(PARALLEL)
-    return mapper
-
-
-def detect_outermost_parallel(tree, deps_graph, mapper=None):
-    """
-    Update ``mapper``, a dictionary from :class:`Iteration`s to
-    :class:`IterationProperty`s, by annotating the outermost Iteration if this
-    turns out to be parallel.
-    """
-    if mapper is None:
-        mapper = OrderedDict()
-    is_OP = True
-    for k, v in deps_graph.items():
-        for i in v:
-            is_OP &= k.indices[0] == i.indices[0]
-            is_OP &= all(k.indices[0].free_symbols.isdisjoint(j.free_symbols)
-                         for j in i.indices[1:])  # not A[x,y] = A[x,x+1]
-    if is_OP:
-        mapper.setdefault(tree[0], []).append(PARALLEL)
-    return mapper
-
-
-def detect_outermost_sequential_inner_parallel(tree, deps_graph, mapper=None):
-    """
-    Update ``mapper``, a dictionary from :class:`Iteration`s to
-    :class:`IterationProperty`s, by annotating the outermost Iteration if this
-    turns out to be sequential and, if that's the case, by annotating the inner
-    Iterations as parallel.
-    """
-    if mapper is None:
-        mapper = OrderedDict()
-    candidate = tree[0]
-    filtered_mapper = OrderedDict()
-    for k, v in deps_graph.items():
-        if candidate.dim == k.base.function.indices[0] and len(v) > 0:
-            filtered_mapper[k] = v
-    if not filtered_mapper:
-        # The outermost Iteration is actually parallel
-        return mapper
-    if len({i.base.function.indices[0] for i in filtered_mapper}) > 1:
-        # Must be u[t+1] = ... v[t+1] = ... , not u[t+1] = ... v[t+2] = ...
-        return mapper
-    is_OS = True
-    for k, v in filtered_mapper.items():
-        # At least one access along the candidate dimension differs (u[t+1] = u[t] ...)
-        # AND the others either differ too or are identical to the LHS, that is
-        # u[t+1, x] = u[t, x] + u[t+1, x] OK, but u[t+1, x] = u[t, x] + u[t+1, x-1] NO
-        is_OS &= all(k.base.function.indices[0] == i.base.function.indices[0] for i in v)
-        is_OS &= any(k.indices[0] != i.indices[0] for i in v)
-        is_OS &= all(k.indices[0] != i.indices[0] or
-                     k.indices[1:] == i.indices[1:] for i in v)
-    if is_OS:
-        mapper.setdefault(candidate, []).append(SEQUENTIAL)
-        for i in tree[tree.index(candidate) + 1:]:
-            mapper.setdefault(i, []).append(PARALLEL)
-    return mapper
-
-
-def detect_innermost_unitstride(tree, deps_graph, mapper=None):
-    """
-    Update ``mapper``, a dictionary from :class:`Iteration`s to
-    :class:`IterationProperty`s, by annotating the innermost Iteration as
-    vectorizable if all array accesses along its dimension turn out to
-    be unit-strided.
-    """
-    if mapper is None:
-        mapper = OrderedDict()
-    innermost = tree[-1]
-    if not IsPerfectIteration().visit(innermost):
-        return mapper
-    if len(tree) == 1 or SEQUENTIAL in mapper.get(tree[-2], []):
-        # Heuristic: there should be at least an outer parallel Iteration
-        # to mark /innermost/ as vectorizable, otherwise it is preferable
-        # to save it for shared-memory parallelism
-        return mapper
-    is_US = True
-    for k, v in deps_graph.items():
-        is_US &= all(k.indices[-1] == i.indices[-1] for i in v)
-    if is_US or PARALLEL in mapper.get(innermost, []):
-        mapper.setdefault(innermost, []).append(VECTOR)
-    return mapper
-
-
-def detect_wrappable_iterations(tree, deps_graph, mapper=None):
-    """
-    Update ``mapper``, a dictionary from :class:`Iteration`s to
-    :class:`IterationProperty`s, by annotating an Iteration as wrappable
-    if the first and last slots accessed through modulo buffered iteration
-    can be mapped to a single slot, thus reducing the working set.
-    """
-    if mapper is None:
-        mapper = OrderedDict()
-    stepping = [i for i in tree if i.dim.is_Stepping]
-    if len(stepping) != 1:
-        return mapper
-    stepping = stepping[0]
-    is_WP = all(stepping.dim == i.base.function.indices[0] for i in deps_graph)
-    if is_WP:
-        accesses = {i.indices[0] for i in deps_graph}
-        accesses |= {i.indices[0] for i in flatten(deps_graph.values())}
-        candidate = sorted(accesses, key=lambda i: i.subs(stepping.dim, 0))[0]
-        for k, v in deps_graph.items():
-            is_WP &= all(k.indices[1:] == i.indices[1:] for i in v
-                         if candidate == i.indices[0])
-    if is_WP:
-        mapper.setdefault(stepping, []).append(WRAPPABLE)
-    return mapper
+            if i == stepper:
+                continue
+            # There must be NO writes to the /back/ timeslot
+            for access in analysis.scopes[i].accesses:
+                if access.is_write and access[stepping] == back:
+                    return
+            # All reads from the /front/ timeslot must not cause dependences with
+            # the writes in the /back/ timeslot along the /i/ dimension
+            for dep in analysis.scopes[i].d_flow:
+                if dep.source[stepping] != front or dep.sink[stepping] != back:
+                    continue
+                if dep.source.section(stepping) != dep.sink.section(stepping):
+                    return
+    analysis.update({stepper: WRAPPABLE})

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -98,7 +98,7 @@ class Operator(Callable):
         # Parameters of the Operator (Dimensions necessary for data casts)
         parameters = self.input + self.dimensions
 
-        # Group expressions based on their Stencil
+        # Group expressions based on their Stencil and data dependences
         clusters = clusterize(expressions, stencils)
 
         # Apply the Devito Symbolic Engine (DSE) for symbolic optimization
@@ -319,7 +319,7 @@ class Operator(Callable):
                 # Can I reuse any of the previously scheduled Iterations ?
                 index = 0
                 for j0, j1 in zip(entries, list(schedule)):
-                    if j0 != j1 or j0.dim in i.atomics:
+                    if j0 != j1 or j0.dim in clusters.atomics[i]:
                         break
                     root = schedule[j1]
                     index += 1

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -307,7 +307,6 @@ class Operator(Callable):
         # Build the Iteration/Expression tree
         processed = []
         schedule = OrderedDict()
-        atomics = ()
         for i in clusters:
             # Build the Expression objects to be inserted within an Iteration tree
             expressions = [Expression(v, np.int32 if i.trace.is_index(k) else self.dtype)
@@ -320,7 +319,7 @@ class Operator(Callable):
                 # Can I reuse any of the previously scheduled Iterations ?
                 index = 0
                 for j0, j1 in zip(entries, list(schedule)):
-                    if j0 != j1 or j0.dim in atomics:
+                    if j0 != j1 or j0.dim in i.atomics:
                         break
                     root = schedule[j1]
                     index += 1
@@ -346,9 +345,6 @@ class Operator(Callable):
             else:
                 # No Iterations are needed
                 processed.extend(expressions)
-
-            # Track dimensions that cannot be fused at next stage
-            atomics = i.atomics
 
         return List(body=processed)
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import pytest
 from sympy import cos, Symbol  # noqa
 
 from devito import (Dimension, Eq, TimeDimension, SteppingDimension, SpaceDimension,  # noqa
-                    Constant, Function, configuration)  # noqa
+                    Constant, Function, TimeFunction, Grid, configuration)  # noqa
 from devito.types import Scalar, Array
 from devito.ir.iet import Iteration
 from devito.tools import as_tuple
@@ -13,6 +13,13 @@ from devito.tools import as_tuple
 
 skipif_yask = pytest.mark.skipif(configuration['backend'] == 'yask',
                                  reason="YASK testing is currently restricted")
+
+
+# Testing dimensions for space and time
+grid = Grid(shape=(3, 3, 3))
+time = grid.time_dim
+t = grid.stepping_dim
+x, y, z = grid.dimensions
 
 
 def scalar(name):
@@ -32,6 +39,10 @@ def function(name, shape, dimensions):
     return Function(name=name, shape=shape, dimensions=dimensions)
 
 
+def timefunction(name):
+    return TimeFunction(name=name, grid=grid)
+
+
 @pytest.fixture(scope="session")
 def dims():
     return {'i': Dimension(name='i'),
@@ -40,14 +51,6 @@ def dims():
             'l': Dimension(name='l'),
             's': Dimension(name='s'),
             'q': Dimension(name='q')}
-
-
-# Testing dimensions for space and time
-time = TimeDimension('time', spacing=Constant(name='dt'))
-t = SteppingDimension('t', parent=time)
-x = SpaceDimension('x', spacing=Constant(name='h_x'))
-y = SpaceDimension('y', spacing=Constant(name='h_y'))
-z = SpaceDimension('z', spacing=Constant(name='h_z'))
 
 
 @pytest.fixture(scope="session")
@@ -150,17 +153,17 @@ def ti3(dims):
 
 @pytest.fixture(scope="session", autouse=True)
 def tu(dims):
-    return array('tu', (10, 3, 5, 7), (t, x, y, z)).indexify()
+    return timefunction('tu').indexify()
 
 
 @pytest.fixture(scope="session", autouse=True)
 def tv(dims):
-    return array('tv', (10, 3, 5, 7), (t, x, y, z)).indexify()
+    return timefunction('tv').indexify()
 
 
 @pytest.fixture(scope="session", autouse=True)
 def tw(dims):
-    return array('tw', (10, 3, 5, 7), (t, x, y, z)).indexify()
+    return timefunction('tw').indexify()
 
 
 @pytest.fixture(scope="session", autouse=True)

--- a/tests/test_dse.py
+++ b/tests/test_dse.py
@@ -6,10 +6,10 @@ import pytest
 from conftest import x, y, z, time, skipif_yask  # noqa
 
 from devito import Eq  # noqa
-from devito.ir import Stencil, Expression, FindNodes, TemporariesGraph, clusterize
+from devito.ir import Stencil, clusterize, TemporariesGraph
 from devito.dse import rewrite, common_subexprs_elimination, collect
 from devito.symbolics import (xreplace_constrained, iq_timeinvariant, iq_timevarying,
-                              estimate_cost, pow_to_mul)
+                              estimate_cost, pow_to_mul, indexify)
 from devito.types import Scalar
 from examples.seismic.acoustic import AcousticWaveSolver
 from examples.seismic import demo_model, RickerSource, GaborSource, Receiver
@@ -105,9 +105,10 @@ def tti_nodse():
 def test_tti_clusters_to_graph():
     solver = tti_operator()
 
-    nodes = FindNodes(Expression).visit(solver.op_fwd('centered').elemental_functions +
-                                        (solver.op_fwd('centered'),))
-    expressions = [n.expr for n in nodes]
+    expressions = solver.op_fwd('centered').args['expressions']
+    subs = solver.op_fwd('centered').args['subs']
+    expressions = [indexify(s) for s in expressions]
+    expressions = [s.xreplace(subs) for s in expressions]
     stencils = solver.op_fwd('centered')._retrieve_stencils(expressions)
     clusters = clusterize(expressions, stencils)
     assert len(clusters) == 3

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -619,14 +619,14 @@ class TestLoopScheduler(object):
     @pytest.mark.parametrize('exprs', [
         ('Eq(ti0[x,y,z], ti0[x,y,z] + ti1[x,y,z])', 'Eq(ti1[x,y,z], ti3[x,y,z])',
          'Eq(ti3[x,y,z], ti1[x,y,z] + 1.)'),
-        ('Eq(ti0[x,y,z], ti0[x,y,z-1] + ti1[x,y,z+1])', 'Eq(ti1[x,y,z], ti3[x,y,z+1])',
+        ('Eq(ti0[x,y,z], ti0[x,y,z-1] + ti1[x,y,z-1])', 'Eq(ti1[x,y,z], ti3[x,y,z-1])',
          'Eq(ti3[x,y,z], ti3[x,y,z-1] + ti0[x,y,z])'),
         ('Eq(ti0[x,y,z+2], ti0[x,y,z-1] + ti1[x,y,z+1])',
          'Eq(ti1[x,y,z+3], ti3[x,y,z+1])',
          'Eq(ti3[x,y,z+2], ti0[x,y,z+1]*ti3[x,y,z-1])'),
         ('Eq(ti0[x,y,z], ti0[x-2,y-1,z-1] + ti1[x+2,y+3,z+1])',
-         'Eq(ti1[x,y,z], ti3[x+1,y-4,z+1])',
-         'Eq(ti3[x,y,z], ti3[x+5,y,z-1] - ti0[x+3,y-2,z+4])')
+         'Eq(ti1[x+4,y+5,z+3], ti3[x+1,y-4,z+1])',
+         'Eq(ti3[x+7,y,z+2], ti3[x+5,y,z-1] - ti0[x-3,y-2,z-4])')
     ])
     def test_consistency_coupled_w_ofs(self, exprs, ti0, ti1, ti3):
         """

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -7,10 +7,11 @@ from conftest import EVAL, dims, time, x, y, z, skipif_yask
 import numpy as np
 import pytest
 
-from devito import (clear_cache, Grid, Eq, Operator, Constant, Function,
-                    TimeFunction, SparseFunction, Dimension, configuration)
+from devito import (clear_cache, Grid, Eq, Operator, Constant, Function, Backward,
+                    Forward, TimeFunction, SparseFunction, Dimension, configuration)
 from devito.foreign import Operator as OperatorForeign
-from devito.ir.iet import IsPerfectIteration, retrieve_iteration_tree
+from devito.ir.iet import (Expression, Iteration, FindNodes, IsPerfectIteration,
+                           retrieve_iteration_tree)
 
 
 def dimify(dimensions):
@@ -498,9 +499,7 @@ class TestDeclarator(object):
     def test_heap_perfect_2D_stencil(self, a, c):
         operator = Operator([Eq(a, c), Eq(c, c*a)], dse='noop', dle=None)
         assert """\
-  float (*a);
   float (*c)[j_size];
-  posix_memalign((void**)&a, 64, sizeof(float[i_size]));
   posix_memalign((void**)&c, 64, sizeof(float[i_size][j_size]));
   struct timeval start_section_0, end_section_0;
   gettimeofday(&start_section_0, NULL);
@@ -508,14 +507,13 @@ class TestDeclarator(object):
   {
     for (int j = j_s; j < j_e; j += 1)
     {
-      a[i] = c[i][j];
-      c[i][j] = a[i]*c[i][j];
+      float s0 = c[i][j];
+      c[i][j] = s0*c[i][j];
     }
   }
   gettimeofday(&end_section_0, NULL);
   timings->section_0 += (double)(end_section_0.tv_sec-start_section_0.tv_sec)\
 +(double)(end_section_0.tv_usec-start_section_0.tv_usec)/1000000;
-  free(a);
   free(c);
   return 0;""" in str(operator.ccode)
 
@@ -612,9 +610,8 @@ class TestLoopScheduler(object):
         trees = [i[0] for i in trees]
         for tree in trees:
             assert IsPerfectIteration().visit(tree[0])
-            assert len(tree[-1].nodes) == 3
-        pivot = set([j.expr for j in trees[0][-1].nodes])
-        assert all(set([j.expr for j in i[-1].nodes]) == pivot for i in trees)
+            exprs = FindNodes(Expression).visit(tree[-1])
+            assert len(exprs) == 3
 
     @pytest.mark.parametrize('exprs', [
         ('Eq(ti0[x,y,z], ti0[x,y,z] + ti1[x,y,z])', 'Eq(ti1[x,y,z], ti3[x,y,z])',
@@ -646,9 +643,91 @@ class TestLoopScheduler(object):
         trees = [i[0] for i in trees]
         for tree in trees:
             assert IsPerfectIteration().visit(tree[0])
-            assert len(tree[-1].nodes) == 3
-        pivot = set([j.expr for j in trees[0][-1].nodes])
-        assert all(set([j.expr for j in i[-1].nodes]) == pivot for i in trees)
+            exprs = FindNodes(Expression).visit(tree[-1])
+            assert len(exprs) == 3
+
+    @pytest.mark.parametrize('exprs,axis,expected,visit', [
+        # WAR 2->3; expected=2
+        (('Eq(ti0[x,y,z], ti0[x,y,z] + ti1[x,y,z])',
+          'Eq(ti1[x,y,z], ti3[x,y,z])',
+          'Eq(ti3[x,y,z], ti1[x,y,z+1] + 1.)'),
+         Forward, ['xyz'], 'xyz'),
+        # WAR 1->2, 2->3; one may think it should be expected=3, but these are all
+        # Arrays, so ti0 gets optimized through index bumping and array contraction,
+        # which results in expected=2
+        (('Eq(ti0[x,y,z], ti0[x,y,z] + ti1[x,y,z])',
+          'Eq(ti1[x,y,z], ti0[x,y,z+1])',
+          'Eq(ti3[x,y,z], ti1[x,y,z+2] + 1.)'),
+         Forward, ['xyz', 'xyz'], 'xyzz'),
+        # WAR 1->3; expected=1
+        (('Eq(ti0[x,y,z], ti0[x,y,z] + ti1[x,y,z])',
+          'Eq(ti1[x,y,z], ti3[x,y,z])',
+          'Eq(ti3[x,y,z], ti0[x,y,z+1] + 1.)'),
+         Forward, ['xyz'], 'xyz'),
+        # WAR 1->2, 2->3; WAW 1->3; expected=2
+        # ti0 is an Array, so the observation made above still holds (expected=2
+        # rather than 3)
+        (('Eq(ti0[x,y,z], ti0[x,y,z] + ti1[x,y,z])',
+          'Eq(ti1[x,y,z], 3*ti0[x,y,z+2])',
+          'Eq(ti0[x,y,0], ti0[x,y,0] + 1.)'),
+         Forward, ['xyz', 'xy'], 'xyz'),
+        # WAR 1->2; WAW 1->3; expected=3
+        # Now tu, tv, tw are not Arrays, so they must end up in separate loops
+        (('Eq(tu[t,x,y,z], tu[t,x,y,z] + tv[t,x,y,z])',
+          'Eq(tv[t,x,y,z], tu[t,x,y,z+2])',
+          'Eq(tu[t,x,y,0], tu[t,x,y,0] + 1.)'),
+         Forward, ['txyz', 'txyz', 'txy'], 'txyzz'),
+        # WAR 1->2; WAW 2->3; expected=3
+        (('Eq(tu[t,x,y,z], tu[t,x,y,z] + tv[t,x,y,z])',
+          'Eq(tv[t,x,y,z], tu[t,x,y,z+2])',
+          'Eq(tw[t,x,y,z], tv[t,x,y,z+3] + 1.)'),
+         Forward, ['txyz', 'txyz', 'txyz'], 'txyzzz'),
+        # WAR 1->2; WAW 1->3; expected=3
+        (('Eq(tu[t,x,y,z], tu[t,x,y,z] + tv[t,x,y,z])',
+          'Eq(tv[t,x,y,z], tu[t,x+2,y,z])',
+          'Eq(tu[t,3,y,0], tu[t,3,y,0] + 1.)'),
+         Forward, ['txyz', 'txyz', 'ty'], 'txyzxyzy'),
+        # WAR 1->2, WAW 2->3; expected=3
+        (('Eq(tu[t,x,y,z], tu[t,x,y,z] + tv[t,x,y,z])',
+          'Eq(tv[t,x,y,z], tu[t,x,y,z+2])',
+          'Eq(tw[t,x,y,z], tv[t,x,y+1,z] + 1.)'),
+         Forward, ['txyz', 'txyz', 'txyz'], 'txyzzyz'),
+        # WAR 1->2; WAW 1->3; expected=3
+        # Time Forward, anti dependence in time, end up in different loop nests
+        (('Eq(tu[t-1,x,y,z], tu[t,x,y,z] + tv[t,x,y,z])',
+          'Eq(tv[t,x,y,z], tu[t,x,y,z+2])',
+          'Eq(tu[t-2,x,y,0], tu[t,x,y,0] + 1.)'),
+         Forward, ['txyz', 'txyz', 'txy'], 'txyztxyztxy'),
+        # Time Backward, so flow dependences in time
+        (('Eq(tu[t-1,x,y,z], tu[t,x+3,y,z] + tv[t,x,y,z])',
+          'Eq(tv[t-1,x,y,z], tu[t,x,y,z+2])',
+          'Eq(tw[t-1,x,y,z], tu[t,x,y+1,z] + tv[t,x,y-1,z])'),
+         Backward, ['txyz'], 'txyz'),
+        # Time Backward, so flow dependences in time, interleaved with independent Eq
+        (('Eq(tu[t-1,x,y,z], tu[t,x+3,y,z] + tv[t,x,y,z])',
+          'Eq(ti0[x,y,z], ti1[x,y,z+2])',
+          'Eq(tw[t-1,x,y,z], tu[t,x,y+1,z] + tv[t,x,y-1,z])'),
+         Backward, ['txyz', 'xyz'], 'txyzxyz'),
+        # Time Backward, so flow dependences in time, interleaved with dependent Eq
+        (('Eq(ti0[x,y,z], ti1[x,y,z+2])',
+          'Eq(tu[t-1,x,y,z], tu[t,x+3,y,z] + tv[t,x,y,z])',
+          'Eq(tw[t-1,x,y,z], tu[t,x,y+1,z] + ti0[x,y-1,z])'),
+         Backward, ['xyz', 'txyz'], 'xyztxyz')
+    ])
+    def test_consistency_anti_dependences(self, exprs, axis, expected, visit,
+                                          ti0, ti1, ti3, tu, tv, tw):
+        """
+        Test that anti dependences end up generating multi loop nests, rather
+        than a single loop nest enclosing all of the equations.
+        """
+        eq1, eq2, eq3 = EVAL(exprs, ti0.base, ti1.base, ti3.base,
+                             tu.base, tv.base, tw.base)
+        op = Operator([eq1, eq2, eq3], dse='noop', dle='noop', time_axis=axis)
+        trees = retrieve_iteration_tree(op)
+        assert len(trees) == len(expected)
+        assert ["".join(i.dim.name for i in j) for j in trees] == expected
+        iters = FindNodes(Iteration).visit(op)
+        assert "".join(i.dim.name for i in iters) == visit
 
     def test_expressions_imperfect_loops(self, ti0, ti1, ti2, t0):
         """
@@ -672,9 +751,7 @@ class TestLoopScheduler(object):
         Test that bc-like equations get inserted into the same loop nest
         as the "main" equations.
         """
-        grid = Grid(shape=(3, 3, 3))
-        x, y, z = grid.dimensions
-        time = grid.time_dim
+        grid = Grid(shape=(3, 3, 3), dimensions=(x, y, z), time_dimension=time)
         a = Function(name='a', grid=grid).indexed
         b = TimeFunction(name='b', grid=grid, save=True, time_dim=6).indexed
         main = Eq(b[time + 1, x, y, z], b[time - 1, x, y, z] + a[x, y, z] + 3.*t0)


### PR DESCRIPTION
~*** This should go in after #421, which will make the diff much cleaner ***~
EDIT: ready for review

This PR exploits the previously merged #401 and #406 PRs to perform advanced data dependence analysis in Devito. Some details about this had already been provided in the descriptions of these two PRs.

There are three major things going on here:
* Reimplementation of cluster fusion, based on vector distance analysis. This is what will fix loop construction for staggered, @mlange05 . So this new piece of code **is** actually fixing bugs that weren't exposed with the currently available use cases. This happens in ``ir/clusters/algorithms.py``.
* Reimplementation of Iteration analysis; that is, the engine that detects, for example, parallel and sequential loops. This happens in ``ir/iet/analysis.py``. This is again based on vector distance analysis, which **vastly** improves the quality of the implementation, besides fixing (subtle) bugs not exposed by the current use cases.
* Introduce a significant number of tests checking loop scheduling. In particular, look at ``tests/test_operator.py::test_consistency_anti_dependences``