### PR TITLE
Fix offsets for explicitly passed arguments

### DIFF
--- a/devito/arguments.py
+++ b/devito/arguments.py
@@ -335,17 +335,15 @@ def infer_dimension_values_tuple(value, rtargs, offsets=None):
         default to 0.
     """
     size_arg, start_arg, end_arg = rtargs
-    start_offset = 0 if offsets is None else offsets.get(start_arg.name, 0)
-    end_offset = 0 if offsets is None else offsets.get(end_arg.name, 0)
     if not isinstance(value, tuple):
         # scalar
-        value = (value, start_arg.default_value + start_offset, value + end_offset)
+        value = (value, start_arg.default_value, value)
     else:
         if len(value) == 2:
             # 2-tuple
             # Assume we've been passed a (start, end) tuple
             start, end = value
-            value = (end, start + start_offset, end + end_offset)
+            value = (end, start, end)
         elif len(value) != 3:
             raise InvalidArgument("Expected either a scalar value or a tuple(2/3)")
     return value

--- a/examples/seismic/tutorials/01_modelling.ipynb
+++ b/examples/seismic/tutorials/01_modelling.ipynb
@@ -466,7 +466,7 @@
     }
    ],
    "source": [
-    "#NBVAL_SKIP\n",
+    "#NBVAL_IGNORE_OUTPUT\n",
     "from examples.seismic import plot_shotrecord\n",
     "\n",
     "plot_shotrecord(rec.data, model, t0, tn)"

--- a/examples/seismic/tutorials/02_rtm.ipynb
+++ b/examples/seismic/tutorials/02_rtm.ipynb
@@ -514,7 +514,7 @@
     }
    ],
    "source": [
-    "#NBVAL_SKIP\n",
+    "#NBVAL_IGNORE_OUTPUT\n",
     "from examples.seismic import plot_image\n",
     "\n",
     "# Plot the inverted image\n",

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -103,7 +103,7 @@ def test_index_alignment(const):
     # Increment one in the forward pass 0 -> 1 -> 2 -> 3
     fwd_eqn = Eq(u.indexed[time+1, x, y], u.indexed[time, x, y] + 1.*const)
     fwd_op = Operator(fwd_eqn)
-    fwd_op(time=last_time_step_u, constant=1)
+    fwd_op(time=nt, constant=1)
     last_time_step_v = (last_time_step_u) % modulo_factor
     # Last time step should be equal to the number of timesteps we ran
     assert(np.allclose(u.data[last_time_step_u, :, :], nt - order_of_eqn))
@@ -112,7 +112,7 @@ def test_index_alignment(const):
     # Decrement one in the reverse pass 3 -> 2 -> 1 -> 0
     adj_eqn = Eq(v.indexed[t-1, x, y], v.indexed[t, x, y] - 1.*const)
     adj_op = Operator(adj_eqn, time_axis=Backward)
-    adj_op(t=(nt - order_of_eqn), constant=1)
+    adj_op(t=nt, constant=1)
     # Last time step should be back to 0
     assert(np.allclose(v.data[0, :, :], 0))
 

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -93,16 +93,12 @@ def test_index_alignment(const):
     """
     nt = 10
     grid = Grid(shape=(3, 5))
-    time = grid.time_dim
-    t = grid.stepping_dim
-    x, y = grid.dimensions
     order_of_eqn = 1
     modulo_factor = order_of_eqn + 1
     last_time_step_u = nt - order_of_eqn
     u = TimeFunction(name='u', grid=grid, save=nt)
     # Increment one in the forward pass 0 -> 1 -> 2 -> 3
-    fwd_eqn = Eq(u.indexed[time+1, x, y], u.indexed[time, x, y] + 1.*const)
-    fwd_op = Operator(fwd_eqn)
+    fwd_op = Operator(Eq(u.forward, u + 1.*const))
     fwd_op(time=nt, constant=1)
     last_time_step_v = (last_time_step_u) % modulo_factor
     # Last time step should be equal to the number of timesteps we ran
@@ -110,7 +106,7 @@ def test_index_alignment(const):
     v = TimeFunction(name='v', grid=grid, save=None)
     v.data[last_time_step_v, :, :] = u.data[last_time_step_u, :, :]
     # Decrement one in the reverse pass 3 -> 2 -> 1 -> 0
