### PR TITLE
Update TimeFunction API to generalise save

### DIFF
--- a/devito/function.py
+++ b/devito/function.py
@@ -2,6 +2,7 @@ import numpy as np
 import sympy
 from collections import OrderedDict
 from functools import partial
+from psutil import virtual_memory
 
 from devito.parameters import configuration
 from devito.logger import debug, error, warning
@@ -374,7 +375,11 @@ class TimeFunction(Function):
                 if not isinstance(self.save, int):
                     raise ValueError("save must be an int indicating the number of " +
                                      "timesteps to be saved (is %s)" % type(self.save))
-                
+                available_mem = virtual_memory().available
+
+                if np.dtype(self.dtype).itemsize * self.save > available_mem:
+                    warning("Trying to allocate more memory for symbol %s " % self.name +
+                            "than available on physical device, this will start swapping")
                 self.time_size = self.save
             else:
                 self.time_size = self.time_order + 1

--- a/devito/function.py
+++ b/devito/function.py
@@ -371,7 +371,10 @@ class TimeFunction(Function):
             self.save = kwargs.get('save', None)
 
             if self.save is not None:
-                assert(isinstance(self.save, int))
+                if not isinstance(self.save, int):
+                    raise ValueError("save must be an int indicating the number of " +
+                                     "timesteps to be saved (is %s)" % type(self.save))
+                
                 self.time_size = self.save
             else:
                 self.time_size = self.time_order + 1

--- a/devito/function.py
+++ b/devito/function.py
@@ -327,7 +327,7 @@ class TimeFunction(Function):
     :param staggered: (Optional) tuple containing staggering offsets.
     :param dtype: (Optional) data type of the buffered data
     :param save: Save the intermediate results to the data buffer. Defaults
-                 to `None`, indicating the use of alternating buffers. If
+                 to ``None``, indicating the use of alternating buffers. If
                  intermediate results are required, the value of save must
                  be set to the required size of the time dimension.
     :param time_dim: The :class:`Dimension` object to use to represent time in this
@@ -414,20 +414,17 @@ class TimeFunction(Function):
         grid = kwargs.get('grid', None)
         time_dim = kwargs.get('time_dim', None)
 
-        if time_dim is not None:
-            assert(isinstance(time_dim, TimeDimension))
-
         if grid is None:
             error('TimeFunction objects require a grid parameter.')
             raise ValueError('No grid provided for TimeFunction.')
 
-        if time_dim is not None:
-            tidx = time_dim
-        else:
-            tidx = grid.time_dim if save else grid.stepping_dim
+        if time_dim is None:
+            time_dim = grid.time_dim if save else grid.stepping_dim
+
+        assert(isinstance(time_dim, Dimension) and time_dim.is_Time)
 
         _indices = Function._indices(**kwargs)
-        return tuple([tidx] + list(_indices))
+        return tuple([time_dim] + list(_indices))
 
     @property
     def dim(self):

--- a/devito/ir/iet/nodes.py
+++ b/devito/ir/iet/nodes.py
@@ -465,7 +465,8 @@ class Callable(Node):
         self.parameters = as_tuple(args)
 
     def __repr__(self):
-        parameters = ",".join([c.dtype_to_ctype(i.dtype) for i in self.parameters])
+        parameters = ",".join(['void*' if i.is_PtrArgument else c.dtype_to_ctype(i.dtype)
+                               for i in self.parameters])
         body = "\n\t".join([str(s) for s in self.body])
         return "Function[%s]<%s; %s>::\n\t%s" % (self.name, self.retval, parameters, body)
 

--- a/devito/ir/support/stencil.py
+++ b/devito/ir/support/stencil.py
@@ -246,6 +246,16 @@ class Stencil(DefaultOrderedDict):
         """
         return Stencil(self.entries)
 
+    def replace(self, mapper):
+        """
+        Return a new Stencil in which a key ``k`` (dimension) appearing in
+        ``mapper``  is replaced by ``mapper[k]``. The original order is therefore
+        unchangend, but a new dictionary is produced with potentially different
+        keys.
+        """
+        return Stencil([(k if k not in mapper else mapper[k], set(v))
+                        for k, v in self.items()])
+
     def __eq__(self, other):
         return self.entries == other.entries
 

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -420,12 +420,7 @@ class Operator(Callable):
 
         # Filter out aliasing stepping dimensions
         mapper = {d.parent: d for d in dimensions if d.is_Stepping}
-        for i in list(stencils):
-            for d in i.dimensions:
-                if d in mapper:
-                    i[mapper[d]] = i.pop(d).union(i.get(mapper[d], set()))
-
-        return stencils
+        return [i.replace(mapper) for i in stencils]
 
     def _retrieve_symbols(self, expressions):
         """

