### PR TITLE
Misc fixes and improvements

### DIFF
--- a/devito/__init__.py
+++ b/devito/__init__.py
@@ -56,13 +56,13 @@ configuration.add('backend', 'core', list(backends_registry),
 
 # Set the Instruction Set Architecture (ISA)
 ISAs = [None, 'cpp', 'avx', 'avx2', 'avx512', 'knc']
-configuration.add('isa', None, ISAs)
+configuration.add('isa', 'cpp', ISAs)
 
 # Set the CPU architecture (only codename)
 PLATFORMs = [None, 'intel64', 'sandybridge', 'ivybridge', 'haswell',
              'broadwell', 'skylake', 'knc', 'knl']
 # TODO: switch arch to actual architecture names; use the mapper in /YASK/
-configuration.add('platform', None, PLATFORMs)
+configuration.add('platform', 'intel64', PLATFORMs)
 
 
 # Initialize the configuration, either from the environment or

--- a/devito/__init__.py
+++ b/devito/__init__.py
@@ -14,7 +14,7 @@ from devito.parameters import *  # noqa
 from devito.symbolics import *  # noqa
 from devito.tools import *  # noqa
 
-from devito.compiler import compiler_registry, GNUCompiler
+from devito.compiler import compiler_registry
 from devito.backends import backends_registry, init_backend
 
 
@@ -38,11 +38,7 @@ configuration.add('compiler', 'custom', list(compiler_registry),
 
 def _cast_and_update_compiler(val):
     # Force re-build the compiler
-    compiler = configuration['compiler']
-    if isinstance(compiler, GNUCompiler):
-        compiler.__init__(version=compiler.version)
-    else:
-        compiler.__init__()
+    configuration['compiler'].__init__(suffix=configuration['compiler'].suffix)
     return bool(val)
 
 

--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -131,28 +131,6 @@ class IntelCompiler(Compiler):
             self.ldflags += ['-qopenmp']
 
 
-class IntelMICCompiler(Compiler):
-    """Set of standard compiler flags for the IntelMIC toolchain
-
-    :param openmp: Boolean indicating if openmp is enabled. False by default
-
-    Note: Generates warning if openmp is disabled.
-    """
-
-    def __init__(self, *args, **kwargs):
-        super(IntelMICCompiler, self).__init__(*args, **kwargs)
-        self.cc = 'icc'
-        self.ld = 'icc'
-        self.cflags = ['-O3', '-g', '-fPIC', '-Wall', '-std=c99', "-mmic"]
-        self.ldflags = ['-shared']
-
-        if configuration['openmp']:
-            self.ldflags += ['-qopenmp']
-        else:
-            log("WARNING: Running on Intel MIC without OpenMP is highly discouraged")
-        self._mic = __import__('pymic')
-
-
 class IntelKNLCompiler(Compiler):
     """Set of standard compiler flags for the clang toolchain"""
 
@@ -209,17 +187,7 @@ def load(basename, compiler):
     :param basename: Name of the .so file.
     :param compiler: The toolchain used for compilation.
     :return: The loaded library.
-
-    Note: If the provided compiler is of type `IntelMICCompiler`
-    we utilise the `pymic` package to manage device streams.
     """
-    if isinstance(compiler, IntelMICCompiler):
-        compiler._device = compiler._mic.devices[0]
-        compiler._stream = compiler._device.get_default_stream()
-        # The name with the extension is only used for MIC
-        lib_file = "%s.%s" % (basename, compiler.lib_ext)
-        return compiler._device.load_library(lib_file)
-
     return npct.load_library(basename, '.')
 
 
@@ -289,6 +257,5 @@ compiler_registry = {
     'clang': ClangCompiler, 'osx': ClangCompiler,
     'intel': IntelCompiler, 'icpc': IntelCompiler,
     'icc': IntelCompiler,
-    'intel-mic': IntelMICCompiler, 'mic': IntelMICCompiler,
     'intel-knl': IntelKNLCompiler, 'knl': IntelKNLCompiler,
 }

--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -4,6 +4,7 @@ from os import environ, path
 from tempfile import mkdtemp
 from time import time
 from sys import platform
+from distutils import version
 import subprocess
 
 import numpy.ctypeslib as npct
@@ -13,7 +14,7 @@ from codepy.toolchain import GCCToolchain
 from devito.exceptions import CompilationError
 from devito.logger import log
 from devito.parameters import configuration
-from devito.tools import change_directory
+from devito.tools import change_directory, sniff_compiler_version
 
 __all__ = ['jit_compile', 'load', 'make', 'GNUCompiler']
 
@@ -28,7 +29,7 @@ class Compiler(GCCToolchain):
     def class MyCompiler(Compiler):
         def __init__(self):
             self.cc = 'mycompiler'
-            self.cflags = ['list', 'of', 'all', 'compiler', 'flags']
+            self.cflags += ['list', 'of', 'all', 'compiler', 'flags']
 
     The flags that can be set are:
         * :data:`self.cc`
@@ -46,13 +47,18 @@ class Compiler(GCCToolchain):
     cpp_mapper = {'gcc': 'g++', 'clang': 'clang++', 'icc': 'icpc',
                   'gcc-4.9': 'g++-4.9', 'gcc-5': 'g++-5', 'gcc-6': 'g++-6'}
 
-    fields = ['cc', 'ld']
+    fields = {'cc', 'ld'}
+
+    CC = 'unknown'
+    LD = 'unknown'
 
     def __init__(self, **kwargs):
-        self.cc = 'unknown'
-        self.ld = 'unknown'
-        self.cflags = []
-        self.ldflags = []
+        super(Compiler, self).__init__(**kwargs)
+        self.suffix = kwargs.get('suffix')
+        self.cc = self.CC if self.suffix is None else ('%s-%s' % (self.CC, self.suffix))
+        self.ld = self.LD if self.suffix is None else ('%s-%s' % (self.LD, self.suffix))
+        self.cflags = ['-O3', '-g', '-fPIC', '-Wall', '-std=c99']
+        self.ldflags = ['-shared']
         self.include_dirs = []
         self.libraries = []
         self.library_dirs = []
@@ -60,6 +66,11 @@ class Compiler(GCCToolchain):
         self.undefines = []
         self.src_ext = 'c'
         self.lib_ext = 'so'
+        if self.suffix is not None:
+            self.version = self.suffix
+        else:
+            # Knowing the version may still be useful to pick supported flags
+            self.version = sniff_compiler_version(self.CC)
 
     def __str__(self):
         return self.__class__.__name__
@@ -71,17 +82,22 @@ class Compiler(GCCToolchain):
 class GNUCompiler(Compiler):
     """Set of standard compiler flags for the GCC toolchain."""
 
+    CC = 'gcc'
+    LD = 'gcc'
+
     def __init__(self, *args, **kwargs):
         super(GNUCompiler, self).__init__(*args, **kwargs)
-        self.version = kwargs.get('version', None)
-        self.cc = 'gcc' if self.version is None else 'gcc-%s' % self.version
-        self.ld = 'gcc' if self.version is None else 'gcc-%s' % self.version
-        self.cflags = ['-O3', '-g', '-march=native', '-fPIC', '-Wall', '-std=c99',
-                       '-Wno-unused-result', '-Wno-unused-variable']
-        self.ldflags = ['-shared']
-
-        if configuration['openmp']:
-            self.ldflags += ['-fopenmp']
+        self.cflags += ['-march=native', '-Wno-unused-result', '-Wno-unused-variable',
+                        '-Wno-unused-but-set-variable']
+        try:
+            if self.version >= version.StrictVersion("4.9.0"):
+                # Append the openmp flag regardless of configuration['openmp'],
+                # since GCC4.9 and later versions implement OpenMP 4.0, hence
+                # they support `#pragma omp simd`
+                self.ldflags += ['-fopenmp']
+        except TypeError:
+            if configuration['openmp']:
+                self.ldflags += ['-fopenmp']
 
 
 class GNUCompilerNoAVX(GNUCompiler):
@@ -93,8 +109,7 @@ class GNUCompilerNoAVX(GNUCompiler):
 
     def __init__(self, *args, **kwargs):
         super(GNUCompilerNoAVX, self).__init__(*args, **kwargs)
-        self.cflags = ['-O3', '-g', '-march=native', '-mno-avx', '-fPIC', '-Wall',
-                       '-std=c99', '-Wno-unused-result', '-Wno-unused-variable']
+        self.cflags += ['-mno-avx']
 
 
 class ClangCompiler(Compiler):
@@ -105,44 +120,45 @@ class ClangCompiler(Compiler):
     Note: Genrates warning if openmp is disabled.
     """
 
+    CC = 'clang'
+    LD = 'clang'
+
     def __init__(self, *args, **kwargs):
         super(ClangCompiler, self).__init__(*args, **kwargs)
-        self.cc = 'clang'
-        self.ld = 'clang'
-        self.cflags = ['-O3', '-g', '-fPIC', '-Wall', '-std=c99']
-        self.ldflags = ['-shared']
-        self.lib_ext = 'dylib'
+        self.lib_ext += 'dylib'
 
 
 class IntelCompiler(Compiler):
-    """Set of standard compiler flags for the Intel toolchain
+    """Set of standard compiler flags for the Intel toolchain.
 
     :param openmp: Boolean indicating if openmp is enabled. False by default
     """
 
+    CC = 'icc'
+    LD = 'icc'
+
     def __init__(self, *args, **kwargs):
         super(IntelCompiler, self).__init__(*args, **kwargs)
-        self.cc = 'icc'
-        self.ld = 'icc'
-        self.cflags = ['-O3', '-g', '-fPIC', '-Wall', '-std=c99', "-xhost"]
-        self.ldflags = ['-shared']
+        self.cflags += ["-xhost"]
+        try:
+            if self.version >= version.StrictVersion("15.0.0"):
+                # Append the openmp flag regardless of configuration['openmp'],
+                # since icc15 and later versions implement OpenMP 4.0, hence
+                # they support `#pragma omp simd`
+                self.ldflags += ['-qopenmp']
+        except TypeError:
+            if configuration['openmp']:
+                # Note: fopenmp, not qopenmp, is what is needed by icc versions < 15.0
+                self.ldflags += ['-fopenmp']
 
-        if configuration['openmp']:
-            self.ldflags += ['-qopenmp']
 
-
-class IntelKNLCompiler(Compiler):
+class IntelKNLCompiler(IntelCompiler):
     """Set of standard compiler flags for the clang toolchain"""
 
     def __init__(self, *args, **kwargs):
         super(IntelKNLCompiler, self).__init__(*args, **kwargs)
-        self.cc = 'icc'
-        self.ld = 'icc'
-        self.cflags = ['-O3', '-g', '-fPIC', '-Wall', '-std=c99', "-xMIC-AVX512"]
-        self.ldflags = ['-shared']
-        if configuration['openmp']:
-            self.ldflags += ['-qopenmp']
-        else:
+        self.cflags += ["-xMIC-AVX512"]
+        if not configuration['openmp']:
             log("WARNING: Running on Intel KNL without OpenMP is highly discouraged")
 
 
@@ -250,12 +266,17 @@ def make(loc, args):
 # DEVITO_ARCH. Developers should add new compiler classes here.
 compiler_registry = {
     'custom': CustomCompiler,
-    'gcc': GNUCompiler, 'gnu': GNUCompiler,
-    'gcc-4.9': partial(GNUCompiler, version='4.9'),
-    'gcc-5': partial(GNUCompiler, version='5'),
-    'gcc-noavx': GNUCompilerNoAVX, 'gnu-noavx': GNUCompilerNoAVX,
-    'clang': ClangCompiler, 'osx': ClangCompiler,
-    'intel': IntelCompiler, 'icpc': IntelCompiler,
+    'gnu': GNUCompiler,
+    'gcc': GNUCompiler,
+    'gcc-4.9': partial(GNUCompiler, suffix='4.9'),
+    'gcc-5': partial(GNUCompiler, suffix='5'),
+    'gcc-noavx': GNUCompilerNoAVX,
+    'gnu-noavx': GNUCompilerNoAVX,
+    'clang': ClangCompiler,
+    'osx': ClangCompiler,
+    'intel': IntelCompiler,
+    'icpc': IntelCompiler,
     'icc': IntelCompiler,
-    'intel-knl': IntelKNLCompiler, 'knl': IntelKNLCompiler,
+    'intel-knl': IntelKNLCompiler,
+    'knl': IntelKNLCompiler,
 }

--- a/devito/function.py
+++ b/devito/function.py
@@ -278,7 +278,7 @@ class Function(TensorFunction):
     def _allocate_memory(self):
         """Allocate memory in terms of numpy ndarrays."""
         debug("Allocating memory for %s (%s)" % (self.name, str(self.shape)))
-        self._data_object = CMemory(self.shape, dtype=self.dtype)
+        self._data_object = CMemory(self.shape, self.indices, dtype=self.dtype)
         if self._first_touch:
             first_touch(self)
         else:

--- a/devito/function.py
+++ b/devito/function.py
@@ -47,6 +47,12 @@ class Constant(AbstractSymbol, ConstantArgProvider):
 
     """
     Symbol representing constant values in symbolic equations.
+
+    .. note::
+
+        The parameters must always be given as keyword arguments, since
+        SymPy uses `*args` to (re-)create the dimension arguments of the
+        symbolic function.
     """
 
     is_Constant = True
@@ -101,6 +107,12 @@ class Function(TensorFunction):
     :param dtype: (Optional) data type of the buffered data.
     :param space_order: Discretisation order for space derivatives
     :param initializer: Function to initialize the data, optional
+
+    .. note::
+
+        The parameters must always be given as keyword arguments, since
+        SymPy uses `*args` to (re-)create the dimension arguments of the
+        symbolic function.
 
     .. note::
 
@@ -338,6 +350,12 @@ class TimeFunction(Function):
 
     .. note::
 
+        The parameters must always be given as keyword arguments, since
+        SymPy uses `*args` to (re-)create the dimension arguments of the
+        symbolic function.
+
+    .. note::
+
        If the parameter ``grid`` is provided, the values for ``shape``,
        ``dimensions`` and ``dtype`` will be derived from it.
 
@@ -498,6 +516,12 @@ class SparseFunction(CompositeFunction):
     :param nt: Size of the time dimension for point data
     :param coordinates: Optional coordinate data for the sparse points
     :param dtype: Data type of the buffered data
+
+    .. note::
+
+        The parameters must always be given as keyword arguments, since
+        SymPy uses `*args` to (re-)create the dimension arguments of the
+        symbolic function.
     """
 
     is_SparseFunction = True

--- a/devito/ir/clusters/algorithms.py
+++ b/devito/ir/clusters/algorithms.py
@@ -14,7 +14,7 @@ def groupby(clusters):
     """
     Given an ordered collection of :class:`PartialCluster` objects, return a
     (potentially) smaller sequence in which dependence-free PartialClusters with
-    identical stencil have been squashed into a single PartialCluster.
+    identical stencil have been squashed into a single :class:`PartialCluster`.
     """
     clusters = clusters.unfreeze()
 

--- a/devito/ir/iet/analysis.py
+++ b/devito/ir/iet/analysis.py
@@ -136,19 +136,16 @@ def mark_wrappable(analysis):
         return
     # Finally check that all data dependences would be honored by using the
     # /front/ index function in place of the /back/ index function
-    for tree in analysis.trees:
-        for i in tree:
-            if i == stepper:
-                continue
-            # There must be NO writes to the /back/ timeslot
-            for access in analysis.scopes[i].accesses:
-                if access.is_write and access[stepping] == back:
-                    return
-            # All reads from the /front/ timeslot must not cause dependences with
-            # the writes in the /back/ timeslot along the /i/ dimension
-            for dep in analysis.scopes[i].d_flow:
-                if dep.source[stepping] != front or dep.sink[stepping] != back:
-                    continue
-                if dep.source.section(stepping) != dep.sink.section(stepping):
-                    return
+    # There must be NO writes to the /back/ timeslot
+    for access in analysis.scopes[stepper].accesses:
+        if access.is_write and access[stepping] == back:
+            return
+    # All reads from the /front/ timeslot must not cause dependences with
+    # the writes in the /back/ timeslot along the /i/ dimension
+    for dep in analysis.scopes[stepper].d_flow:
+        if dep.source[stepping] != front or dep.sink[stepping] != back:
+            continue
+        if dep.sink.lex_gt(dep.source) and\
+                dep.source.section(stepping) != dep.sink.section(stepping):
+            return
     analysis.update({stepper: WRAPPABLE})

--- a/devito/ir/iet/nodes.py
+++ b/devito/ir/iet/nodes.py
@@ -400,11 +400,9 @@ class Iteration(Node):
         if a limit is unknown."""
         lower = start if start is not None else self.limits[0]
         upper = finish if finish is not None else self.limits[1]
-        if lower and self.offsets[0]:
-            lower = lower - self.offsets[0]
 
-        if upper and self.offsets[1]:
-            upper = upper - self.offsets[1]
+        lower = lower - self.offsets[0]
+        upper = upper - self.offsets[1]
 
         return (lower, upper)
 

--- a/devito/memory.py
+++ b/devito/memory.py
@@ -9,7 +9,7 @@ import numpy as np
 from sympy import Eq
 
 from devito.logger import error
-from devito.tools import numpy_to_ctypes
+from devito.tools import as_tuple, numpy_to_ctypes
 import devito
 
 """
@@ -20,8 +20,10 @@ libc = ctypes.CDLL(find_library('c'))
 
 class CMemory(object):
 
-    def __init__(self, shape, dtype=np.float32, alignment=None):
-        self.ndpointer, self.data_pointer = malloc_aligned(shape, alignment, dtype)
+    def __init__(self, shape, indices, dtype):
+        self.ndpointer, self.data_pointer = malloc_aligned(shape, dtype)
+        self.ndpointer = Data(self.ndpointer,
+                              [i.modulo if i.is_Stepping else None for i in indices])
 
     def __del__(self):
         free(self.data_pointer)
@@ -31,12 +33,12 @@ class CMemory(object):
         self.ndpointer.fill(val)
 
 
-def malloc_aligned(shape, alignment=None, dtype=np.float32):
+def malloc_aligned(shape, dtype=np.float32, alignment=None):
     """ Allocate memory using the C function malloc_aligned
     :param shape: Shape of the array to allocate
+    :param dtype: Numpy datatype to allocate. Default to np.float32
     :param alignment: number of bytes to align to. Defaults to
     page size if not set.
-    :param dtype: Numpy datatype to allocate. Default to np.float32
 
     :returns (pointer, data_pointer) the first element of the tuple
     is the reference that can be used to access the data as a ctypes
@@ -68,16 +70,73 @@ def malloc_aligned(shape, alignment=None, dtype=np.float32):
 
 
 def free(internal_pointer):
-    """Use the C function free to free the memory allocated for the
+    """
+    Use the C function free to free the memory allocated for the
     given pointer.
     """
     libc.free(internal_pointer)
 
 
 def first_touch(array):
-    """Uses the Propagator low-level API to initialize the given array(in Devito types)
-    in the same pattern that would later be used to access it.
+    """
+    Uses an Operator to initialize the given array in the same pattern that
+    would later be used to access it.
     """
     exp_init = [Eq(array.indexed[array.indices], 0)]
     op = devito.Operator(exp_init)
     op.apply()
+
+
+class Data(np.ndarray):
+
+    """
+    A special :class:`numpy.ndarray` that supports logic indexing over modulo
+    buffered dimensions.
+
+    The type :class:`numpy.ndarray` is subclassed as indicated at: ::
+
+        https://docs.scipy.org/doc/numpy-1.13.0/user/basics.subclassing.html
+
+    The new instance takes an existing ndarray as input, casts it to one of
+    type ``Data``, and adds the extra attribute ``wrap``.
+    """
+
+    def __new__(cls, array, wrap=None):
+        obj = np.asarray(array).view(cls)
+        obj._wrap = wrap
+        return obj
+
+    def __array_finalize__(self, obj):
+        if obj is None:
+            return
+        self._wrap = getattr(obj, '_wrap', None)
+
+    def __getitem__(self, index):
+        index = self._apply_wrap(index)
+        return super(Data, self).__getitem__(index)
+
+    def __setitem__(self, index, val):
+        index = self._apply_wrap(index)
+        super(Data, self).__setitem__(index, val)
+
+    def _apply_wrap(self, index):
+        if isinstance(index, np.ndarray):
+            # Mask array
+            return index
+        else:
+            index = as_tuple(index)
+            wrapped = []
+            for i, j in zip(index, self._wrap):
+                if j is None:
+                    wrapped.append(i)
+                elif isinstance(i, slice):
+                    handle = []
+                    handle.append(i.start if i.start is None else (i.start % j))
+                    handle.append(i.stop if i.stop is None else (i.stop % (j + 1)))
+                    handle.append(i.step)
+                    wrapped.append(slice(*handle))
+                elif isinstance(i, (tuple, list)):
+                    wrapped.append([k % j for k in i])
+                else:
+                    wrapped.append(i % j)
+            return wrapped[0] if len(index) == 1 else tuple(wrapped)

--- a/devito/memory.py
+++ b/devito/memory.py
@@ -98,43 +98,66 @@ class Data(np.ndarray):
         https://docs.scipy.org/doc/numpy-1.13.0/user/basics.subclassing.html
 
     The new instance takes an existing ndarray as input, casts it to one of
-    type ``Data``, and adds the extra attribute ``wrap``.
+    type ``Data``, and adds the extra attribute ``modulo``.
+
+    .. note::
+
+        Any view or copy ``A`` created starting from ``self``, for instance via
+        a slice operation or a universal function ("ufunc" in NumPy jargon), will
+        still be of type :class:`Data`. However, if ``A`` is a view and its rank
+        is lower than that of ``self``, namely ``A.ndim < self.ndim``, then the
+        ``modulo`` attribute is dropped. A suitable exception is then raised if
+        user code seems to attempt accessing data through modulo iteration on
+        such a contracted view.
     """
 
-    def __new__(cls, array, wrap=None):
+    def __new__(cls, array, modulo=None):
         obj = np.asarray(array).view(cls)
-        obj._wrap = wrap
+        obj.modulo = tuple(modulo)
         return obj
 
     def __array_finalize__(self, obj):
-        if obj is None:
+        if type(obj) != Data:
             return
-        self._wrap = getattr(obj, '_wrap', None)
+        # `self` is the newly created object
+        # `obj` is the object from which `self` was created
+        if self.ndim == obj.ndim:
+            self.modulo = obj.modulo
+        else:
+            self.modulo = tuple(None for i in range(self.ndim))
 
     def __getitem__(self, index):
-        index = self._apply_wrap(index)
+        index = self._convert_index(index)
         return super(Data, self).__getitem__(index)
 
     def __setitem__(self, index, val):
-        index = self._apply_wrap(index)
+        index = self._convert_index(index)
         super(Data, self).__setitem__(index, val)
 
-    def _apply_wrap(self, index):
+    def _convert_index(self, index):
         if isinstance(index, np.ndarray):
-            # Mask array
+            # Using a mask array, nothing we really have to do
             return index
         else:
             index = as_tuple(index)
             wrapped = []
-            for i, j in zip(index, self._wrap):
+            for i, j in zip(index, self.modulo):
                 if j is None:
                     wrapped.append(i)
                 elif isinstance(i, slice):
-                    handle = []
-                    handle.append(i.start if i.start is None else (i.start % j))
-                    handle.append(i.stop if i.stop is None else (i.stop % (j + 1)))
-                    handle.append(i.step)
-                    wrapped.append(slice(*handle))
+                    if i.start is None:
+                        start = i.start
+                    elif i.start >= 0:
+                        start = i.start % j
+                    else:
+                        start = -(i.start % j)
+                    if i.stop is None:
+                        stop = i.stop
+                    elif i.stop >= 0:
+                        stop = i.stop % (j + 1)
+                    else:
+                        stop = -(i.stop % (j + 1))
+                    wrapped.append(slice(start, stop, i.step))
                 elif isinstance(i, (tuple, list)):
                     wrapped.append([k % j for k in i])
                 else:

--- a/devito/tools.py
+++ b/devito/tools.py
@@ -271,10 +271,6 @@ class memoized(object):
         return partial(self.__call__, obj)
 
 
-default_isa = 'cpp'
-default_platform = 'intel64'
-
-
 def infer_cpu():
     """
     Detect the highest Instruction Set Architecture and the platform
@@ -283,7 +279,7 @@ def infer_cpu():
     """
     info = cpuinfo.get_cpu_info()
     # ISA
-    isa = default_isa
+    isa = configuration._defaults['isa']
     for i in reversed(configuration._accepted['isa']):
         if i in info['flags']:
             isa = i
@@ -306,7 +302,7 @@ def infer_cpu():
             platform = None
     # Is it a known platform?
     if platform not in configuration._accepted['platform']:
-        platform = default_platform
+        platform = configuration._defaults['platform']
     return isa, platform
 
 

--- a/devito/tools.py
+++ b/devito/tools.py
@@ -3,14 +3,10 @@ import os
 import ctypes
 from collections import Callable, Iterable, OrderedDict, Hashable
 from functools import partial, wraps
-from itertools import product
-from subprocess import PIPE, Popen
+from itertools import product, zip_longest
+from subprocess import DEVNULL, PIPE, Popen, CalledProcessError, check_output
 import cpuinfo
-try:
-    from itertools import izip_longest as zip_longest
-except ImportError:
-    # Python3.5 compatibility
-    from itertools import zip_longest
+from distutils import version
 
 from devito.parameters import configuration
 
@@ -304,6 +300,48 @@ def infer_cpu():
     if platform not in configuration._accepted['platform']:
         platform = configuration._defaults['platform']
     return isa, platform
+
+
+def sniff_compiler_version(cc):
+    """
+    Try to detect the compiler version.
+
+    Adapted from: ::
+
+        https://github.com/OP2/PyOP2/
+    """
+    try:
+        ver = check_output([cc, "--version"]).decode("utf-8")
+    except (CalledProcessError, UnicodeDecodeError):
+        return version.LooseVersion("unknown")
+
+    if ver.startswith("gcc"):
+        compiler = "gcc"
+    elif ver.startswith("clang"):
+        compiler = "clang"
+    elif ver.startswith("Apple LLVM"):
+        compiler = "clang"
+    elif ver.startswith("icc"):
+        compiler = "icc"
+    else:
+        compiler = "unknown"
+
+    ver = version.LooseVersion("unknown")
+    if compiler in ["gcc", "icc"]:
+        try:
+            # gcc-7 series only spits out patch level on dumpfullversion.
+            ver = check_output([cc, "-dumpfullversion"], stderr=DEVNULL).decode("utf-8")
+            ver = version.StrictVersion(ver.strip())
+        except CalledProcessError:
+            try:
+                ver = check_output([cc, "-dumpversion"], stderr=DEVNULL).decode("utf-8")
+                ver = version.StrictVersion(ver.strip())
+            except (CalledProcessError, UnicodeDecodeError):
+                pass
+        except UnicodeDecodeError:
+            pass
+
+    return ver
 
 
 class silencio(object):

--- a/devito/types.py
+++ b/devito/types.py
@@ -145,7 +145,7 @@ class AbstractSymbol(sympy.Symbol, CachedSymbol):
     def __new__(cls, *args, **kwargs):
         options = kwargs.get('options', {})
         if cls in _SymbolCache:
-            newobj = sympy.Function.__new__(cls, *args, **options)
+            newobj = sympy.Symbol.__new__(cls, *args, **options)
             newobj._cached_init()
         else:
             name = kwargs.get('name')

--- a/devito/types.py
+++ b/devito/types.py
@@ -35,11 +35,7 @@ class Basic(object):
                         -----------------------------------
                         |                                 |
                   CachedSymbol                          Object
-                        |                          <see Object.__doc__>
-           --------------------------
-           |                        |
-    AbstractSymbol          AbstractFunction
-                        <see AbstractFunction.__doc__>
+          <root of the symbol objects>       <root of the generic objects>
 
     All derived :class:`Basic` objects may be emitted through code generation
     to create a just-in-time compilable kernel.
@@ -74,7 +70,31 @@ class Basic(object):
 
 
 class CachedSymbol(Basic):
-    """Base class for symbolic objects that caches on the class type."""
+    """
+    Base class for symbolic objects that caches on the class type.
+
+    In order to maintain meta information across the numerous
+    re-instantiation SymPy performs during symbolic manipulation, we inject
+    the symbol name as the class name and cache all created objects on that
+    name. This entails that a symbolic object inheriting from :class:`CachedSymbol`
+    should implement `__init__` in the following way:
+
+        .. code-block::
+            def __init__(self, \*args, \*\*kwargs):
+                if not self._cached():
+                    ... # Initialise object properties from kwargs
+
+    This class is the root of the symbolic objects hierarchy, which is
+    structured as follows.
+
+                                    CachedSymbol
+                                         |
+                        -----------------------------------
+                        |                                 |
+                  AbstractSymbol                    AbstractFunction
+           <root of the scalar symbols>       <root of the tensor symbols>
+
+    """
 
     @classmethod
     def _cached(cls):
@@ -102,9 +122,22 @@ class CachedSymbol(Basic):
 
 class AbstractSymbol(sympy.Symbol, CachedSymbol):
     """
-    Base class for dimension-free symbols that are cached by Devito,
-    in addition to SymPy caching. Note that these objects are not
-    :class:`Function` objects and do not have any indexing dimensions.
+    Base class for dimension-free symbols, cached by both Devito and Sympy.
+    Note that these objects are not :class:`Function` objects and do not have
+    any indexing dimensions.
+
+    This class is the root of the scalar (i.e., dimension-free) symbols hierarchy,
+    which is structured as follows
+
+                             AbstractSymbol
+                                   |
+                 -------------------------------------
+                 |                                   |
+               Symbol                             Constant
+
+    The difference between a :class:`Constant` and a :class:`Symbol` object
+    is that the former carries data (a scalar) and is created directly by the
+    user, whereas the latter is created and managed internally by Devito.
     """
 
     is_AbstractSymbol = True
@@ -162,52 +195,30 @@ class Symbol(AbstractSymbol):
 
 
 class AbstractFunction(sympy.Function, CachedSymbol):
-    """Base class for data classes that provides symbolic behaviour.
+    """
+    Base class for tensor symbols, cached by both Devito and SymPy.
+    It inherits from and mimick the behaviour of a :class:`sympy.Function`.
 
-    :param name: Symbolic name to give to the resulting function. Must
-                 be given as keyword argument.
-    :param shape: Shape of the underlying object. Must be given as
-                  keyword argument.
+    This class is the root of the tensor symbols hierarchy, which is
+    structured as follows.
 
-    This class implements the behaviour of Devito's symbolic
-    objects by inheriting from and mimicking the behaviour of
-    :class:`sympy.Function`. In order to maintain meta information
-    across the numerous re-instantiation SymPy performs during
-    symbolic manipulation, we inject the symbol name as the class name
-    and cache all created objects on that name. This entails that a
-    symbolic object should implement `__init__` in the following
-    format:
-
-    def __init__(self, \*args, \*\*kwargs):
-        if not self._cached():
-            ... # Initialise object properties from kwargs
-
-    Note: The parameters :param name: and :param shape: must always be
-    present and given as keyword arguments, since SymPy uses `*args`
-    to (re-)create the dimension arguments of the symbolic function.
-
-    This class is the root of the Devito data objects hierarchy, which
-    is structured as follows.
-
-                             AbstractFunction
+                            AbstractFunction
                                    |
                  -------------------------------------
                  |                                   |
             SymbolicData                      SymbolicFunction
                  |                                   |
-          ------------------                 ------------------
-          |                |                 |                |
-       Scalar            Array            Constant      TensorFunction
-                                                              |
-                                                ------------------------------
-                                                |             |              |
-                                            Function      TimeFunction  CompositeFunction
-                                                                             |
-                                                                         SparseFunction
+               Array                           TensorFunction
+                                                     |
+                                       ------------------------------
+                                       |             |              |
+                                    Function    TimeFunction  CompositeFunction
+                                                                    |
+                                                               SparseFunction
 
     The key difference between a :class:`SymbolicFunction` and a :class:`SymbolicData`
-    is that the former is created directly by the user and employed in some
-    computation, while the latter is created and managed internally by Devito.
+    object is that the former carries data and is created directly by the user,
+    whereas the latter is created and managed internally by Devito.
     """
 
     is_AbstractFunction = True

--- a/devito/yask/utils.py
+++ b/devito/yask/utils.py
@@ -4,7 +4,6 @@ import ctypes
 from devito.cgen_utils import INT, ccode
 from devito.ir.iet import Element, Expression, FindNodes, Transformer
 from devito.symbolics import FunctionFromPointer, ListInitializer, retrieve_indexed
-from devito.tools import as_tuple
 
 from devito.yask import namespace
 
@@ -56,94 +55,3 @@ def make_grid_accesses(node):
 def rawpointer(obj):
     """Return a :class:`ctypes.c_void_p` pointing to ``obj``."""
     return ctypes.cast(int(obj), ctypes.c_void_p)
-
-
-def convert_multislice(multislice, shape, offsets, mode='get'):
-    """
-    Convert a multislice into a format suitable to YASK's get_elements_{...}
-    and set_elements_{...} grid routines.
-
-    A multislice is the typical object received by NumPy ndarray's __getitem__
-    and __setitem__ methods; this function, therefore, converts NumPy indices
-    into YASK indices.
-
-    In particular, a multislice is either a single element or an iterable of
-    elements. An element can be a slice object, an integer index, or a tuple
-    of integer indices.
-
-    In the general case in which ``multislice`` is an iterable, each element in
-    the iterable corresponds to a dimension in ``shape``. In this case, an element
-    can be either a slice or an integer index, but not a tuple of integers.
-
-    If ``multislice`` is a single element,  then it is interpreted as follows: ::
-
-        * slice object: the slice spans the whole shape;
-        * single (integer) index: shape is one-dimensional, and the index
-          represents a specific entry;
-        * a tuple of (integer) indices: it must be ``len(multislice) == len(shape)``,
-          and each entry in ``multislice`` corresponds to a specific entry in a
-          dimension in ``shape``.
-
-    The returned value is a 3-tuple ``(starts, ends, shapes)``, where ``starts,
-    ends, shapes`` are lists of length ``len(shape)``. By taking ``starts[i]`` and
-    `` ends[i]``, one gets the start and end points of the section of elements to
-    be accessed along dimension ``i``; ``shapes[i]`` gives the size of the section.
-    """
-
-    # Note: the '-1' below are because YASK uses '<=', rather than '<', to check
-    # bounds when iterating over grid dimensions
-
-    assert mode in ['get', 'set']
-    multislice = as_tuple(multislice)
-
-    # Convert dimensions
-    cstart = []
-    cstop = []
-    cshape = []
-    for i, v in enumerate(multislice):
-        if isinstance(v, slice):
-            if v.step is not None:
-                raise NotImplementedError("Unsupported stepping != 1.")
-            if v.start is None:
-                start = 0
-            elif v.start < 0:
-                start = shape[i] + v.start
-            else:
-                start = v.start
-            cstart.append(start)
-            if v.stop is None:
-                stop = shape[i] - 1
-            elif v.stop < 0:
-                stop = shape[i] + v.stop
-            else:
-                stop = v.stop - 1
-            cstop.append(stop)
-            cshape.append(cstop[-1] - cstart[-1] + 1)
-        else:
-            if v is None:
-                start = 0
-                stop = shape[i] - 1
-            elif v < 0:
-                start = shape[i] + v
-                stop = shape[i] + v
-            else:
-                start = v
-                stop = v
-            cstart.append(start)
-            cstop.append(stop)
-            if mode == 'set':
-                cshape.append(1)
-
-    # Remainder (e.g., requesting A[1] and A has shape (3,3))
-    nremainder = len(shape) - len(multislice)
-    cstart.extend([0]*nremainder)
-    cstop.extend([shape[i + j] - 1 for j in range(1, nremainder + 1)])
-    cshape.extend([shape[i + j] for j in range(1, nremainder + 1)])
-
-    assert len(shape) == len(cstart) == len(cstop) == len(offsets)
-
-    # Shift by the specified offsets
-    cstart = [int(j + i) for i, j in zip(offsets, cstart)]
-    cstop = [int(j + i) for i, j in zip(offsets, cstop)]
-
-    return cstart, cstop, cshape

--- a/devito/yask/utils.py
+++ b/devito/yask/utils.py
@@ -116,7 +116,7 @@ def convert_multislice(multislice, shape, offsets, mode='get'):
             elif v.stop < 0:
                 stop = shape[i] + v.stop
             else:
-                stop = v.stop
+                stop = v.stop - 1
             cstop.append(stop)
             cshape.append(cstop[-1] - cstart[-1] + 1)
         else:

--- a/devito/yask/wrappers.py
+++ b/devito/yask/wrappers.py
@@ -120,30 +120,31 @@ class YaskGrid(object):
     def __repr__(self):
         return repr(self[:])
 
-    def __meta_binop(op):
+    def __meta_op__(op, reverse=False):
         # Used to build all binary operations such as __eq__, __add__, etc.
         # These all boil down to calling the numpy equivalents
         def f(self, other):
-            return getattr(self[:], op)(other)
+            o1, o2 = (self[:], other) if reverse is False else (other, self[:])
+            return getattr(o1, op)(o2)
         return f
-    __eq__ = __meta_binop('__eq__')
-    __ne__ = __meta_binop('__ne__')
-    __le__ = __meta_binop('__le__')
-    __lt__ = __meta_binop('__lt__')
-    __ge__ = __meta_binop('__ge__')
-    __gt__ = __meta_binop('__gt__')
-    __add__ = __meta_binop('__add__')
-    __radd__ = __meta_binop('__add__')
-    __sub__ = __meta_binop('__sub__')
-    __rsub__ = __meta_binop('__sub__')
-    __mul__ = __meta_binop('__mul__')
-    __rmul__ = __meta_binop('__mul__')
-    __div__ = __meta_binop('__div__')
-    __rdiv__ = __meta_binop('__div__')
-    __truediv__ = __meta_binop('__truediv__')
-    __rtruediv__ = __meta_binop('__truediv__')
-    __mod__ = __meta_binop('__mod__')
-    __rmod__ = __meta_binop('__mod__')
+    __eq__ = __meta_op__('__eq__')
+    __ne__ = __meta_op__('__ne__')
+    __le__ = __meta_op__('__le__')
+    __lt__ = __meta_op__('__lt__')
+    __ge__ = __meta_op__('__ge__')
+    __gt__ = __meta_op__('__gt__')
+    __add__ = __meta_op__('__add__')
+    __radd__ = __meta_op__('__add__')
+    __sub__ = __meta_op__('__sub__')
+    __rsub__ = __meta_op__('__sub__', True)
+    __mul__ = __meta_op__('__mul__')
+    __rmul__ = __meta_op__('__mul__', True)
+    __div__ = __meta_op__('__div__')
+    __rdiv__ = __meta_op__('__div__', True)
+    __truediv__ = __meta_op__('__truediv__')
+    __rtruediv__ = __meta_op__('__truediv__', True)
+    __mod__ = __meta_op__('__mod__')
+    __rmod__ = __meta_op__('__mod__', True)
 
     def _reset(self):
         """

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -57,6 +57,38 @@ class TestAPI(object):
         assert op.parameters[5].is_PtrArgument
         assert 'a_dense[i] = 2.0F*constant + a_dense[i]' in str(op.ccode)
 
+    def test_logic_indexing(self):
+        """
+        Tests that logic indexing for stepping dimensions works.
+        """
+        grid = Grid(shape=(4, 4, 4))
+        nt = 5
+
+        u = Function(name='u', grid=grid)
+        try:
+            u.data[5]
+            assert False
+        except IndexError:
+            pass
+
+        v = TimeFunction(name='v', grid=grid, save=nt)
+        try:
+            v.data[nt]
+            assert False
+        except IndexError:
+            pass
+
+        v_mod = TimeFunction(name='v_mod', grid=grid)
+        v_mod.data[0] = 1.
+        v_mod.data[1] = 2.
+        assert np.all(v_mod.data[0] == 1.)
+        assert np.all(v_mod.data[1] == 2.)
+        assert np.all(v_mod.data[2] == v_mod.data[0])
+        assert np.all(v_mod.data[4] == v_mod.data[0])
+        assert np.all(v_mod.data[3] == v_mod.data[1])
+        assert np.all(v_mod.data[-1] == v_mod.data[1])
+        assert np.all(v_mod.data[-2] == v_mod.data[0])
+
 
 @skipif_yask
 class TestArithmetic(object):

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -57,9 +57,85 @@ class TestAPI(object):
         assert op.parameters[5].is_PtrArgument
         assert 'a_dense[i] = 2.0F*constant + a_dense[i]' in str(op.ccode)
 
+
+class TestData(object):
+
+    @classmethod
+    def setup_class(cls):
+        clear_cache()
+
+    @pytest.fixture
+    def u(self):
+        grid = Grid(shape=(16, 16, 16))
+        u = Function(name='yu3D', grid=grid, space_order=0)
+        return u
+
+    def test_indexing(self, u):
+        """
+        Tests packing/unpacking :class:`Data` objects.
+        """
+        # Test simple insertion and extraction
+        u.data[0, 1, 1] = 1.
+        assert u.data[0, 0, 0] == 0.
+        assert u.data[0, 1, 1] == 1.
+        assert np.all(u.data == u.data[:, :, :])
+        assert 1. in u.data[0]
+        assert 1. in u.data[0, 1]
+
+        # Test negative indices
+        assert u.data[0, -15, -15] == 1.
+        u.data[6, 0, 0] = 1.
+        assert u.data[-10, :, :].sum() == 1.
+
+        # Test setting whole array to given value
+        u.data[:] = 3.
+        assert np.all(u.data == 3.)
+
+        # Test insertion of single value into block
+        u.data[5, :, 5] = 5.
+        assert np.all(u.data[5, :, 5] == 5.)
+
+        # Test extraction of block with negative indices
+        sliced = u.data[-11, :, -11]
+        assert sliced.shape == (16,)
+        assert np.all(sliced == 5.)
+
+        # Test insertion of block into block
+        block = np.ndarray(shape=(1, 16, 1), dtype=np.float32)
+        block.fill(4.)
+        u.data[4:5, :, 4:5] = block
+        assert np.all(u.data[4, :, 4] == block)
+
+    def test_arithmetic(self, u):
+        """
+        Tests arithmetic operations between :class:`Data` objects and values.
+        """
+        u.data[:] = 1
+
+        # Simple arithmetic
+        assert np.all(u.data == 1)
+        assert np.all(u.data + 2. == 3.)
+        assert np.all(u.data - 2. == -1.)
+        assert np.all(u.data * 2. == 2.)
+        assert np.all(u.data / 2. == 0.5)
+        assert np.all(u.data % 2 == 1.)
+
+        # Increments and partial increments
+        u.data[:] += 2.
+        assert np.all(u.data == 3.)
+        u.data[9, :, :] += 1.
+        assert all(np.all(u.data[i, :, :] == 3.) for i in range(9))
+        assert np.all(u.data[9, :, :] == 4.)
+
+        # Right operations __rOP__
+        u.data[:] = 1.
+        arr = np.ndarray(shape=(16, 16, 16), dtype=np.float32)
+        arr.fill(2.)
+        assert np.all(arr - u.data == 1.)
+
     def test_logic_indexing(self):
         """
-        Tests that logic indexing for stepping dimensions works.
+        Tests logic indexing for stepping dimensions.
         """
         grid = Grid(shape=(4, 4, 4))
         nt = 5

--- a/tests/test_yask.py
+++ b/tests/test_yask.py
@@ -25,108 +25,11 @@ def setup_module(module):
     contexts.dump()
 
 
-@pytest.fixture(scope="module")
-def u(dims):
-    grid = Grid(shape=(16, 16, 16))
-    u = Function(name='yu3D', grid=grid, space_order=0)
-    u.data  # Trigger initialization
-    return u
-
-
 @pytest.fixture(autouse=True)
 def reset_isa():
     """Force back to NO-SIMD after each test, as some tests may optionally
     switch on SIMD."""
     configuration.yask['develop-mode'] = True
-
-
-class TestGrids(object):
-
-    """
-    Test YASK grid wrappers.
-    """
-
-    @classmethod
-    def setup_class(cls):
-        clear_cache()
-
-    def test_data_type(self, u):
-        assert type(u._data_object) == YaskGrid
-
-    @pytest.mark.xfail(reason="YASK always seems to use 3D grids")
-    def test_data_movement_1D(self):
-        grid = Grid(shape=(16,))
-        u = Function(name='yu1D', grid=grid, space_order=0)
-        u.data
-        assert type(u._data_object) == YaskGrid
-
-        u.data[1] = 1.
-        assert u.data[0] == 0.
-        assert u.data[1] == 1.
-        assert all(i == 0 for i in u.data[2:])
-
-    def test_data_movement_nD(self, u):
-        """
-        Tests packing/unpacking data to/from YASK through Devito's YaskGrid.
-        """
-        # Test simple insertion and extraction
-        u.data[0, 1, 1] = 1.
-        assert u.data[0, 0, 0] == 0.
-        assert u.data[0, 1, 1] == 1.
-        assert np.all(u.data == u.data[:, :, :])
-        assert 1. in u.data[0]
-        assert 1. in u.data[0, 1]
-
-        # Test negative indices
-        assert u.data[0, -15, -15] == 1.
-        u.data[6, 0, 0] = 1.
-        assert u.data[-10, :, :].sum() == 1.
-
-        # Test setting whole array to given value
-        u.data[:] = 3.
-        assert np.all(u.data == 3.)
-
-        # Test insertion of single value into block
-        u.data[5, :, 5] = 5.
-        assert np.all(u.data[5, :, 5] == 5.)
-
-        # Test extraction of block with negative indices
-        sliced = u.data[-11, :, -11]
-        assert sliced.shape == (16,)
-        assert np.all(sliced == 5.)
-
-        # Test insertion of block into block
-        block = np.ndarray(shape=(1, 16, 1), dtype=np.float32)
-        block.fill(4.)
-        u.data[4, :, 4] = block
-        assert np.all(u.data[4, :, 4] == block)
-
-    def test_data_arithmetic_nD(self, u):
-        """
-        Tests arithmetic operations through YaskGrids.
-        """
-        u.data[:] = 1
-
-        # Simple arithmetic
-        assert np.all(u.data == 1)
-        assert np.all(u.data + 2. == 3.)
-        assert np.all(u.data - 2. == -1.)
-        assert np.all(u.data * 2. == 2.)
-        assert np.all(u.data / 2. == 0.5)
-        assert np.all(u.data % 2 == 1.)
-
-        # Increments and partial increments
-        u.data[:] += 2.
-        assert np.all(u.data == 3.)
-        u.data[9, :, :] += 1.
-        assert all(np.all(u.data[i, :, :] == 3.) for i in range(9))
-        assert np.all(u.data[9, :, :] == 4.)
-
-        # Right operations __rOP__
-        u.data[:] = 1.
-        arr = np.ndarray(shape=(16, 16, 16), dtype=np.float32)
-        arr.fill(2.)
-        assert np.all(arr - u.data == -1.)
 
 
 class TestOperatorSimple(object):


### PR DESCRIPTION
Yet another consolidation PR

- Better, up-to-date docs
- Fix output reports (reported iteration counts might be a small quantity (O(1)) off)
- Add logic iteration access for modulo buffered dimension (see Slack)
- Refactor the ``codepy.Compiler`` hierarchy and (finally!) get rid of all annoying gcc-induced warnings. Travis' trace will now be much cleaner. 
- If the specific compiler version supports OpenMP 4.0, we now unconditionally add the appropriate ``-openmp`` flag so that ``#pragma simd omp`` are reconognised and vectorization properly triggered
- Drop support for Intel MIC (untested => broken; unused => useless; broken + useless => drop)