-    adj_eqn = Eq(v.indexed[t-1, x, y], v.indexed[t, x, y] - 1.*const)
+    adj_eqn = Eq(v.backward, v - 1.*const)
     adj_op = Operator(adj_eqn, time_axis=Backward)
     adj_op(t=nt, constant=1)
     # Last time step should be back to 0
@@ -134,7 +130,7 @@ def test_index_alignment(const):
     # Checkpointed version doesn't require to save u
     u_nosave = TimeFunction(name='u_n', grid=grid)
     # change equations to use new symbols
-    fwd_eqn_2 = Eq(u_nosave.indexed[t+1, x, y], u_nosave.indexed[t, x, y] + 1.*const)
+    fwd_eqn_2 = Eq(u_nosave.forward, u_nosave + 1.*const)
     fwd_op_2 = Operator(fwd_eqn_2)
     cp = DevitoCheckpoint([u_nosave])
     wrap_fw = CheckpointOperator(fwd_op_2, time=nt, constant=1)

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -359,7 +359,7 @@ class TestArguments(object):
         op = Operator(eqn)
         op_arguments, _ = op.arguments(time=nt-10)
         assert(op_arguments[time.start_name] == 0)
-        assert(op_arguments[time.end_name] == nt - 8)
+        assert(op_arguments[time.end_name] == nt - 10)
 
     def test_dimension_size_override(self):
         """Test explicit overrides for the leading time dimension"""

--- a/tests/test_save.py
+++ b/tests/test_save.py
@@ -34,7 +34,7 @@ def run_simulation(save=False, dx=0.01, dy=0.01, a=0.5, timesteps=100):
     eqn = Eq(u.dt, a * (u.dx2 + u.dy2))
     stencil = solve(eqn, u.forward)[0]
     op = Operator(Eq(u.forward, stencil), time_axis=Forward)
-    op.apply(time=timesteps-1, dt=dt)
+    op.apply(time=timesteps, dt=dt)
 
     if save:
         return u.data[timesteps - 1, :]

--- a/tests/test_yask.py
+++ b/tests/test_yask.py
@@ -173,7 +173,7 @@ class TestOperatorSimple(object):
         u = TimeFunction(name='yu4D', grid=grid, space_order=space_order)
         u.data.with_halo[:] = 0.
         op = Operator(Eq(u.forward, u + 1.))
-        op(yu4D=u, t=1)
+        op(yu4D=u, t=2)
         assert 'run_solution' in str(op)
         # Chech that the domain size has actually been written to
         assert np.all(u.data[1] == 1.)
@@ -192,7 +192,7 @@ class TestOperatorSimple(object):
         u = TimeFunction(name='yu4D', grid=grid, space_order=0)
         u.data.with_halo[:] = 0.
         op = Operator(Eq(u.forward, u + 1.))
-        op(yu4D=u, t=11)
+        op(yu4D=u, t=12)
         assert 'run_solution' in str(op)
         assert np.all(u.data[0] == 10.)
         assert np.all(u.data[1] == 11.)
@@ -214,7 +214,7 @@ class TestOperatorSimple(object):
         v = TimeFunction(name='yv4D', grid=grid, space_order=space_order)
         v.data.with_halo[:] = 1.
         op = Operator(Eq(v.forward, v.laplace + 6*v), subs=grid.spacing_map)
-        op(yv4D=v, t=1)
+        op(yv4D=v, t=2)
         assert 'run_solution' in str(op)
         # Chech that the domain size has actually been written to
         assert np.all(v.data[1] == 6.)
@@ -234,7 +234,7 @@ class TestOperatorSimple(object):
         u.data.with_halo[:] = 1.
         v.data.with_halo[:] = 2.
         op = Operator(Eq(v.forward, u + v))
-        op(yu4D=u, yv4D=v, t=1)
+        op(yu4D=u, yv4D=v, t=2)
         assert 'run_solution' in str(op)
         # Chech that the domain size has actually been written to
         assert np.all(v.data[1] == 3.)
@@ -270,7 +270,7 @@ class TestOperatorSimple(object):
                Eq(v.indexed[t + 1, 0, 2, z], v.indexed[t + 1, 0, 2, z] + 2.),
                Eq(v.indexed[t + 1, 0, 5, z], v.indexed[t + 1, 0, 5, z] + 2.)]
         op = Operator(eqs)
