### PR TITLE
Operator bug

### DIFF
--- a/devito/operator.py
+++ b/devito/operator.py
@@ -203,6 +203,11 @@ class Operator(Callable):
 
         arguments = self._default_args()
 
+        none_args = dict([(k, v) for (k, v) in arguments.items() if v is None])
+        if len(none_args) > 0:
+            raise ValueError("Unknown value for arguments: " +
+                             ", ".join(none_args.keys()))
+
         if autotune:
             arguments = self._autotune(arguments)
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [flake8]
 max-line-length = 90
-ignore = F403,E226,E731,W503,F405
+ignore = F403,E226,E731,W503,F405, E722, E741
 
 [tool:pytest]
 python_files = test_*.py example_*.py

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -5,8 +5,7 @@ from pyrevolve import Revolver
 import numpy as np
 from conftest import skipif_yask
 import pytest
-from devito import Grid, TimeFunction, Operator, Backward, Function
-from sympy import Eq
+from devito import Grid, TimeFunction, Operator, Backward, Function, Eq
 
 
 @skipif_yask

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -470,15 +470,17 @@ class TestArguments(object):
         op_arguments, _ = op.arguments(b=b1, time=nt - 1, time_e=nt - 2)
         assert(op_arguments[time.start_name] == 0)
         assert(op_arguments[time.end_name] == nt - 2)
-        
+
     def test_no_value(self, const):
         grid = Grid(shape=(3, 5))
         a = TimeFunction(name='a', grid=grid)
         eqn = Eq(a, a + 1.*const)
         op = Operator(eqn)
         with pytest.raises(ValueError):
-            op(t=12) # This should raise an exception because we don't have a value for constant
+            # This should raise an exception because we don't have a value for constant
+            op(t=12)
         op(t=12, constant=1)
+
 
 @skipif_yask
 class TestDeclarator(object):

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -470,7 +470,15 @@ class TestArguments(object):
         op_arguments, _ = op.arguments(b=b1, time=nt - 1, time_e=nt - 2)
         assert(op_arguments[time.start_name] == 0)
         assert(op_arguments[time.end_name] == nt - 2)
-
+        
+    def test_no_value(self, const):
+        grid = Grid(shape=(3, 5))
+        a = TimeFunction(name='a', grid=grid)
+        eqn = Eq(a, a + 1.*const)
+        op = Operator(eqn)
+        with pytest.raises(ValueError):
+            op(t=12) # This should raise an exception because we don't have a value for constant
+        op(t=12, constant=1)
 
 @skipif_yask
 class TestDeclarator(object):


### PR DESCRIPTION
This was originally part of #424 but I pulled it out because it seems to trigger an unrelated bug.

This PR passes all tests without OpenMP, but fails to compile with OpenMP.

~I believe this might be related to [this bug](https://gcc.gnu.org/bugzilla/show_bug.cgi?id=35158)~