--- a/examples/seismic/acoustic/gradient_example.py
+++ b/examples/seismic/acoustic/gradient_example.py
@@ -83,13 +83,12 @@ class GradientExample(object):
     @property
     def temp_field(self):
         return TimeFunction(name="u", grid=self.model.grid, time_order=self.time_order,
-                            space_order=self.space_order, save=False)
+                            space_order=self.space_order, save=None)
 
     @cached_property
     def forward_field(self):
-        return TimeFunction(name="u", grid=self.model.grid, time_dim=self.nt,
-                            time_order=self.time_order, space_order=self.space_order,
-                            save=True)
+        return TimeFunction(name="u", grid=self.model.grid, save=self.nt,
+                            time_order=self.time_order, space_order=self.space_order)
 
     @cached_property
     def adjoint_field(self):

--- a/examples/seismic/acoustic/operators.py
+++ b/examples/seismic/acoustic/operators.py
@@ -73,7 +73,7 @@ def ForwardOperator(model, source, receiver, time_order=2, space_order=4,
 
     # Create symbols for forward wavefield, source and receivers
     u = TimeFunction(name='u', grid=model.grid,
-                     save=save, time_dim=source.nt if save else None,
+                     save=source.nt if save else None,
                      time_order=2, space_order=space_order)
     src = PointSource(name='src', grid=model.grid, ntime=source.nt,
                       npoint=source.npoint)
@@ -110,7 +110,7 @@ def AdjointOperator(model, source, receiver, time_order=2, space_order=4, **kwar
     """
     m, damp = model.m, model.damp
 
-    v = TimeFunction(name='v', grid=model.grid, save=False,
+    v = TimeFunction(name='v', grid=model.grid, save=None,
                      time_order=2, space_order=space_order)
     srca = PointSource(name='srca', grid=model.grid, ntime=source.nt,
                        npoint=source.npoint)
@@ -150,9 +150,9 @@ def GradientOperator(model, source, receiver, time_order=2, space_order=4, save=
 
     # Gradient symbol and wavefield symbols
     grad = Function(name='grad', grid=model.grid)
-    u = TimeFunction(name='u', grid=model.grid, save=save, time_dim=source.nt if save
+    u = TimeFunction(name='u', grid=model.grid, save=source.nt if save
                      else None, time_order=2, space_order=space_order)
-    v = TimeFunction(name='v', grid=model.grid, save=False,
+    v = TimeFunction(name='v', grid=model.grid, save=None,
                      time_order=2, space_order=space_order)
     rec = Receiver(name='rec', grid=model.grid, ntime=receiver.nt,
                    npoint=receiver.npoint)
@@ -197,9 +197,9 @@ def BornOperator(model, source, receiver, time_order=2, space_order=4, **kwargs)
                    npoint=receiver.npoint)
 
     # Create wavefields and a dm field
-    u = TimeFunction(name="u", grid=model.grid, save=False,
+    u = TimeFunction(name="u", grid=model.grid, save=None,
                      time_order=2, space_order=space_order)
-    U = TimeFunction(name="U", grid=model.grid, save=False,
+    U = TimeFunction(name="U", grid=model.grid, save=None,
                      time_order=2, space_order=space_order)
     dm = Function(name="dm", grid=model.grid)
 

--- a/examples/seismic/acoustic/wavesolver.py
+++ b/examples/seismic/acoustic/wavesolver.py
@@ -94,8 +94,8 @@ class AcousticWaveSolver(object):
 
         # Create the forward wavefield if not provided
         if u is None:
-            u = TimeFunction(name='u', grid=self.model.grid, save=save,
-                             time_dim=self.source.nt if save else None,
+            u = TimeFunction(name='u', grid=self.model.grid,
+                             save=self.source.nt if save else None,
                              time_order=2, space_order=self.space_order)
 
         # Pick m from model unless explicitly provided
@@ -129,7 +129,7 @@ class AcousticWaveSolver(object):
 
         # Create the adjoint wavefield if not provided
         if v is None:
-            v = TimeFunction(name='v', grid=self.model.grid, save=False,
+            v = TimeFunction(name='v', grid=self.model.grid, save=None,
                              time_order=2, space_order=self.space_order)
 
         # Pick m from model unless explicitly provided
@@ -161,7 +161,7 @@ class AcousticWaveSolver(object):
 
         # Create the forward wavefield
         if v is None:
-            v = TimeFunction(name='v', grid=self.model.grid, save=False,
+            v = TimeFunction(name='v', grid=self.model.grid, save=None,
                              time_order=2, space_order=self.space_order)
 
         # Pick m from model unless explicitly provided

--- a/examples/seismic/tutorials/02_rtm.ipynb
+++ b/examples/seismic/tutorials/02_rtm.ipynb
@@ -113,9 +113,7 @@
   {
    "cell_type": "code",
    "execution_count": 3,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -179,9 +177,7 @@
   {
    "cell_type": "code",
    "execution_count": 4,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -272,9 +268,7 @@
   {
    "cell_type": "code",
    "execution_count": 8,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -368,9 +362,7 @@
   {
    "cell_type": "code",
    "execution_count": 9,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [],
    "source": [
     "# Define gradient operator for imaging\n",
@@ -384,7 +376,7 @@
     "    v = TimeFunction(name='v', grid=model.grid, time_order=2, space_order=4)\n",
     "\n",
     "    u = TimeFunction(name='u', grid=model.grid, time_order=2, space_order=4,\n",
-    "                     save=True, time_dim=nt)\n",
+    "                     save=nt)\n",
     "    \n",
     "    # Define the wave equation, but with a negated damping term\n",
     "    eqn = model.m * v.dt2 - v.laplace - model.damp * v.dt\n",
@@ -423,9 +415,7 @@
   {
    "cell_type": "code",
    "execution_count": 10,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -452,9 +442,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -512,9 +500,7 @@
   {
    "cell_type": "code",
    "execution_count": 12,
-   "metadata": {
-    "collapsed": false
-   },
+   "metadata": {},
    "outputs": [
     {
      "data": {
@@ -568,7 +554,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.2"
+   "version": "3.4.3"
   },
   "widgets": {
    "state": {},

--- a/examples/seismic/tutorials/03_fwi.ipynb
+++ b/examples/seismic/tutorials/03_fwi.ipynb
@@ -647,7 +647,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.4.3"
   },
   "widgets": {
    "state": {},

--- a/examples/seismic/tutorials/06_skimage_tv.ipynb
+++ b/examples/seismic/tutorials/06_skimage_tv.ipynb
@@ -400,7 +400,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.4.3"
   },
   "widgets": {
    "state": {},

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -99,7 +99,7 @@ def test_index_alignment(const):
     order_of_eqn = 1
     modulo_factor = order_of_eqn + 1
     last_time_step_u = nt - order_of_eqn
-    u = TimeFunction(name='u', grid=grid, save=True, time_dim=nt)
+    u = TimeFunction(name='u', grid=grid, save=nt)
     # Increment one in the forward pass 0 -> 1 -> 2 -> 3
     fwd_eqn = Eq(u.indexed[time+1, x, y], u.indexed[time, x, y] + 1.*const)
     fwd_op = Operator(fwd_eqn)
@@ -107,7 +107,7 @@ def test_index_alignment(const):
     last_time_step_v = (last_time_step_u) % modulo_factor
     # Last time step should be equal to the number of timesteps we ran
     assert(np.allclose(u.data[last_time_step_u, :, :], nt - order_of_eqn))
-    v = TimeFunction(name='v', grid=grid, save=False)
+    v = TimeFunction(name='v', grid=grid, save=None)
     v.data[last_time_step_v, :, :] = u.data[last_time_step_u, :, :]
     # Decrement one in the reverse pass 3 -> 2 -> 1 -> 0
     adj_eqn = Eq(v.indexed[t-1, x, y], v.indexed[t, x, y] - 1.*const)

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -864,8 +864,7 @@ class TestForeign(object):
     def test_explicit_run(self):
         time_dim = 6
         grid = Grid(shape=(11, 11))
-        a = TimeFunction(name='a', grid=grid, time_order=1,
-                         save=time_dim)
+        a = TimeFunction(name='a', grid=grid, time_order=1, save=time_dim)
         eqn = Eq(a.forward, a + 1.)
         op = Operator(eqn)
         assert isinstance(op, OperatorForeign)

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -322,7 +322,7 @@ class TestArguments(object):
         """Test that the dimension sizes are being inferred correctly"""
         grid = Grid(shape=(3, 5, 7))
         a = Function(name='a', grid=grid)
-        b = TimeFunction(name='b', grid=grid, save=True, time_dim=nt)
+        b = TimeFunction(name='b', grid=grid, save=nt)
         op = Operator(Eq(b, a))
 
         time = b.indices[0]
@@ -336,7 +336,7 @@ class TestArguments(object):
         shape = (10, 10, 10)
         grid = Grid(shape=shape, dimensions=(i, j, k))
         a = Function(name='a', grid=grid).indexed
-        b = TimeFunction(name='b', grid=grid, save=True, time_dim=nt)
+        b = TimeFunction(name='b', grid=grid, save=nt)
         time = b.indices[0]
         eqn = Eq(b.indexed[time + 1, i, j, k], b.indexed[time - 1, i, j, k]
                  + b.indexed[time, i, j, k] + a[i, j, k])
@@ -352,7 +352,7 @@ class TestArguments(object):
         shape = (10, 10, 10)
         grid = Grid(shape=shape, dimensions=(i, j, k))
         a = Function(name='a', grid=grid).indexed
-        b = TimeFunction(name='b', grid=grid, save=True, time_dim=nt)
+        b = TimeFunction(name='b', grid=grid, save=nt)
         time = b.indices[0]
         eqn = Eq(b.indexed[time + 1, i, j, k], b.indexed[time - 1, i, j, k]
                  + b.indexed[time, i, j, k] + a[i, j, k])
@@ -442,10 +442,10 @@ class TestArguments(object):
         shape = (10, 10, 10)
         grid = Grid(shape=shape, dimensions=(i, j, k))
         a = Function(name='a', grid=grid).indexed
-        b_function = TimeFunction(name='b', grid=grid, save=True, time_dim=nt)
+        b_function = TimeFunction(name='b', grid=grid, save=nt)
         b = b_function.indexed
         time = b_function.indices[0]
-        b1 = TimeFunction(name='b1', grid=grid, save=True, time_dim=nt+1).indexed
+        b1 = TimeFunction(name='b1', grid=grid, save=nt+1).indexed
         eqn = Eq(b[time, i, j, k], a[i, j, k])
         op = Operator(eqn)
 
@@ -753,7 +753,7 @@ class TestLoopScheduler(object):
         """
         grid = Grid(shape=(3, 3, 3), dimensions=(x, y, z), time_dimension=time)
         a = Function(name='a', grid=grid).indexed
-        b = TimeFunction(name='b', grid=grid, save=True, time_dim=6).indexed
+        b = TimeFunction(name='b', grid=grid, save=6).indexed
         main = Eq(b[time + 1, x, y, z], b[time - 1, x, y, z] + a[x, y, z] + 3.*t0)
         bcs = [Eq(b[time, 0, y, z], 0.),
                Eq(b[time, x, 0, z], 0.),
@@ -845,7 +845,7 @@ class TestLoopScheduler(object):
         time = grid.time_dim
         t = grid.stepping_dim
         u1 = TimeFunction(name='u1', grid=grid)
-        u2 = TimeFunction(name='u2', grid=grid, save=True, time_dim=2)
+        u2 = TimeFunction(name='u2', grid=grid, save=2)
         eqn_1 = Eq(u1.indexed[t+1, x, y, z], u1.indexed[t, x, y, z] + 1.)
         eqn_2 = Eq(u2.indexed[time+1, x, y, z], u2.indexed[time, x, y, z] + 1.)
         op = Operator([eqn_1, eqn_2], dse='noop', dle='noop')
@@ -865,7 +865,7 @@ class TestForeign(object):
         time_dim = 6
         grid = Grid(shape=(11, 11))
         a = TimeFunction(name='a', grid=grid, time_order=1,
-                         time_dim=time_dim, save=True)
+                         save=time_dim)
         eqn = Eq(a.forward, a + 1.)
         op = Operator(eqn)
         assert isinstance(op, OperatorForeign)

--- a/tests/test_save.py
+++ b/tests/test_save.py
@@ -27,14 +27,14 @@ def run_simulation(save=False, dx=0.01, dy=0.01, a=0.5, timesteps=100):
 
     grid = Grid(shape=(nx, ny))
     u = TimeFunction(
-        name='u', grid=grid, time_dim=timesteps, initializer=initializer,
-        time_order=1, space_order=2, save=save
+        name='u', grid=grid, save=timesteps, initializer=initializer,
+        time_order=1, space_order=2
     )
 
     eqn = Eq(u.dt, a * (u.dx2 + u.dy2))
     stencil = solve(eqn, u.forward)[0]
     op = Operator(Eq(u.forward, stencil), time_axis=Forward)
-    op.apply(time=timesteps, dt=dt)
+    op.apply(time=timesteps-1, dt=dt)
 
     if save:
         return u.data[timesteps - 1, :]

--- a/tests/test_timestepping.py
+++ b/tests/test_timestepping.py
@@ -15,28 +15,28 @@ def grid(shape=(11, 11)):
 def a(grid):
     """Forward time data object, unrolled (save=True)"""
     return TimeFunction(name='a', grid=grid, time_order=1,
-                        time_dim=6, save=True)
+                        save=6)
 
 
 @pytest.fixture
 def b(grid):
     """Backward time data object, unrolled (save=True)"""
     return TimeFunction(name='b', grid=grid, time_order=1,
-                        time_dim=6, save=True)
+                        save=6)
 
 
 @pytest.fixture
 def c(grid):
     """Forward time data object, buffered (save=False)"""
     return TimeFunction(name='c', grid=grid, time_order=1,
-                        save=False, time_axis=Forward)
+                        save=None, time_axis=Forward)
 
 
 @pytest.fixture
 def d(grid):
     """Forward time data object, unrolled (save=True), end order"""
     return TimeFunction(name='d', grid=grid, time_order=2,
-                        time_dim=6, save=True)
+                        save=6)
 
 
 @skipif_yask

