### PR TITLE
Some consolidation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,10 +71,6 @@ before_script:
     fi
 
 script:
-  - cat /proc/cpuinfo
-  - lscpu
-  - gcc -march=native -Q --help=target
-  - gcc -march=native -Q --help=target | grep march
   - flake8 --builtins=ArgumentError .
   - py.test -vs tests/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -71,6 +71,10 @@ before_script:
     fi
 
 script:
+  - cat /proc/cpuinfo
+  - lscpu
+  - gcc -march=native -Q --help=target
+  - gcc -march=native -Q --help=target | grep march
   - flake8 --builtins=ArgumentError .
   - py.test -vs tests/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ matrix:
       env: DEVITO_ARCH=gcc-4.9 DEVITO_OPENMP=1 OMP_NUM_THREADS=2
     - os: linux
       python: "3.6"
-      env: DEVITO_ARCH=gcc-4.9 DEVITO_OPENMP=0 DEVITO_BACKEND=yask
+      env: DEVITO_ARCH=gcc-7 DEVITO_OPENMP=0 DEVITO_BACKEND=yask
   allow_failures:
     - os: linux
       python: "2.7"
@@ -33,12 +33,14 @@ matrix:
 addons:
   apt:
     sources:
-      - ubuntu-toolchain-r-test     # For gcc 4.9 and 5
+      - ubuntu-toolchain-r-test     # For gcc 4.9, 5 and 7
     packages:
       - gcc-4.9
       - g++-4.9
       - gcc-5
       - g++-5
+      - gcc-7
+      - g++-7
 
 before_install:
   # Setup anaconda

--- a/.travis.yml
+++ b/.travis.yml
@@ -65,8 +65,7 @@ before_script:
   - if [[ $DEVITO_BACKEND == 'yask' ]]; then
       conda install swig; cd ../;
       git clone https://github.com/opesci/yask.git;
-      cd yask; git checkout develop;
-      make compiler && make compiler-api; pip install -e .; cd ../devito;
+      cd yask; make compiler && make compiler-api; pip install -e .; cd ../devito;
     fi
 
 script:

--- a/devito/__init__.py
+++ b/devito/__init__.py
@@ -1,14 +1,10 @@
 from __future__ import absolute_import
-import gc
-
-from sympy.core import cache
 
 from devito.base import *  # noqa
 from devito.finite_difference import *  # noqa
 from devito.dimension import *  # noqa
 from devito.grid import *  # noqa
 from devito.function import Forward, Backward  # noqa
-from devito.types import _SymbolCache  # noqa
 from devito.logger import error, warning, info  # noqa
 from devito.parameters import *  # noqa
 from devito.symbolics import *  # noqa
@@ -16,15 +12,6 @@ from devito.tools import *  # noqa
 
 from devito.compiler import compiler_registry
 from devito.backends import backends_registry, init_backend
-
-
-def clear_cache():
-    cache.clear_cache()
-    gc.collect()
-
-    for key, val in list(_SymbolCache.items()):
-        if val() is None:
-            del _SymbolCache[key]
 
 
 from ._version import get_versions  # noqa
@@ -63,3 +50,7 @@ configuration.add('platform', 'intel64', PLATFORMs)
 # Initialize the configuration, either from the environment or
 # defaults. This will also trigger the backend initialization
 init_configuration()
+
+
+# Expose a mechanism to clean up the symbol caches (SymPy's, Devito's)
+clear_cache = CacheManager().clear  # noqa

--- a/devito/__init__.py
+++ b/devito/__init__.py
@@ -51,12 +51,11 @@ configuration.add('backend', 'core', list(backends_registry),
                   callback=init_backend)
 
 # Set the Instruction Set Architecture (ISA)
-ISAs = [None, 'cpp', 'avx', 'avx2', 'avx512', 'knc']
+ISAs = [None, 'cpp', 'avx', 'avx2', 'avx512']
 configuration.add('isa', 'cpp', ISAs)
 
 # Set the CPU architecture (only codename)
-PLATFORMs = [None, 'intel64', 'sandybridge', 'ivybridge', 'haswell',
-             'broadwell', 'skylake', 'knc', 'knl']
+PLATFORMs = [None, 'intel64', 'snb', 'ivb', 'hsw', 'bdw', 'skx', 'knl']
 # TODO: switch arch to actual architecture names; use the mapper in /YASK/
 configuration.add('platform', 'intel64', PLATFORMs)
 

--- a/devito/__init__.py
+++ b/devito/__init__.py
@@ -38,12 +38,11 @@ configuration.add('backend', 'core', list(backends_registry),
                   callback=init_backend)
 
 # Set the Instruction Set Architecture (ISA)