-        op(yu4D=u, yv4D=v, t=1)
+        op(yu4D=u, yv4D=v, t=2)
         assert 'run_solution' in str(op)
         assert len(retrieve_iteration_tree(op)) == 3
         assert np.all(u.data[0] == 0.)
@@ -314,7 +314,7 @@ class TestOperatorSimple(object):
                Eq(p.indexed[0, 2], 1.), Eq(p.indexed[0, 3], 0.),
                Eq(u.indexed[t + 1, ind(x), ind(y), ind(z)], u.indexed[t, x, y, z])]
         op = Operator(eqs, subs=grid.spacing_map)
-        op(yu4D=u, time=1)
+        op(yu4D=u, time=2)
         assert 'run_solution' not in str(op)
         assert all(np.all(u.data[1, :, :, i] == 3 - i) for i in range(4))
 
@@ -328,7 +328,7 @@ class TestOperatorSimple(object):
         u.data[:] = 2.
         eq = Eq(u.backward, u - 1.)
         op = Operator(eq, time_axis=Backward)
-        op(yu4D=u, t=2)
+        op(yu4D=u, t=3)
         assert 'run_solution' in str(op)
         assert np.all(u.data[2] == 2.)
         assert np.all(u.data[1] == 1.)
@@ -354,7 +354,7 @@ class TestOperatorSimple(object):
         assert 'run_solution' in str(op)
         # No data has been allocated for the temporaries yet
         assert op.yk_soln.grids['r0'].is_storage_allocated() is False
-        op.apply(yu4D=u, yv3D=v, t=1)
+        op.apply(yu4D=u, yv3D=v, t=2)
         # Temporary data has already been released after execution
         assert op.yk_soln.grids['r0'].is_storage_allocated() is False
         assert np.all(v.data == 0.)
@@ -379,7 +379,7 @@ class TestOperatorSimple(object):
         assert p.data[0][0] == 3.
         # Check re-executing with another constant gives the correct result
         c2 = Constant(name='c', value=5.)
-        op.apply(yu4D=u, c=c2, t=3)
+        op.apply(yu4D=u, c=c2, t=4)
         assert np.all(u.data[0] == 30.)
         assert p.data[0][0] == 6.
 


### PR DESCRIPTION
**Problem:** The current implementation enforces a different indexing scheme for explicitly passed dimension arguments to the one used throughout the rest of the codebase (allocation, codegen, etc.) by adding stencil offsets to the provided values. Since we currently do not capture user-induced buffer overruns (see #426), this can lead to user-induced buffer overruns that cause sporadic failures in the test base if explicitly passed arguments do not account for this magic behaviour.

**This merge reverts this behaviour and enforces a consistent index addressing scheme throughout the code base.** It accordingly adjusts to the _currently(!) correct_ usage of explicitly provided values for the time dimension in all failing test cases (mostly YASK and checkpointing), and reverts the previous and unsuccessful attempts at fixing the sporadic failures due to the incurred buffer overruns.

**TLDR; More details on indexing schemes:**
Devito's current scheme is, for lack of a better name, "allocation-based". This means we allocate exactly the data shape provided by the user and all dimension indexing is done in terms of absolute values relative to this allocated shape. Since stencils usually have a "read-from" radius that is greater than the "write-to" region, this means that we address the desired iteration space for each loop/dimension as an absolute value that _includes the halo or buffer region_. For example, with a first order timestepping scheme that reads from `t` and writes to `t+1`, passing `t=2` means compute up to time index 2, not "compute two timesteps", and will compute a single timestep `t[1, :, :]` from the initial time index `t[0, :, :]`.

The alternative approach is what we currently call "domain-based". This is the approach taken by YASK and we are planning to switch to this scheme soon. It effectively defines the "domain" of each dimension as the "write-to" region of the data and indexes all access with respect to the first "written" data point, not the first allocated (read) data point. This approach may be more intuitive but requires a significant effort to implement from the current state of play to track and normalise dimensions accesses from data objects with different "read" radiuses. A separate issue will be filed to give more detail.

**Final note: Whichever scheme we may prefer, it is extremely important that this scheme is honoured throughout the entire codebase! Switching to a new scheme thus needs to be done wholesale, not in parts or for individual components, to avoid wasting more time on chasing sporadic phantom bugs!**  