--- a/tests/test_timestepping.py
+++ b/tests/test_timestepping.py
@@ -14,29 +14,25 @@ def grid(shape=(11, 11)):
 @pytest.fixture
 def a(grid):
     """Forward time data object, unrolled (save=True)"""
-    return TimeFunction(name='a', grid=grid, time_order=1,
-                        save=6)
+    return TimeFunction(name='a', grid=grid, time_order=1, save=6)
 
 
 @pytest.fixture
 def b(grid):
     """Backward time data object, unrolled (save=True)"""
-    return TimeFunction(name='b', grid=grid, time_order=1,
-                        save=6)
+    return TimeFunction(name='b', grid=grid, time_order=1, save=6)
 
 
 @pytest.fixture
 def c(grid):
     """Forward time data object, buffered (save=False)"""
-    return TimeFunction(name='c', grid=grid, time_order=1,
-                        save=None, time_axis=Forward)
+    return TimeFunction(name='c', grid=grid, time_order=1, save=None, time_axis=Forward)
 
 
 @pytest.fixture
 def d(grid):
     """Forward time data object, unrolled (save=True), end order"""
-    return TimeFunction(name='d', grid=grid, time_order=2,
-                        save=6)
+    return TimeFunction(name='d', grid=grid, time_order=2, save=6)
 
 
 @skipif_yask


### PR DESCRIPTION
With this PR, we change the `TimeFunction` API so that instead of using `save=True` in combination with `time_dim=nt`, we just use `save=nt` (and `save=None` for the `save=False` case). All tests and examples have been updated to use the new API which looks cleaner. 

`time_dim` is now changed as a means of setting the symbolic `Dimension` object used to represent the `TimeFunction`'s time dimension internally. This is currently being debated in slack.

Also included are two unrelated bug-fixes from @FabioLuporini :
1. `repr(Operator)` now works
2. Loop scheduling bug when `time` and `t` are used in the same expression - we now generate the correct loop nest. Test included for this. 

