### PR TITLE
Misc: cleanup, fixes, improvements, docs

### DIFF
--- a/devito/__init__.py
+++ b/devito/__init__.py
@@ -56,13 +56,13 @@ configuration.add('backend', 'core', list(backends_registry),
 
 # Set the Instruction Set Architecture (ISA)
 ISAs = [None, 'cpp', 'avx', 'avx2', 'avx512', 'knc']
-configuration.add('isa', None, ISAs)
+configuration.add('isa', 'cpp', ISAs)
 
 # Set the CPU architecture (only codename)
 PLATFORMs = [None, 'intel64', 'sandybridge', 'ivybridge', 'haswell',
              'broadwell', 'skylake', 'knc', 'knl']
 # TODO: switch arch to actual architecture names; use the mapper in /YASK/
-configuration.add('platform', None, PLATFORMs)
+configuration.add('platform', 'intel64', PLATFORMs)
 
 
 # Initialize the configuration, either from the environment or

--- a/devito/__init__.py
+++ b/devito/__init__.py
@@ -14,7 +14,7 @@ from devito.parameters import *  # noqa
 from devito.symbolics import *  # noqa
 from devito.tools import *  # noqa
 
-from devito.compiler import compiler_registry, GNUCompiler
+from devito.compiler import compiler_registry
 from devito.backends import backends_registry, init_backend
 
 
@@ -38,11 +38,7 @@ configuration.add('compiler', 'custom', list(compiler_registry),
 
 def _cast_and_update_compiler(val):
     # Force re-build the compiler
-    compiler = configuration['compiler']
-    if isinstance(compiler, GNUCompiler):
-        compiler.__init__(version=compiler.version)
-    else:
-        compiler.__init__()
+    configuration['compiler'].__init__(suffix=configuration['compiler'].suffix)
     return bool(val)
 
 

--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -131,28 +131,6 @@ class IntelCompiler(Compiler):
             self.ldflags += ['-qopenmp']
 
 
-class IntelMICCompiler(Compiler):
-    """Set of standard compiler flags for the IntelMIC toolchain
-
-    :param openmp: Boolean indicating if openmp is enabled. False by default
-
-    Note: Generates warning if openmp is disabled.
-    """
-
-    def __init__(self, *args, **kwargs):
-        super(IntelMICCompiler, self).__init__(*args, **kwargs)
-        self.cc = 'icc'
-        self.ld = 'icc'
-        self.cflags = ['-O3', '-g', '-fPIC', '-Wall', '-std=c99', "-mmic"]
-        self.ldflags = ['-shared']
-
-        if configuration['openmp']:
-            self.ldflags += ['-qopenmp']
-        else:
-            log("WARNING: Running on Intel MIC without OpenMP is highly discouraged")
-        self._mic = __import__('pymic')
-
-
 class IntelKNLCompiler(Compiler):
     """Set of standard compiler flags for the clang toolchain"""
 
@@ -209,17 +187,7 @@ def load(basename, compiler):
     :param basename: Name of the .so file.
     :param compiler: The toolchain used for compilation.
     :return: The loaded library.
-
-    Note: If the provided compiler is of type `IntelMICCompiler`
-    we utilise the `pymic` package to manage device streams.
     """
-    if isinstance(compiler, IntelMICCompiler):
-        compiler._device = compiler._mic.devices[0]
-        compiler._stream = compiler._device.get_default_stream()
-        # The name with the extension is only used for MIC
-        lib_file = "%s.%s" % (basename, compiler.lib_ext)
-        return compiler._device.load_library(lib_file)
-
     return npct.load_library(basename, '.')
 
 
@@ -289,6 +257,5 @@ compiler_registry = {
     'clang': ClangCompiler, 'osx': ClangCompiler,
     'intel': IntelCompiler, 'icpc': IntelCompiler,
     'icc': IntelCompiler,
-    'intel-mic': IntelMICCompiler, 'mic': IntelMICCompiler,
     'intel-knl': IntelKNLCompiler, 'knl': IntelKNLCompiler,
 }

--- a/devito/dimension.py
+++ b/devito/dimension.py
@@ -69,6 +69,10 @@ class Dimension(sympy.Symbol, DimensionArgProvider):
     def end_name(self):
         return "%s_e" % self.name
 
+    def _hashable_content(self):
+        return super(Dimension, self)._hashable_content() +\
+            (self.reverse, self.spacing)
+
 
 class SpaceDimension(Dimension):
 
@@ -133,6 +137,9 @@ class SteppingDimension(Dimension):
     def spacing(self):
         return self.parent.spacing
 
+    def _hashable_content(self):
+        return (self.parent._hashable_content(), self.modulo)
+
 
 class LoweredDimension(Dimension):
 
@@ -165,3 +172,6 @@ class LoweredDimension(Dimension):
     @property
     def reverse(self):
         return self.stepping.reverse
+
+    def _hashable_content(self):
+        return sympy.Symbol._hashable_content(self) + (self.stepping, self.offset)

--- a/devito/function.py
+++ b/devito/function.py
@@ -47,6 +47,12 @@ class Constant(AbstractSymbol, ConstantArgProvider):
 
     """
     Symbol representing constant values in symbolic equations.
+
+    .. note::
+
+        The parameters must always be given as keyword arguments, since
+        SymPy uses ``*args`` to (re-)create the dimension arguments of the
+        symbolic function.
     """
 
     is_Constant = True
@@ -101,6 +107,12 @@ class Function(TensorFunction):
     :param dtype: (Optional) data type of the buffered data.
     :param space_order: Discretisation order for space derivatives
     :param initializer: Function to initialize the data, optional
+
+    .. note::
+
+        The parameters must always be given as keyword arguments, since
+        SymPy uses ``*args`` to (re-)create the dimension arguments of the
+        symbolic function.
 
     .. note::
 
@@ -338,6 +350,12 @@ class TimeFunction(Function):
 
     .. note::
 
+        The parameters must always be given as keyword arguments, since
+        SymPy uses ``*args`` to (re-)create the dimension arguments of the
+        symbolic function.
+
+    .. note::
+
        If the parameter ``grid`` is provided, the values for ``shape``,
        ``dimensions`` and ``dtype`` will be derived from it.
 
@@ -498,6 +516,12 @@ class SparseFunction(CompositeFunction):
     :param nt: Size of the time dimension for point data
     :param coordinates: Optional coordinate data for the sparse points
     :param dtype: Data type of the buffered data
+
+    .. note::
+
+        The parameters must always be given as keyword arguments, since
+        SymPy uses `*args` to (re-)create the dimension arguments of the
+        symbolic function.
     """
 
     is_SparseFunction = True

--- a/devito/ir/clusters/algorithms.py
+++ b/devito/ir/clusters/algorithms.py
@@ -14,7 +14,7 @@ def groupby(clusters):
     """
     Given an ordered collection of :class:`PartialCluster` objects, return a
     (potentially) smaller sequence in which dependence-free PartialClusters with
-    identical stencil have been squashed into a single PartialCluster.
+    identical stencil have been squashed into a single :class:`PartialCluster`.
     """
     clusters = clusters.unfreeze()
 

--- a/devito/ir/iet/analysis.py
+++ b/devito/ir/iet/analysis.py
@@ -136,19 +136,16 @@ def mark_wrappable(analysis):
         return
     # Finally check that all data dependences would be honored by using the
     # /front/ index function in place of the /back/ index function
-    for tree in analysis.trees:
-        for i in tree:
-            if i == stepper:
-                continue
-            # There must be NO writes to the /back/ timeslot
-            for access in analysis.scopes[i].accesses:
-                if access.is_write and access[stepping] == back:
-                    return
-            # All reads from the /front/ timeslot must not cause dependences with
-            # the writes in the /back/ timeslot along the /i/ dimension
-            for dep in analysis.scopes[i].d_flow:
-                if dep.source[stepping] != front or dep.sink[stepping] != back:
-                    continue
-                if dep.source.section(stepping) != dep.sink.section(stepping):
-                    return
+    # There must be NO writes to the /back/ timeslot
+    for access in analysis.scopes[stepper].accesses:
+        if access.is_write and access[stepping] == back:
+            return
+    # All reads from the /front/ timeslot must not cause dependences with
+    # the writes in the /back/ timeslot along the /i/ dimension
+    for dep in analysis.scopes[stepper].d_flow:
+        if dep.source[stepping] != front or dep.sink[stepping] != back:
+            continue
+        if dep.sink.lex_gt(dep.source) and\
+                dep.source.section(stepping) != dep.sink.section(stepping):
+            return
     analysis.update({stepper: WRAPPABLE})

--- a/devito/ir/iet/nodes.py
+++ b/devito/ir/iet/nodes.py
@@ -400,11 +400,9 @@ class Iteration(Node):
         if a limit is unknown."""
         lower = start if start is not None else self.limits[0]
         upper = finish if finish is not None else self.limits[1]
-        if lower and self.offsets[0]:
-            lower = lower - self.offsets[0]
 
-        if upper and self.offsets[1]:
-            upper = upper - self.offsets[1]
+        lower = lower - self.offsets[0]
+        upper = upper - self.offsets[1]
 
         return (lower, upper)
 

--- a/devito/tools.py
+++ b/devito/tools.py
@@ -271,10 +271,6 @@ class memoized(object):
         return partial(self.__call__, obj)
 
 
-default_isa = 'cpp'
-default_platform = 'intel64'
-
-
 def infer_cpu():
     """
     Detect the highest Instruction Set Architecture and the platform
@@ -283,7 +279,7 @@ def infer_cpu():
     """
     info = cpuinfo.get_cpu_info()
     # ISA
-    isa = default_isa
+    isa = configuration._defaults['isa']
     for i in reversed(configuration._accepted['isa']):
         if i in info['flags']:
             isa = i
@@ -306,7 +302,7 @@ def infer_cpu():
             platform = None
     # Is it a known platform?
     if platform not in configuration._accepted['platform']:
-        platform = default_platform
+        platform = configuration._defaults['platform']
     return isa, platform
 
 

--- a/devito/types.py
+++ b/devito/types.py
@@ -145,7 +145,7 @@ class AbstractSymbol(sympy.Symbol, CachedSymbol):
     def __new__(cls, *args, **kwargs):
         options = kwargs.get('options', {})
         if cls in _SymbolCache:
-            newobj = sympy.Function.__new__(cls, *args, **options)
+            newobj = sympy.Symbol.__new__(cls, *args, **options)
             newobj._cached_init()
         else:
             name = kwargs.get('name')

--- a/devito/types.py
+++ b/devito/types.py
@@ -35,11 +35,7 @@ class Basic(object):
                         -----------------------------------
                         |                                 |
                   CachedSymbol                          Object
-                        |                          <see Object.__doc__>
-           --------------------------
-           |                        |
-    AbstractSymbol          AbstractFunction
-                        <see AbstractFunction.__doc__>
+          <root of the symbol objects>       <root of the generic objects>
 
     All derived :class:`Basic` objects may be emitted through code generation
     to create a just-in-time compilable kernel.
@@ -74,7 +70,31 @@ class Basic(object):
 
 
 class CachedSymbol(Basic):
-    """Base class for symbolic objects that caches on the class type."""
+    """
+    Base class for symbolic objects that caches on the class type.
+
+    In order to maintain meta information across the numerous
+    re-instantiation SymPy performs during symbolic manipulation, we inject
+    the symbol name as the class name and cache all created objects on that
+    name. This entails that a symbolic object inheriting from :class:`CachedSymbol`
+    should implement `__init__` in the following way:
+
+        .. code-block::
+            def __init__(self, \*args, \*\*kwargs):
+                if not self._cached():
+                    ... # Initialise object properties from kwargs
+
+    This class is the root of the symbolic objects hierarchy, which is
+    structured as follows.
+
+                                    CachedSymbol
+                                         |
+                        -----------------------------------
+                        |                                 |
+                  AbstractSymbol                    AbstractFunction
+           <root of the scalar symbols>       <root of the tensor symbols>
+
+    """
 
     @classmethod
     def _cached(cls):
@@ -102,9 +122,22 @@ class CachedSymbol(Basic):
 
 class AbstractSymbol(sympy.Symbol, CachedSymbol):
     """
-    Base class for dimension-free symbols that are cached by Devito,
-    in addition to SymPy caching. Note that these objects are not
-    :class:`Function` objects and do not have any indexing dimensions.
+    Base class for dimension-free symbols, cached by both Devito and Sympy.
+    Note that these objects are not :class:`Function` objects and do not have
+    any indexing dimensions.
+
+    This class is the root of the scalar (i.e., dimension-free) symbols hierarchy,
+    which is structured as follows
+
+                             AbstractSymbol
+                                   |
+                 -------------------------------------
+                 |                                   |
+               Symbol                             Constant
+
+    The difference between a :class:`Constant` and a :class:`Symbol` object
+    is that the former carries data (a scalar) and is created directly by the
+    user, whereas the latter is created and managed internally by Devito.
     """
 
     is_AbstractSymbol = True
@@ -162,52 +195,30 @@ class Symbol(AbstractSymbol):
 
 
 class AbstractFunction(sympy.Function, CachedSymbol):
-    """Base class for data classes that provides symbolic behaviour.
+    """
+    Base class for tensor symbols, cached by both Devito and SymPy.
+    It inherits from and mimick the behaviour of a :class:`sympy.Function`.
 
-    :param name: Symbolic name to give to the resulting function. Must
-                 be given as keyword argument.
-    :param shape: Shape of the underlying object. Must be given as
-                  keyword argument.
+    This class is the root of the tensor symbols hierarchy, which is
+    structured as follows.
 
-    This class implements the behaviour of Devito's symbolic
-    objects by inheriting from and mimicking the behaviour of
-    :class:`sympy.Function`. In order to maintain meta information
-    across the numerous re-instantiation SymPy performs during
-    symbolic manipulation, we inject the symbol name as the class name
-    and cache all created objects on that name. This entails that a
-    symbolic object should implement `__init__` in the following
-    format:
-
-    def __init__(self, \*args, \*\*kwargs):
-        if not self._cached():
-            ... # Initialise object properties from kwargs
-
-    Note: The parameters :param name: and :param shape: must always be
-    present and given as keyword arguments, since SymPy uses `*args`
-    to (re-)create the dimension arguments of the symbolic function.
-
-    This class is the root of the Devito data objects hierarchy, which
-    is structured as follows.
-
-                             AbstractFunction
+                            AbstractFunction
                                    |
                  -------------------------------------
                  |                                   |
             SymbolicData                      SymbolicFunction
                  |                                   |
-          ------------------                 ------------------
-          |                |                 |                |
-       Scalar            Array            Constant      TensorFunction
-                                                              |
-                                                ------------------------------
-                                                |             |              |
-                                            Function      TimeFunction  CompositeFunction
-                                                                             |
-                                                                         SparseFunction
+               Array                           TensorFunction
+                                                     |
+                                       ------------------------------
+                                       |             |              |
+                                    Function    TimeFunction  CompositeFunction
+                                                                    |
+                                                               SparseFunction
 
     The key difference between a :class:`SymbolicFunction` and a :class:`SymbolicData`
-    is that the former is created directly by the user and employed in some
-    computation, while the latter is created and managed internally by Devito.
+    object is that the former carries data and is created directly by the user,
+    whereas the latter is created and managed internally by Devito.
     """
 
     is_AbstractFunction = True

--- a/devito/yask/utils.py
+++ b/devito/yask/utils.py
@@ -116,7 +116,7 @@ def convert_multislice(multislice, shape, offsets, mode='get'):
             elif v.stop < 0:
                 stop = shape[i] + v.stop
             else:
-                stop = v.stop
+                stop = v.stop - 1
             cstop.append(stop)
             cshape.append(cstop[-1] - cstart[-1] + 1)
         else:

--- a/devito/yask/wrappers.py
+++ b/devito/yask/wrappers.py
@@ -120,30 +120,31 @@ class YaskGrid(object):
     def __repr__(self):
         return repr(self[:])
 
-    def __meta_binop(op):
+    def __meta_op__(op, reverse=False):
         # Used to build all binary operations such as __eq__, __add__, etc.
         # These all boil down to calling the numpy equivalents
         def f(self, other):
-            return getattr(self[:], op)(other)
+            o1, o2 = (self[:], other) if reverse is False else (other, self[:])
+            return getattr(o1, op)(o2)
         return f
-    __eq__ = __meta_binop('__eq__')
-    __ne__ = __meta_binop('__ne__')
-    __le__ = __meta_binop('__le__')
-    __lt__ = __meta_binop('__lt__')
-    __ge__ = __meta_binop('__ge__')
-    __gt__ = __meta_binop('__gt__')
-    __add__ = __meta_binop('__add__')
-    __radd__ = __meta_binop('__add__')
-    __sub__ = __meta_binop('__sub__')
-    __rsub__ = __meta_binop('__sub__')
-    __mul__ = __meta_binop('__mul__')
-    __rmul__ = __meta_binop('__mul__')
-    __div__ = __meta_binop('__div__')
-    __rdiv__ = __meta_binop('__div__')
-    __truediv__ = __meta_binop('__truediv__')
-    __rtruediv__ = __meta_binop('__truediv__')
-    __mod__ = __meta_binop('__mod__')
-    __rmod__ = __meta_binop('__mod__')
+    __eq__ = __meta_op__('__eq__')
+    __ne__ = __meta_op__('__ne__')
+    __le__ = __meta_op__('__le__')
+    __lt__ = __meta_op__('__lt__')
+    __ge__ = __meta_op__('__ge__')
+    __gt__ = __meta_op__('__gt__')
+    __add__ = __meta_op__('__add__')
+    __radd__ = __meta_op__('__add__')
+    __sub__ = __meta_op__('__sub__')
+    __rsub__ = __meta_op__('__sub__', True)
+    __mul__ = __meta_op__('__mul__')
+    __rmul__ = __meta_op__('__mul__', True)
+    __div__ = __meta_op__('__div__')
+    __rdiv__ = __meta_op__('__div__', True)
+    __truediv__ = __meta_op__('__truediv__')
+    __rtruediv__ = __meta_op__('__truediv__', True)
+    __mod__ = __meta_op__('__mod__')
+    __rmod__ = __meta_op__('__mod__', True)
 
     def _reset(self):
         """

--- a/tests/test_yask.py
+++ b/tests/test_yask.py
@@ -126,7 +126,7 @@ class TestGrids(object):
         u.data[:] = 1.
         arr = np.ndarray(shape=(16, 16, 16), dtype=np.float32)
         arr.fill(2.)
-        assert np.all(arr - u.data == -1.)
+        assert np.all(arr - u.data == 1.)
 
 
 class TestOperatorSimple(object):


### PR DESCRIPTION
Yet another consolidation PR

- Improved (up-to-date) docs
- Fix output reports (reported iteration counts might be a small quantity (O(1)) off)
- Refactor the ``codepy.Compiler`` hierarchy and (finally!) get rid of all annoying gcc-induced warnings. Travis' trace will now be much cleaner. 
- If the specific compiler version supports OpenMP 4.0, we now unconditionally add the appropriate ``-openmp`` flag so that ``#pragma simd omp`` are reconognised and vectorization properly triggered
- Drop support for Intel MIC (untested => broken; unused => useless; broken + useless => drop)
- Fix a subtle bug by adding a specialised ``_hashable_content`` to ``Dimensions``
- Minor fixes in YASK