-ISAs = [None, 'cpp', 'avx', 'avx2', 'avx512']
+ISAs = ['cpp', 'avx', 'avx2', 'avx512']
 configuration.add('isa', 'cpp', ISAs)
 
 # Set the CPU architecture (only codename)
-PLATFORMs = [None, 'intel64', 'snb', 'ivb', 'hsw', 'bdw', 'skx', 'knl']
-# TODO: switch arch to actual architecture names; use the mapper in /YASK/
+PLATFORMs = ['intel64', 'snb', 'ivb', 'hsw', 'bdw', 'skx', 'knl']
 configuration.add('platform', 'intel64', PLATFORMs)
 
 

--- a/devito/base.py
+++ b/devito/base.py
@@ -36,3 +36,7 @@ class SparseFunction(with_metaclass(_BackendSelector, function.SparseFunction)):
 
 class Operator(with_metaclass(_BackendSelector, operator.Operator)):
     pass
+
+
+class CacheManager(with_metaclass(_BackendSelector, types.CacheManager)):
+    pass

--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -271,7 +271,8 @@ def make(loc, args):
                 log.write(" ".join(command))
                 log.write("\n\n")
                 try:
-                    subprocess.check_call(command, stderr=err, stdout=log)
+                    #subprocess.check_call(command, stderr=err, stdout=log)
+                    subprocess.check_call(command, stderr=subprocess.STDOUT)
                 except subprocess.CalledProcessError as e:
                     raise CompilationError('Command "%s" return error status %d. '
                                            'Unable to compile code.\n'

--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -42,32 +42,46 @@ class Compiler(GCCToolchain):
         * :data:`self.src_ext`
         * :data:`self.lib_ext`
         * :data:`self.undefines`
-    """
 
-    cpp_mapper = {'gcc': 'g++', 'clang': 'clang++', 'icc': 'icpc',
-                  'gcc-4.9': 'g++-4.9', 'gcc-5': 'g++-5', 'gcc-6': 'g++-6'}
+    Two additional parameters may be passed.
+    :param suffix: A string indicating a specific compiler version available on
+                   the system. For example, assuming ``compiler=gcc`` and
+                   ``suffix='4.9'``, then the ``gcc-4.9`` program will be used
+                   to compile the generated code.
+    :param cpp: Defaults to False. Pass True to set up for C++ compilation,
+                instead of C compilation.
+    """
 
     fields = {'cc', 'ld'}
 
     CC = 'unknown'
-    LD = 'unknown'
+    CPP = 'unknown'
 
     def __init__(self, **kwargs):
         super(Compiler, self).__init__(**kwargs)
+
         self.suffix = kwargs.get('suffix')
-        self.cc = self.CC if self.suffix is None else ('%s-%s' % (self.CC, self.suffix))
-        self.ld = self.LD if self.suffix is None else ('%s-%s' % (self.LD, self.suffix))
+        self.cc = self.CC if kwargs.get('cpp', False) is False else self.CPP
+        self.cc = self.cc if self.suffix is None else ('%s-%s' % (self.cc, self.suffix))
+        self.ld = self.cc  # Wanted by the superclass
+
         self.cflags = ['-O3', '-g', '-fPIC', '-Wall', '-std=c99']
         self.ldflags = ['-shared']
+
         self.include_dirs = []
         self.libraries = []
         self.library_dirs = []
         self.defines = []
         self.undefines = []
-        self.src_ext = 'c'
+
+        self.src_ext = 'c' if kwargs.get('cpp', False) is False else 'cpp'
         self.lib_ext = 'so'
+
         if self.suffix is not None:
-            self.version = self.suffix
+            try:
+                self.version = version.StrictVersion(str(float(self.suffix)))
+            except (TypeError, ValueError):
+                self.version = version.LooseVersion(self.suffix)
         else:
             # Knowing the version may still be useful to pick supported flags
             self.version = sniff_compiler_version(self.CC)
@@ -83,7 +97,7 @@ class GNUCompiler(Compiler):
     """Set of standard compiler flags for the GCC toolchain."""
 
     CC = 'gcc'
-    LD = 'gcc'
+    CPP = 'g++'
 
     def __init__(self, *args, **kwargs):
         super(GNUCompiler, self).__init__(*args, **kwargs)
@@ -121,7 +135,7 @@ class ClangCompiler(Compiler):
     """
 
     CC = 'clang'
-    LD = 'clang'
+    CPP = 'clang++'
 
     def __init__(self, *args, **kwargs):
         super(ClangCompiler, self).__init__(*args, **kwargs)
@@ -135,7 +149,7 @@ class IntelCompiler(Compiler):
     """
 
     CC = 'icc'
-    LD = 'icc'
+    CPP = 'icpc'
 
     def __init__(self, *args, **kwargs):
         super(IntelCompiler, self).__init__(*args, **kwargs)
@@ -170,13 +184,13 @@ class CustomCompiler(Compiler):
 
     :param openmp: Boolean indicating if openmp is enabled. False by default
 
-    Note: Currently honours CC, CFLAGS, LD and LDFLAGS, with defaults similar
+    Note: Currently honours CC, CFLAGS and LDFLAGS, with defaults similar
     to the default GNU settings. If DEVITO_ARCH is enabled, the OpenMP linker
     flags are read from OMP_LDFLAGS or otherwise default to ``-fopenmp``.
     """
 
     CC = environ.get('CC', 'gcc')
-    LD = environ.get('LD', 'gcc')
+    CPP = environ.get('CPP', 'g++')
 
     def __init__(self, *args, **kwargs):
         super(CustomCompiler, self).__init__(*args, **kwargs)
@@ -272,8 +286,6 @@ compiler_registry = {
     'custom': CustomCompiler,
     'gnu': GNUCompiler,
     'gcc': GNUCompiler,
-    'gcc-4.9': partial(GNUCompiler, suffix='4.9'),
-    'gcc-5': partial(GNUCompiler, suffix='5'),
     'gcc-noavx': GNUCompilerNoAVX,
     'gnu-noavx': GNUCompilerNoAVX,
     'clang': ClangCompiler,
@@ -284,3 +296,5 @@ compiler_registry = {
     'intel-knl': IntelKNLCompiler,
     'knl': IntelKNLCompiler,
 }
+compiler_registry.update({'gcc-%s' % i: partial(GNUCompiler, suffix=i)
+                          for i in ['4.9', '5', '6', '7']})

--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -140,7 +140,7 @@ class IntelCompiler(Compiler):
     def __init__(self, *args, **kwargs):
         super(IntelCompiler, self).__init__(*args, **kwargs)
         self.cflags += ["-xhost"]
-        if configuration['platform'] == 'skylake':
+        if configuration['platform'] == 'skx':
             # Systematically use 512-bit vectors on skylake
             self.cflags += ["-qopt-zmm-usage=high"]
         try:

--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -271,8 +271,7 @@ def make(loc, args):
                 log.write(" ".join(command))
                 log.write("\n\n")
                 try:
-                    #subprocess.check_call(command, stderr=err, stdout=log)
-                    subprocess.check_call(command, stderr=subprocess.STDOUT)
+                    subprocess.check_call(command, stderr=err, stdout=log)
                 except subprocess.CalledProcessError as e:
                     raise CompilationError('Command "%s" return error status %d. '
                                            'Unable to compile code.\n'

--- a/devito/core/__init__.py
+++ b/devito/core/__init__.py
@@ -18,3 +18,4 @@ add_sub_configuration(core_configuration, env_vars_mapper)
 # The following used by backends.backendSelector
 from devito.function import Constant, Function, TimeFunction, SparseFunction  # noqa
 from devito.core.operator import Operator  # noqa
+from devito.types import CacheManager  # noqa

--- a/devito/data.py
+++ b/devito/data.py
@@ -51,7 +51,7 @@ class Data(np.ndarray):
         return obj
 
     def __del__(self):
-        if self._c_pointer is not None:
+        if self._c_pointer is None:
             return
         free(self._c_pointer)
         self._c_pointer = None
@@ -66,9 +66,9 @@ class Data(np.ndarray):
         else:
             self.modulo = tuple(None for i in range(self.ndim))
         self.halo = getattr(obj, 'halo', None)
-        # Views or references created via operations on `obj` do not get
-        # an explicit reference to the C pointer (`_c_pointer`). This makes
-        # sure that only one object (the "root" Data) will free the C-allocated
+        # Views or references created via operations on `obj` do not get an
+        # explicit reference to the C pointer (`_c_pointer`). This makes sure
+        # that only one object (the "root" Data) will free the C-allocated memory
         self._c_pointer = None
 
     def __getitem__(self, index):

--- a/devito/parameters.py
+++ b/devito/parameters.py
@@ -30,9 +30,16 @@ class Parameters(OrderedDict):
             for key, value in kwargs.items():
                 self[key] = value
 
-    def __setitem__(self, key, value):
-        super(Parameters, self).__setitem__(key, value)
-        self._updated(key, value)
+    def _check_key_value(func):
+        def wrapper(self, key, value):
+            accepted = self._accepted[key]
+            if accepted is not None:
+                tocheck = list(value) if isinstance(value, dict) else [value]
+                if any(i not in accepted for i in tocheck):
+                    raise ValueError("Illegal configuration parameter (%s, %s). "
+                                     "Accepted: %s" % (key, value, str(accepted)))
+            func(self, key, value)
+        return wrapper
 
     def _updated(self, key, value):
         """
@@ -43,6 +50,19 @@ class Parameters(OrderedDict):
             retval = self._update_functions[key](value)
             if retval is not None:
                 super(Parameters, self).__setitem__(key, retval)
+
+    @_check_key_value
+    def __setitem__(self, key, value):
+        super(Parameters, self).__setitem__(key, value)
+        self._updated(key, value)
+
+    @_check_key_value
+    def update(self, key, value):
+        """
+        Update the parameter ``key`` to ``value``. This is different from
+        ``self[key] = value`` as the callback, if any, is bypassed.
+        """
+        super(Parameters, self).__setitem__(key, value)
 
     def add(self, key, value, accepted=None, callback=None):
         """
@@ -58,14 +78,6 @@ class Parameters(OrderedDict):
         self._defaults[key] = value
         if callable(callback):
             self._update_functions[key] = callback
-
-    def update(self, key, value):
-        """
-        Update the parameter ``key`` to ``value``. This is different from
-        ``self[key] = value`` as the callback, if any, is bypassed.
-        """
-        assert key in self
-        super(Parameters, self).__setitem__(key, value)
 
     def initialize(self):
         """
@@ -102,14 +114,14 @@ def init_configuration(configuration=configuration, env_vars_mapper=env_vars_map
     # Populate /configuration/ with user-provided options
     if environ.get('DEVITO_CONFIG') is None:
         # Try env variables, otherwise stick to defaults
-        for k, v in sorted(env_vars_mapper.items()):
-            configuration.update(v, environ.get(k, configuration._defaults[v]))
+        unprocessed = OrderedDict([(v, environ.get(k, configuration._defaults[v]))
+                                   for k, v in sorted(env_vars_mapper.items())])
     else:
         # Attempt reading from the specified configuration file
         raise NotImplementedError("Devito doesn't support configuration via file yet.")
 
     # Parameters validation
-    for k, v in list(configuration.items()):
+    for k, v in unprocessed.items():
         try:
             items = v.split(';')
             # Env variable format: 'var=k1:v1;k2:v2:k3:v3:...'
@@ -130,10 +142,6 @@ def init_configuration(configuration=configuration, env_vars_mapper=env_vars_map
                     keys[i] = int(j)
                 except (TypeError, ValueError):
                     keys[i] = j
-        accepted = configuration._accepted[k]
-        if accepted is not None and any(i not in accepted for i in keys):
-            raise ValueError("Illegal configuration parameter (%s, %s). "
-                             "Accepted: %s" % (k, v, str(accepted)))
         if len(keys) == len(values):
             configuration.update(k, dict(zip(keys, values)))
         elif len(keys) == 1:
@@ -146,7 +154,11 @@ def init_configuration(configuration=configuration, env_vars_mapper=env_vars_map
 
 def add_sub_configuration(sub_configuration, sub_env_vars_mapper=None):
     init_configuration(sub_configuration, sub_env_vars_mapper or {})
+    # For use from within a backend (i.e., inside Devito)
     setattr(configuration, sub_configuration.name, sub_configuration)
+    # For use in user code, when the backend is a runtime choice and some
+    # options are in common between the supported backends
+    setattr(configuration, 'backend', sub_configuration)
 
 
 def print_defaults():

--- a/devito/tools.py
+++ b/devito/tools.py
@@ -10,7 +10,7 @@ from distutils import version
 
 from devito.parameters import configuration
 
-__all__ = ['memoized', 'infer_cpu', 'sweep', 'silencio']
+__all__ = ['memoized_func', 'memoized_meth', 'infer_cpu', 'sweep', 'silencio']
 
 
 def as_tuple(item, type=None, length=None):
@@ -231,11 +231,13 @@ class change_directory(object):
         os.chdir(self.savedPath)
 
 
-class memoized(object):
+class memoized_func(object):
     """
     Decorator. Caches a function's return value each time it is called.
     If called later with the same arguments, the cached value is returned
-    (not reevaluated).
+    (not reevaluated). This decorator may also be used on class methods,
+    but it will cache at the class level; to cache at the instance level,
+    use ``memoized_meth``.
 
     Adapted from: ::
 
@@ -265,6 +267,55 @@ class memoized(object):
     def __get__(self, obj, objtype):
         """Support instance methods."""
         return partial(self.__call__, obj)
+
+
+class memoized_meth(object):
+    """
+    Decorator. Cache the return value of a class method.
+
+    Unlike ``memoized_func``, the return value of a given method invocation
+    will be cached on the instance whose method was invoked. All arguments
+    passed to a method decorated with memoize must be hashable.
+
+    If a memoized method is invoked directly on its class the result will not
+    be cached. Instead the method will be invoked like a static method: ::
+
+        class Obj(object):
+            @memoize
+            def add_to(self, arg):
+                return self + arg
+        Obj.add_to(1) # not enough arguments
+        Obj.add_to(1, 2) # returns 3, result is not cached
+
+    Adapted from: ::
+
+        code.activestate.com/recipes/577452-a-memoize-decorator-for-instance-methods/
+    """
+
+    def __init__(self, func):
+        self.func = func
+
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            return self.func
+        return partial(self, obj)
+
+    def __call__(self, *args, **kw):
+        if not isinstance(args, Hashable):
+            # Uncacheable, a list, for instance.
+            # Better to not cache than blow up.
+            return self.func(*args)
+        obj = args[0]
+        try:
+            cache = obj.__cache
+        except AttributeError:
+            cache = obj.__cache = {}
+        key = (self.func, args[1:], frozenset(kw.items()))
+        try:
+            res = cache[key]
+        except KeyError:
+            res = cache[key] = self.func(*args, **kw)
+        return res
 
 
 def infer_cpu():

--- a/devito/tools.py
+++ b/devito/tools.py
@@ -277,7 +277,9 @@ def infer_cpu():
     # ISA
     isa = configuration._defaults['isa']
     for i in reversed(configuration._accepted['isa']):
-        if i in info['flags']:
+        if any(j.startswith(i) for j in info['flags']):
+            # Using `startswith`, rather than `==`, as a flag such as 'avx512'
+            # appears as 'avx512f, avx512cd, ...'
             isa = i
             break
     # Platform

--- a/devito/tools.py
+++ b/devito/tools.py
@@ -348,9 +348,8 @@ def infer_cpu():
     except:
         # Then, try infer from the brand name, otherwise fallback to default
         try:
-            mapper = {'v3': 'hsw', 'v4': 'bdw', 'v5': 'skx'}
-            cpu_iteration = info['brand'].split()[4]
-            platform = mapper[cpu_iteration]
+            platform = info['brand'].split()[4]
+            platform = {'v2': 'ivb', 'v3': 'hsw', 'v4': 'bdw', 'v5': 'skx'}[platform]
         except:
             platform = None
     # Is it a known platform?

--- a/devito/tools.py
+++ b/devito/tools.py
@@ -341,10 +341,14 @@ def infer_cpu():
         p1.stdout.close()  # Allow p1 to receive a SIGPIPE if p2 exits.
         output, _ = p2.communicate()
         platform = output.decode("utf-8").split()[1]
+        # Full list of possible /platform/ values at this point at:
+        # https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html
+        platform = {'sandybridge': 'snb', 'ivybridge': 'ivb', 'haswell': 'hsw',
+                    'broadwell': 'bdw', 'skylake': 'skx', 'knl': 'knl'}[platform]
     except:
         # Then, try infer from the brand name, otherwise fallback to default
         try:
-            mapper = {'v3': 'haswell', 'v4': 'broadwell', 'v5': 'skylake'}
+            mapper = {'v3': 'hsw', 'v4': 'bdw', 'v5': 'skx'}
             cpu_iteration = info['brand'].split()[4]
             platform = mapper[cpu_iteration]
         except:

--- a/devito/types.py
+++ b/devito/types.py
@@ -1,6 +1,7 @@
 from __future__ import absolute_import
 import weakref
 import abc
+import gc
 
 import numpy as np
 import sympy
@@ -499,3 +500,22 @@ class Indexed(sympy.Indexed):
 
     def _hashable_content(self):
         return super(Indexed, self)._hashable_content() + (self.base.function,)
+
+
+# Utilities
+
+
+class CacheManager(object):
+
+    """
+    Drop unreferenced objects from the SymPy and Devito caches. The associated
+    data is lost (and thus memory is freed).
+    """
+
+    @classmethod
+    def clear(cls):
+        sympy.cache.clear_cache()
+        gc.collect()
+        for key, val in list(_SymbolCache.items()):
+            if val() is None:
+                del _SymbolCache[key]

--- a/devito/yask/__init__.py
+++ b/devito/yask/__init__.py
@@ -61,6 +61,7 @@ class YaskCompiler(configuration['compiler'].__class__):
 
     def __init__(self, *args, **kwargs):
         kwargs['cpp'] = True
+        kwargs['suffix'] = configuration['compiler'].suffix
         super(YaskCompiler, self).__init__(*args, **kwargs)
         self.cflags = [i for i in configuration['compiler'].cflags
                        if not i.startswith('-std')] + ['-std=c++11']
@@ -89,11 +90,9 @@ def switch_cpu(develop_mode):
         isa, platform = infer_cpu()
         configuration['isa'] = os.environ.get('DEVITO_ISA', isa)
         configuration['platform'] = os.environ.get('DEVITO_PLATFORM', platform)
-        print('AAAAAAAAAAAAAAAAa', isa, platform)
     else:
         configuration['isa'] = 'cpp'
         configuration['platform'] = 'intel64'
-        print('BBBBBBBBBBBBBBBBBB')
 yask_configuration.add('develop-mode', True, [False, True], switch_cpu)  # noqa
 
 env_vars_mapper = {

--- a/devito/yask/__init__.py
+++ b/devito/yask/__init__.py
@@ -109,10 +109,11 @@ env_vars_mapper = {
 
 add_sub_configuration(yask_configuration, env_vars_mapper)
 
-log("Backend successfully initialized!")
-
 
 # The following used by backends.backendSelector
 from devito.yask.function import Constant, Function, TimeFunction  # noqa
 from devito.function import SparseFunction  # noqa
 from devito.yask.operator import Operator  # noqa
+from devito.yask.types import CacheManager  # noqa
+
+log("Backend successfully initialized!")

--- a/devito/yask/__init__.py
+++ b/devito/yask/__init__.py
@@ -60,13 +60,10 @@ namespace['type-grid'] = ctypes_pointer('yask::yk_grid_ptr')
 class YaskCompiler(configuration['compiler'].__class__):
 
     def __init__(self, *args, **kwargs):
+        kwargs['cpp'] = True
         super(YaskCompiler, self).__init__(*args, **kwargs)
-        # Switch to C++
-        self.cc = self.cpp_mapper[configuration['compiler'].cc]
-        self.ld = self.cpp_mapper[configuration['compiler'].ld]
         self.cflags = [i for i in configuration['compiler'].cflags
                        if not i.startswith('-std')] + ['-std=c++11']
-        self.src_ext = 'cpp'
         # Tell the compiler where to get YASK header files and shared objects
         self.include_dirs.append(os.path.join(namespace['path'], 'include'))
         self.library_dirs.append(os.path.join(namespace['path'], 'lib'))

--- a/devito/yask/__init__.py
+++ b/devito/yask/__init__.py
@@ -91,21 +91,10 @@ def switch_cpu(develop_mode):
     if bool(develop_mode) is False:
         isa, platform = infer_cpu()
         configuration['isa'] = os.environ.get('DEVITO_ISA', isa)
-        platform = os.environ.get('DEVITO_PLATFORM', platform)
-        # Need to map to platforms known to YASK
-        mapper = {'intel64': 'intel64',
-                  'sandybridge': 'snb', 'ivybridge': 'ivb',
-                  'haswell': 'hsw', 'broadwell': 'hsw',
-                  'skylake': 'skx',
-                  'knc': 'knc', 'knl': 'knl'}
-        if platform in mapper.values():
-            configuration['platform'] = platform
-        elif platform in mapper:
-            configuration['platform'] = mapper[platform]
-        else:
-            exit("Unknown platform `%s` to run in optimized mode" % platform)
+        configuration['platform'] = os.environ.get('DEVITO_PLATFORM', platform)
     else:
-        configuration['isa'], configuration['platform'] = 'cpp', 'intel64'
+        configuration['isa'] = 'cpp'
+        configuration['platform'] = 'intel64'
 yask_configuration.add('develop-mode', True, [False, True], switch_cpu)  # noqa
 
 env_vars_mapper = {

--- a/devito/yask/__init__.py
+++ b/devito/yask/__init__.py
@@ -89,9 +89,11 @@ def switch_cpu(develop_mode):
         isa, platform = infer_cpu()
         configuration['isa'] = os.environ.get('DEVITO_ISA', isa)
         configuration['platform'] = os.environ.get('DEVITO_PLATFORM', platform)
+        print('AAAAAAAAAAAAAAAAa', isa, platform)
     else:
         configuration['isa'] = 'cpp'
         configuration['platform'] = 'intel64'
+        print('BBBBBBBBBBBBBBBBBB')
 yask_configuration.add('develop-mode', True, [False, True], switch_cpu)  # noqa
 
 env_vars_mapper = {

--- a/devito/yask/data.py
+++ b/devito/yask/data.py
@@ -92,10 +92,6 @@ class Data(object):
             # array, i.e., it's not a view
             self.base = None
 
-    def __del__(self):
-        if self.base is None:
-            self.grid.release_storage()
-
     def __getitem__(self, index):
         start, stop, shape = self._convert_index(index)
         if not shape:

--- a/devito/yask/data.py
+++ b/devito/yask/data.py
@@ -92,6 +92,10 @@ class Data(object):
             # array, i.e., it's not a view
             self.base = None
 
+    def __del__(self):
+        if self.base is None:
+            self.grid.release_storage()
+
     def __getitem__(self, index):
         start, stop, shape = self._convert_index(index)
         if not shape:

--- a/devito/yask/function.py
+++ b/devito/yask/function.py
@@ -1,7 +1,6 @@
 import ctypes
 import numpy as np
 
-import devito.types as types
 import devito.function as function
 from devito.tools import numpy_to_ctypes
 
@@ -9,11 +8,6 @@ from devito.yask.data import DataScalar
 from devito.yask.wrappers import contexts
 
 __all__ = ['Constant', 'Function', 'TimeFunction']
-
-
-types.Basic.from_YASK = False
-
-types.Array.from_YASK = True
 
 
 class Constant(function.Constant):

--- a/devito/yask/function.py
+++ b/devito/yask/function.py
@@ -40,6 +40,10 @@ class Function(function.Function):
         # eg with save=True one gets /time/ instead /t/
         self._data_object = context.make_grid(self)
 
+    def __del__(self):
+        if self._data_object is not None:
+            self._data_object.release_storage()
+
     @property
     def _data_buffer(self):
         data = self.data

--- a/devito/yask/types.py
+++ b/devito/yask/types.py
@@ -1,0 +1,19 @@
+from devito.logger import yask as log
+import devito.types as types
+
+from devito.yask.wrappers import contexts
+
+__all__ = ['CacheManager']
+
+
+types.Basic.from_YASK = False
+types.Array.from_YASK = True
+
+
+class CacheManager(types.CacheManager):
+
+    @classmethod
+    def clear(cls):
+        super(CacheManager, cls).clear()
+        log("Dumping all contexts")
+        contexts.dump()

--- a/devito/yask/types.py
+++ b/devito/yask/types.py
@@ -14,6 +14,6 @@ class CacheManager(types.CacheManager):
 
     @classmethod
     def clear(cls):
-        super(CacheManager, cls).clear()
-        log("Dumping all contexts")
+        log("Dumping contexts and symbol caches")
         contexts.dump()
+        super(CacheManager, cls).clear()

--- a/examples/seismic/acoustic/wavesolver.py
+++ b/examples/seismic/acoustic/wavesolver.py
@@ -1,4 +1,4 @@
-from devito import Function, TimeFunction, memoized
+from devito import Function, TimeFunction, memoized_meth
 from examples.seismic import PointSource, Receiver
 from examples.seismic.acoustic.operators import (
     ForwardOperator, AdjointOperator, GradientOperator, BornOperator
@@ -42,28 +42,28 @@ class AcousticWaveSolver(object):
         # Cache compiler options
         self._kwargs = kwargs
 
-    @memoized
+    @memoized_meth
     def op_fwd(self, save=False):
         """Cached operator for forward runs with buffered wavefield"""
         return ForwardOperator(self.model, save=save, source=self.source,
                                receiver=self.receiver, time_order=self.time_order,
                                space_order=self.space_order, **self._kwargs)
 
-    @memoized
+    @memoized_meth
     def op_adj(self):
         """Cached operator for adjoint runs"""
         return AdjointOperator(self.model, save=False, source=self.source,
                                receiver=self.receiver, time_order=self.time_order,
                                space_order=self.space_order, **self._kwargs)
 
-    @memoized
+    @memoized_meth
     def op_grad(self):
         """Cached operator for gradient runs"""
         return GradientOperator(self.model, save=True, source=self.source,
                                 receiver=self.receiver, time_order=self.time_order,
                                 space_order=self.space_order, **self._kwargs)
 
-    @memoized
+    @memoized_meth
     def op_born(self):
         """Cached operator for born runs"""
         return BornOperator(self.model, save=False, source=self.source,

--- a/examples/seismic/benchmark.py
+++ b/examples/seismic/benchmark.py
@@ -15,10 +15,11 @@ def benchmark():
     """
     Benchmarking script for seismic forward operators.
 
+    \b
     There are three main 'execution modes':
-    run:   a single run with given DSE/DLE levels
+    run: a single run with given DSE/DLE levels
     bench: complete benchmark with multiple DSE/DLE levels
-    test:  tests numerical correctness with different parameters
+    test: tests numerical correctness with different parameters
 
     Further, this script can generate a roofline plot from a benchmark
     """
@@ -34,7 +35,7 @@ def option_simulation(f):
 
     options = [
         click.option('-P', '--problem', type=click.Choice(['acoustic', 'tti']),
-                     help='Number of grid points along each axis'),
+                     help='Problem name'),
         click.option('-d', '--shape', default=(50, 50, 50),
                      help='Number of grid points along each axis'),
         click.option('-s', '--spacing', default=(20., 20., 20.),

--- a/examples/seismic/benchmark.py
+++ b/examples/seismic/benchmark.py
@@ -317,7 +317,8 @@ def get_ob_bench(problem, resultsdir, parameters):
             devito_params['to'] = params['time_order']
             devito_params['dse'] = params['dse']
             devito_params['dle'] = params['dle']
-            devito_params['at'] = params['autotune'] and configuration.core['autotuning']
+            devito_params['at'] = (params['autotune'] and
+                                   configuration.backend['autotuning'])
             return '_'.join(['%s[%s]' % (k, v) for k, v in devito_params.items()])
 
     return DevitoBenchmark(name=problem, resultsdir=resultsdir, parameters=parameters)

--- a/examples/seismic/benchmark.py
+++ b/examples/seismic/benchmark.py
@@ -24,9 +24,10 @@ def benchmark():
     Further, this script can generate a roofline plot from a benchmark
     """
 
-    # Make sure that with YASK we run in performance mode
+    # Make sure that with YASK we run in benchmarking mode
     if configuration['backend'] == 'yask':
         configuration.yask['develop-mode'] = False
+        configuration.yask['autotuning'] = 'preemptive'
 
 
 def option_simulation(f):

--- a/examples/seismic/benchmark.py
+++ b/examples/seismic/benchmark.py
@@ -175,6 +175,9 @@ def bench(problem, **kwargs):
     bench.execute(get_ob_exec(run), warmups=0, repeats=repeats)
     bench.save()
 
+    # Final clean up, just in case the benchmarker is used from external Python modules
+    clear_cache()
+
 
 @benchmark.command(name='plot')
 @option_simulation
@@ -333,14 +336,14 @@ def get_ob_exec(func):
             self.func = func
 
         def run(self, *args, **kwargs):
+            clear_cache()
+
             gflopss, oi, timings, _ = self.func(*args, **kwargs)
 
             for key in timings.keys():
                 self.register(gflopss[key], measure="gflopss", event=key)
                 self.register(oi[key], measure="oi", event=key)
                 self.register(timings[key], measure="timings", event=key)
-
-            clear_cache()
 
     return DevitoExecutor(func)
 

--- a/examples/seismic/benchmark.py
+++ b/examples/seismic/benchmark.py
@@ -63,7 +63,7 @@ def option_performance(f):
         'O3': {'autotune': True, 'dse': 'aggressive', 'dle': 'advanced'},
         # Parametric
         'dse': {'autotune': True,
-                'dse': ['basic', 'advanced', 'speculative', 'aggressive'],
+                'dse': ['basic', 'advanced', 'aggressive'],
                 'dle': 'advanced'},
         'dle': {'autotune': True,
                 'dse': 'advanced',
@@ -250,12 +250,10 @@ def plot(problem, **kwargs):
         # DLE basic
         ('basic', 'basic'): ('D', 'r'),
         ('advanced', 'basic'): ('D', 'g'),
-        ('speculative', 'basic'): ('D', 'y'),
         ('aggressive', 'basic'): ('D', 'b'),
         # DLE advanced
         ('basic', 'advanced'): ('o', 'r'),
         ('advanced', 'advanced'): ('o', 'g'),
-        ('speculative', 'advanced'): ('o', 'y'),
         ('aggressive', 'advanced'): ('o', 'b'),
     }
 

--- a/examples/seismic/tti/wavesolver.py
+++ b/examples/seismic/tti/wavesolver.py
@@ -1,5 +1,5 @@
 # coding: utf-8
-from devito import TimeFunction, memoized
+from devito import TimeFunction, memoized_meth
 from examples.seismic.tti.operators import ForwardOperator
 from examples.seismic import Receiver
 
@@ -31,7 +31,7 @@ class AnisotropicWaveSolver(object):
         # Cache compiler options
         self._kwargs = kwargs
 
-    @memoized
+    @memoized_meth
     def op_fwd(self, kernel='shifted', save=False):
         """Cached operator for forward runs with buffered wavefield"""
         return ForwardOperator(self.model, save=save, source=self.source,


### PR DESCRIPTION
* Our memoizer caches at the class level; for the seismic wrappers, instead, it'd be better to cache at the instance level. Otherwise, these are unusable from benchmark.py as we would start leaking memory. This PR introduces a new memoizer suitable for instance-level caching. 
* Better compilation infrastructure
* ``benchmark.py`` tweaks; in particular, better memory clean up, use preemptive AT in yask mode
* Allow per-backend specialisation of caching clean up
* Fix up potential memory leak in YASK