### PR TITLE
Memoization fix and misc

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -65,8 +65,7 @@ before_script:
   - if [[ $DEVITO_BACKEND == 'yask' ]]; then
       conda install swig; cd ../;
       git clone https://github.com/opesci/yask.git;
-      cd yask; git checkout develop;
-      make compiler && make compiler-api; pip install -e .; cd ../devito;
+      cd yask; make compiler && make compiler-api; pip install -e .; cd ../devito;
     fi
 
 script:

--- a/devito/data.py
+++ b/devito/data.py
@@ -51,7 +51,7 @@ class Data(np.ndarray):
         return obj
 
     def __del__(self):
-        if self._c_pointer is not None:
+        if self._c_pointer is None:
             return
         free(self._c_pointer)
         self._c_pointer = None
@@ -66,9 +66,9 @@ class Data(np.ndarray):
         else:
             self.modulo = tuple(None for i in range(self.ndim))
         self.halo = getattr(obj, 'halo', None)
-        # Views or references created via operations on `obj` do not get
-        # an explicit reference to the C pointer (`_c_pointer`). This makes
-        # sure that only one object (the "root" Data) will free the C-allocated
+        # Views or references created via operations on `obj` do not get an
+        # explicit reference to the C pointer (`_c_pointer`). This makes sure
+        # that only one object (the "root" Data) will free the C-allocated memory
         self._c_pointer = None
 
     def __getitem__(self, index):

--- a/devito/tools.py
+++ b/devito/tools.py
@@ -10,7 +10,7 @@ from distutils import version
 
 from devito.parameters import configuration
 
-__all__ = ['memoized', 'infer_cpu', 'sweep', 'silencio']
+__all__ = ['memoized_func', 'memoized_meth', 'infer_cpu', 'sweep', 'silencio']
 
 
 def as_tuple(item, type=None, length=None):
@@ -231,11 +231,13 @@ class change_directory(object):
         os.chdir(self.savedPath)
 
 
