### PR TITLE
Timeslot avoidance optimisation

### DIFF
--- a/examples/seismic/acoustic/gradient_example.py
+++ b/examples/seismic/acoustic/gradient_example.py
@@ -120,10 +120,10 @@ class GradientExample(object):
         G = np.dot(gradient.reshape(-1), dm.reshape(-1))
         # FWI Gradient test
         H = [0.5, 0.25, .125, 0.0625, 0.0312, 0.015625, 0.0078125]
-        error1 = np.zeros(7)
-        error2 = np.zeros(7)
+        err1 = np.zeros(len(H))
+        err2 = np.zeros(len(H))
 
-        for i in range(0, 7):
+        for i in range(len(H)):
             # Add the perturbation to the model
             mloc = m0 + H[i] * dm
             # Set field to zero (we're re-using it)
@@ -134,14 +134,13 @@ class GradientExample(object):
                                        src=self.src, dt=self.dt)
             d = self.rec.data
             # First order error Phi(m0+dm) - Phi(m0)
-            error1[i] = np.absolute(.5*linalg.norm(d - self.rec_t.data)**2 - F0)
+            err1[i] = np.absolute(.5*linalg.norm(d - self.rec_t.data)**2 - F0)
             # Second order term r Phi(m0+dm) - Phi(m0) - <J(m0)^T \delta d, dm>
-            error2[i] = np.absolute(.5*linalg.norm(d - self.rec_t.data)**2 - F0 - H[i]
-                                    * G)
+            err2[i] = np.absolute(.5*linalg.norm(d - self.rec_t.data)**2 - F0 - H[i] * G)
 
-        # Test slope of the  tests
-        p1 = np.polyfit(np.log10(H), np.log10(error1), 1)
-        p2 = np.polyfit(np.log10(H), np.log10(error2), 1)
+        # Test slope of the tests
+        p1 = np.polyfit(np.log10(H), np.log10(err1), 1)
+        p2 = np.polyfit(np.log10(H), np.log10(err2), 1)
         assert np.isclose(p1[0], 1.0, rtol=0.1)
         assert np.isclose(p2[0], 2.0, rtol=0.1)
 

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -53,7 +53,7 @@ def test_acoustic_save_and_nosave(shape=(50, 50), spacing=(15.0, 15.0), tn=500.,
     field_last_time_step = np.copy(u.data[last_time_step, :, :])
     rec_bk = np.copy(rec.data)
     rec, u, summary = solver.forward(save=False)
-    last_time_step = (last_time_step) % (time_order + 1)
+    last_time_step = solver.source.nt % time_order
     assert(np.allclose(u.data[last_time_step, :, :], field_last_time_step))
     assert(np.allclose(rec.data, rec_bk))
 

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -371,12 +371,12 @@ class TestArguments(object):
         # Test dimension override via the buffered dimenions
         a.data[0] = 0.
         op(a=a, t=6)
-        assert(np.allclose(a.data[1], 5.))
+        assert(np.allclose(a.data[0], 6.))
 
         # Test dimension override via the parent dimenions
         a.data[0] = 0.
         op(a=a, time=5)
-        assert(np.allclose(a.data[0], 4.))
+        assert(np.allclose(a.data[0], 5.))
 
     def test_override_composite_data(self):
         i, j = dimify('i j')


### PR DESCRIPTION
This should go in after #422 

Use data dependence analysis to reuse buffered timeslots whenever possible, thus reducing the working set. In practice, this depends on things such as the chosen timestepping scheme

Trivial example.
Before:
```
u[t+1, ..] = f(u[t, ...], u[t-1, ...])
```
With this PR, in some cases :
```
u[t+1, ..] = f(u[t, ...], u[t+1, ...])
```