-class memoized(object):
+class memoized_func(object):
     """
     Decorator. Caches a function's return value each time it is called.
     If called later with the same arguments, the cached value is returned
-    (not reevaluated).
+    (not reevaluated). This decorator may also be used on class methods,
+    but it will cache at the class level; to cache at the instance level,
+    use ``memoized_meth``.
 
     Adapted from: ::
 
@@ -265,6 +267,55 @@ class memoized(object):
     def __get__(self, obj, objtype):
         """Support instance methods."""
         return partial(self.__call__, obj)
+
+
+class memoized_meth(object):
+    """
+    Decorator. Cache the return value of a class method.
+
+    Unlike ``memoized_func``, the return value of a given method invocation
+    will be cached on the instance whose method was invoked. All arguments
+    passed to a method decorated with memoize must be hashable.
+
+    If a memoized method is invoked directly on its class the result will not
+    be cached. Instead the method will be invoked like a static method: ::
+
+        class Obj(object):
+            @memoize
+            def add_to(self, arg):
+                return self + arg
+        Obj.add_to(1) # not enough arguments
+        Obj.add_to(1, 2) # returns 3, result is not cached
+
+    Adapted from: ::
+
+        code.activestate.com/recipes/577452-a-memoize-decorator-for-instance-methods/
+    """
+
+    def __init__(self, func):
+        self.func = func
+
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            return self.func
+        return partial(self, obj)
+
+    def __call__(self, *args, **kw):
+        if not isinstance(args, Hashable):
+            # Uncacheable, a list, for instance.
+            # Better to not cache than blow up.
+            return self.func(*args)
+        obj = args[0]
+        try:
+            cache = obj.__cache
+        except AttributeError:
+            cache = obj.__cache = {}
+        key = (self.func, args[1:], frozenset(kw.items()))
+        try:
+            res = cache[key]
+        except KeyError:
+            res = cache[key] = self.func(*args, **kw)
+        return res
 
 
 def infer_cpu():

--- a/devito/tools.py
+++ b/devito/tools.py
@@ -277,7 +277,9 @@ def infer_cpu():
     # ISA
     isa = configuration._defaults['isa']
     for i in reversed(configuration._accepted['isa']):
-        if i in info['flags']:
+        if any(j.startswith(i) for j in info['flags']):
+            # Using `startswith`, rather than `==`, as a flag such as 'avx512'
+            # appears as 'avx512f, avx512cd, ...'
             isa = i
             break
     # Platform

--- a/devito/yask/data.py
+++ b/devito/yask/data.py
@@ -92,6 +92,10 @@ class Data(object):
             # array, i.e., it's not a view
             self.base = None
 
+    def __del__(self):
+        if self.base is None:
+            self.grid.release_storage()
+
     def __getitem__(self, index):
         start, stop, shape = self._convert_index(index)
         if not shape:

--- a/examples/seismic/acoustic/wavesolver.py
+++ b/examples/seismic/acoustic/wavesolver.py
@@ -1,4 +1,4 @@
-from devito import Function, TimeFunction, memoized
+from devito import Function, TimeFunction, memoized_meth
 from examples.seismic import PointSource, Receiver
 from examples.seismic.acoustic.operators import (
     ForwardOperator, AdjointOperator, GradientOperator, BornOperator
@@ -42,28 +42,28 @@ class AcousticWaveSolver(object):
         # Cache compiler options
         self._kwargs = kwargs
 
-    @memoized
+    @memoized_meth
     def op_fwd(self, save=False):
         """Cached operator for forward runs with buffered wavefield"""
         return ForwardOperator(self.model, save=save, source=self.source,
                                receiver=self.receiver, time_order=self.time_order,
                                space_order=self.space_order, **self._kwargs)
 
-    @memoized
+    @memoized_meth
     def op_adj(self):
         """Cached operator for adjoint runs"""
         return AdjointOperator(self.model, save=False, source=self.source,
                                receiver=self.receiver, time_order=self.time_order,
                                space_order=self.space_order, **self._kwargs)
 
-    @memoized
+    @memoized_meth
     def op_grad(self):
         """Cached operator for gradient runs"""
         return GradientOperator(self.model, save=True, source=self.source,
                                 receiver=self.receiver, time_order=self.time_order,
                                 space_order=self.space_order, **self._kwargs)
 
-    @memoized
+    @memoized_meth
     def op_born(self):
         """Cached operator for born runs"""
         return BornOperator(self.model, save=False, source=self.source,

--- a/examples/seismic/benchmark.py
+++ b/examples/seismic/benchmark.py
@@ -63,7 +63,7 @@ def option_performance(f):
         'O3': {'autotune': True, 'dse': 'aggressive', 'dle': 'advanced'},
         # Parametric
         'dse': {'autotune': True,
-                'dse': ['basic', 'advanced', 'speculative', 'aggressive'],
+                'dse': ['basic', 'advanced', 'aggressive'],
                 'dle': 'advanced'},
         'dle': {'autotune': True,
                 'dse': 'advanced',
@@ -250,12 +250,10 @@ def plot(problem, **kwargs):
         # DLE basic
         ('basic', 'basic'): ('D', 'r'),
         ('advanced', 'basic'): ('D', 'g'),
-        ('speculative', 'basic'): ('D', 'y'),
         ('aggressive', 'basic'): ('D', 'b'),
         # DLE advanced
         ('basic', 'advanced'): ('o', 'r'),
         ('advanced', 'advanced'): ('o', 'g'),
-        ('speculative', 'advanced'): ('o', 'y'),
         ('aggressive', 'advanced'): ('o', 'b'),
     }
 

--- a/examples/seismic/benchmark.py
+++ b/examples/seismic/benchmark.py
@@ -333,14 +333,14 @@ def get_ob_exec(func):
             self.func = func
 
         def run(self, *args, **kwargs):
+            clear_cache()
+
             gflopss, oi, timings, _ = self.func(*args, **kwargs)
 
             for key in timings.keys():
                 self.register(gflopss[key], measure="gflopss", event=key)
                 self.register(oi[key], measure="oi", event=key)
                 self.register(timings[key], measure="timings", event=key)
-
-            clear_cache()
 
     return DevitoExecutor(func)
 

--- a/examples/seismic/benchmark.py
+++ b/examples/seismic/benchmark.py
@@ -334,6 +334,10 @@ def get_ob_exec(func):
 
         def run(self, *args, **kwargs):
             clear_cache()
+            # Temporary hack
+            if configuration['backend'] == 'yask':
+                from devito.yask.wrappers import contexts
+                contexts.dump()
 
             gflopss, oi, timings, _ = self.func(*args, **kwargs)
 

--- a/examples/seismic/tti/wavesolver.py
+++ b/examples/seismic/tti/wavesolver.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-from devito import TimeFunction, memoized
+from devito import TimeFunction, memoized_meth
 from examples.seismic.tti.operators import ForwardOperator
 from examples.seismic import Receiver
 
@@ -31,7 +31,7 @@ class AnisotropicWaveSolver(object):
         # Cache compiler options
         self._kwargs = kwargs
 
-    @memoized
+    @memoized_meth
     def op_fwd(self, kernel='shifted', save=False):
         """Cached operator for forward runs with buffered wavefield"""
         return ForwardOperator(self.model, save=save, source=self.source,


### PR DESCRIPTION
Our memoizer caches at the class level; for the seismic wrappers, instead, it'd be better to cache at the instance level. Otherwise, these are unusable from ``benchmark.py`` as we would start leaking memory. This PR mainly introduces a new memoizer suitable for instance-level caching. It also ships a number of minor fixes