### PR TITLE
Cleanup, fixes, and additions before domain-allocation switch (PART 1)

### DIFF
--- a/devito/dle/backends/advanced.py
+++ b/devito/dle/backends/advanced.py
@@ -155,7 +155,7 @@ class DevitoRewriter(BasicRewriter):
                 name = "%s%d_block" % (i.dim.name, len(mapper))
 
                 # Build Iteration over blocks
-                dim = blocked.setdefault(i, Dimension(name))
+                dim = blocked.setdefault(i, Dimension(name=name))
                 block_size = dim.symbolic_size
                 iter_size = i.dim.symbolic_extent
                 start = i.limits[0] - i.offsets[0]

--- a/devito/dse/aliases.py
+++ b/devito/dse/aliases.py
@@ -176,7 +176,7 @@ def calculate_offsets(indexeds):
         for d, i in zip(dimensions, indexed.indices):
             offset = i - d
             if offset.is_Number:
-                handle.append(offset)
+                handle.append(int(offset))
             else:
                 return None
         processed.append(tuple(handle))

--- a/devito/dse/manipulation.py
+++ b/devito/dse/manipulation.py
@@ -70,6 +70,9 @@ def collect_nested(expr, aggressive=False):
             rebuilt, candidates = zip(*[run(arg) for arg in expr.args])
             rebuilt = collect_const(expr.func(*rebuilt))
             return rebuilt, flatten(candidates)
+        elif expr.is_Equality:
+            rebuilt, candidates = zip(*[run(expr.lhs), run(expr.rhs)])
+            return expr.func(*rebuilt, evaluate=False), flatten(candidates)
         else:
             rebuilt, candidates = zip(*[run(arg) for arg in expr.args])
             return expr.func(*rebuilt), flatten(candidates)

--- a/devito/dse/manipulation.py
+++ b/devito/dse/manipulation.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 
 from sympy import collect, collect_const
 
-from devito.ir.dfg import TemporariesGraph
+from devito.ir import FlowGraph
 from devito.symbolics import Eq, count, estimate_cost, q_op, q_leaf, xreplace_constrained
 from devito.types import Indexed, Array
 from devito.tools import flatten
@@ -18,9 +18,8 @@ def promote_scalar_expressions(exprs, shape, indices, onstack):
     processed = []
 
     # Fist promote the LHS
-    graph = TemporariesGraph(exprs)
     mapper = {}
-    for k, v in graph.items():
+    for k, v in FlowGraph(exprs).items():
         if v.is_scalar:
             # Create a new function symbol
             data = Array(name=k.name, shape=shape,
@@ -138,7 +137,7 @@ def compact_temporaries(temporaries, leaves):
     exprs = temporaries + leaves
     targets = {i.lhs for i in leaves}
 
-    g = TemporariesGraph(exprs)
+    g = FlowGraph(exprs)
 
     mapper = {k: v.rhs for k, v in g.items()
               if v.is_scalar and

--- a/devito/function.py
+++ b/devito/function.py
@@ -179,22 +179,22 @@ class Function(TensorFunction):
             space_order = kwargs.get('space_order', 1)
             if isinstance(space_order, int):
                 self.space_order = space_order
-                self._halo = tuple((ceil(space_order/2),)*2 for i in range(self.dim))
+                self._halo = tuple((ceil(space_order/2),)*2 for i in range(self.ndim))
             elif isinstance(space_order, tuple) and len(space_order) == 3:
                 space_order, left_points, right_points = space_order
                 self.space_order = space_order
-                self._halo = tuple((left_points, right_points) for i in range(self.dim))
+                self._halo = tuple((left_points, right_points) for i in range(self.ndim))
             else:
                 raise ValueError("'space_order' must be int or 3-tuple of ints")
 
             padding = kwargs.get('padding', 0)
             if isinstance(padding, int):
-                self._padding = tuple((padding,)*2 for i in range(self.dim))
-            elif isinstance(padding, tuple) and len(padding) == self.dim:
+                self._padding = tuple((padding,)*2 for i in range(self.ndim))
+            elif isinstance(padding, tuple) and len(padding) == self.ndim:
                 self._padding = tuple((i,)*2 if isinstance(i, int) else i
                                       for i in padding)
             else:
-                raise ValueError("'padding' must be int or %d-tuple of ints" % self.dim)
+                raise ValueError("'padding' must be int or %d-tuple of ints" % self.ndim)
 
             # Dynamically add derivative short-cuts
             self._initialize_derivatives()
@@ -435,7 +435,7 @@ class Function(TensorFunction):
         raise NotImplementedError
 
     @property
-    def dim(self):
+    def ndim(self):
         """Return the number of spatial dimensions."""
         return len(self._grid_shape_domain)
 
@@ -467,7 +467,7 @@ class Function(TensorFunction):
         """
         derivs = tuple('d%s2' % d.name for d in self.space_dimensions)
 
-        return sum([getattr(self, d) for d in derivs[:self.dim]])
+        return sum([getattr(self, d) for d in derivs[:self.ndim]])
 
     def laplace2(self, weight=1):
         """

--- a/devito/function.py
+++ b/devito/function.py
@@ -11,7 +11,7 @@ from devito.logger import debug, error, warning
 from devito.data import Data, first_touch
 from devito.cgen_utils import INT, FLOAT
 from devito.dimension import Dimension, TimeDimension
-from devito.types import SymbolicFunction, AbstractSymbol
+from devito.types import SymbolicFunction, AbstractCachedSymbol
 from devito.finite_difference import (centered, cross_derivative,
                                       first_derivative, left, right,
                                       second_derivative, generic_derivative,
@@ -44,7 +44,7 @@ Forward = TimeAxis('Forward')
 Backward = TimeAxis('Backward')
 
 
-class Constant(AbstractSymbol):
+class Constant(AbstractCachedSymbol):
 
     """
     Symbol representing constant values in symbolic equations.
@@ -710,7 +710,7 @@ class SparseFunction(CompositeFunction):
                 raise ValueError('No grid provided for SparseFunction.')
 
             # Allocate and copy coordinate data
-            d = Dimension('d')
+            d = Dimension(name='d')
             self.coordinates = Function(name='%s_coords' % self.name,
                                         dimensions=[self.indices[-1], d],
                                         shape=(self.npoint, self.grid.dim))
@@ -735,7 +735,8 @@ class SparseFunction(CompositeFunction):
         dimensions = kwargs.get('dimensions', None)
         grid = kwargs.get('grid', None)
         nt = kwargs.get('nt', 0)
-        indices = [grid.time_dim, Dimension('p')] if nt > 0 else [Dimension('p')]
+        dim = Dimension(name='p')
+        indices = [grid.time_dim, dim] if nt > 0 else [dim]
         return dimensions or indices
 
     @property

--- a/devito/grid.py
+++ b/devito/grid.py
@@ -83,11 +83,11 @@ class Grid(object):
         assert (self.dim == len(self.origin) == len(self.extent) == len(self.spacing))
         # Store or create default symbols for time and stepping dimensions
         if time_dimension is None:
-            self.time_dim = TimeDimension('time', spacing=Constant(name='dt'))
-            self.stepping_dim = SteppingDimension('t', parent=self.time_dim)
+            self.time_dim = TimeDimension(name='time', spacing=Constant(name='dt'))
+            self.stepping_dim = SteppingDimension(name='t', parent=self.time_dim)
         else:
             self.time_dim = time_dimension
-            self.stepping_dim = SteppingDimension('%s_s' % time_dimension.name,
+            self.stepping_dim = SteppingDimension(name='%s_s' % time_dimension.name,
                                                   parent=self.time_dim)
 
     def __repr__(self):

--- a/devito/grid.py
+++ b/devito/grid.py
@@ -85,10 +85,12 @@ class Grid(object):
         if time_dimension is None:
             self.time_dim = TimeDimension(name='time', spacing=Constant(name='dt'))
             self.stepping_dim = SteppingDimension(name='t', parent=self.time_dim)
-        else:
+        elif isinstance(time_dimension, TimeDimension):
             self.time_dim = time_dimension
             self.stepping_dim = SteppingDimension(name='%s_s' % time_dimension.name,
                                                   parent=self.time_dim)
+        else:
+            raise ValueError("`time_dimension` must be None or of type TimeDimension")
 
     def __repr__(self):
         return "Grid[extent=%s, shape=%s, dimensions=%s]" % (

--- a/devito/ir/__init__.py
+++ b/devito/ir/__init__.py
@@ -1,4 +1,3 @@
 from devito.ir.clusters import *  # noqa
-from devito.ir.dfg import *  # noqa
 from devito.ir.iet import *  # noqa
 from devito.ir.support import *  # noqa

--- a/devito/ir/clusters/__init__.py
+++ b/devito/ir/clusters/__init__.py
@@ -1,2 +1,3 @@
 from devito.ir.clusters.cluster import *  # noqa
 from devito.ir.clusters.algorithms import *  # noqa
+from devito.ir.clusters.graph import *  # noqa

--- a/devito/ir/clusters/algorithms.py
+++ b/devito/ir/clusters/algorithms.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 
 from devito.ir.support import Scope
 from devito.ir.clusters.cluster import PartialCluster, ClusterGroup
-from devito.ir.dfg import TemporariesGraph
+from devito.ir.clusters.graph import FlowGraph
 from devito.symbolics import xreplace_indices
 from devito.types import Scalar
 from devito.tools import flatten
@@ -229,7 +229,7 @@ def clusterize(exprs, stencils):
 
     # Create a PartialCluster for each sequence of expressions computing a tensor
     mapper = OrderedDict()
-    g = TemporariesGraph(exprs)
+    g = FlowGraph(exprs)
     for (k, v), j in zip(g.items(), stencils):
         if v.is_tensor:
             exprs = g.trace(k)

--- a/devito/ir/clusters/cluster.py
+++ b/devito/ir/clusters/cluster.py
@@ -2,7 +2,7 @@ from collections import defaultdict
 
 from cached_property import cached_property
 
-from devito.ir.dfg import TemporariesGraph
+from devito.ir.clusters.graph import FlowGraph
 from devito.tools import as_tuple
 
 __all__ = ["Cluster", "ClusterGroup"]
@@ -40,7 +40,7 @@ class PartialCluster(object):
 
     @property
     def trace(self):
-        return TemporariesGraph(self.exprs)
+        return FlowGraph(self.exprs)
 
     @property
     def unknown(self):
@@ -76,7 +76,7 @@ class Cluster(PartialCluster):
 
     @cached_property
     def trace(self):
-        return TemporariesGraph(self.exprs)
+        return FlowGraph(self.exprs)
 
     @property
     def is_dense(self):

--- a/devito/ir/dfg/__init__.py
+++ b/devito/ir/dfg/__init__.py
@@ -1,1 +1,0 @@
-from devito.ir.dfg.graph import *  # noqa

--- a/devito/ir/iet/analysis.py
+++ b/devito/ir/iet/analysis.py
@@ -11,7 +11,7 @@ from functools import cmp_to_key
 from devito.ir.iet import (Iteration, SEQUENTIAL, PARALLEL, VECTOR, WRAPPABLE,
                            MapIteration, NestedTransformer, retrieve_iteration_tree)
 from devito.ir.support import Scope
-from devito.tools import as_tuple
+from devito.tools import as_tuple, filter_ordered
 
 __all__ = ['analyze_iterations']
 
@@ -69,7 +69,12 @@ def mark_parallel(analysis):
         for depth, i in enumerate(tree):
             if i in properties:
                 continue
-            dims = [j.dim for j in tree[:depth + 1]]
+            # Get all tree dimensions, including the unbounded indices
+            dims = []
+            for j in tree[:depth + 1]:
+                dims.append(j.dim)
+                dims.extend([k.dim for k in j.uindices])
+            dims = filter_ordered(dims)
             # The i-th Iteration is PARALLEL if for all dependences (d_1, ..., d_n):
             # (d_1, ..., d_{i-1}) > 0, OR
             # (d_1, ..., d_i) = 0

--- a/devito/ir/iet/nodes.py
+++ b/devito/ir/iet/nodes.py
@@ -300,14 +300,6 @@ class Iteration(Node):
         return "<%sIteration %s; %s>" % (properties, index, self.limits)
 
     @property
-    def is_Open(self):
-        return self.dim.size is None
-
-    @property
-    def is_Closed(self):
-        return not self.is_Open
-
-    @property
     def is_Linear(self):
         return len(self.uindices) == 0
 

--- a/devito/ir/iet/utils.py
+++ b/devito/ir/iet/utils.py
@@ -1,9 +1,8 @@
-from devito.ir.iet import Expression, Iteration, List, FindSections, MergeOuterIterations
-from devito.symbolics import Eq
+from devito.ir.iet import Iteration, List, FindSections
 from devito.tools import as_tuple, flatten
 
 __all__ = ['filter_iterations', 'retrieve_iteration_tree', 'is_foldable',
-           'compose_nodes', 'copy_arrays']
+           'compose_nodes']
 
 
 def retrieve_iteration_tree(node, mode='normal'):
@@ -120,30 +119,3 @@ def compose_nodes(nodes, retrieve=False):
         return body, tree
     else:
         return body
-
-
-def copy_arrays(mapper, reverse=False):
-    """
-    Build an Iteration/Expression tree performing the copy ``k = v``, or
-    ``v = k`` if reverse=True, for each (k, v) in mapper. (k, v) are expected
-    to be of type :class:`IndexedData`. The loop bounds are inferred from
-    the dimensions used in ``k``.
-    """
-    if not mapper:
-        return ()
-
-    # Build the Iteration tree for the copy
-    iterations = []
-    for k, v in mapper.items():
-        handle = []
-        indices = k.function.indices
-        for i, j in zip(k.shape, indices):
-            handle.append(Iteration([], dimension=j, limits=i))
-        lhs, rhs = (v, k) if reverse else (k, v)
-        handle.append(Expression(Eq(lhs[indices], rhs[indices]), dtype=k.function.dtype))
-        iterations.append(compose_nodes(handle))
-
-    # Maybe some Iterations are mergeable
-    iterations = MergeOuterIterations().visit(iterations)
-
-    return iterations

--- a/devito/ir/iet/visitors.py
+++ b/devito/ir/iet/visitors.py
@@ -641,7 +641,7 @@ class ResolveTimeStepping(Transformer):
                 vname = Scalar(name="%s%d" % (o.dim.name, i), dtype=np.int32)
                 value = (o.dim.parent + off) % o.dim.modulo
                 init.append(UnboundedIndex(vname, value, value))
-                subs[o.dim + off] = LoweredDimension(vname.name, o.dim, off)
+                subs[o.dim + off] = LoweredDimension(name=vname.name, origin=o.dim + off)
             # Always lower to symbol
             subs[o.dim.parent] = Scalar(name=o.dim.parent.name, dtype=np.int32)
             return o._rebuild(index=o.dim.parent.name, uindices=init,

--- a/devito/ir/iet/visitors.py
+++ b/devito/ir/iet/visitors.py
@@ -15,7 +15,7 @@ import numpy as np
 from devito.cgen_utils import blankline, ccode
 from devito.dimension import LoweredDimension
 from devito.exceptions import VisitorException
-from devito.ir.iet.nodes import Iteration, Node, UnboundedIndex
+from devito.ir.iet.nodes import Node, UnboundedIndex
 from devito.types import Scalar
 from devito.tools import (as_tuple, filter_ordered, filter_sorted, flatten, ctypes_to_C,
                           GenericVisitor)
@@ -25,7 +25,7 @@ from devito.arguments import runtime_arguments
 __all__ = ['FindNodes', 'FindSections', 'FindSymbols', 'MapExpressions',
            'IsPerfectIteration', 'SubstituteExpression', 'printAST', 'CGen',
            'ResolveTimeStepping', 'Transformer', 'NestedTransformer',
-           'FindAdjacentIterations', 'MergeOuterIterations', 'MapIteration']
+           'FindAdjacentIterations', 'MapIteration']
 
 
 class Visitor(GenericVisitor):
@@ -660,56 +660,6 @@ class ResolveTimeStepping(Transformer):
             subs = {}
         obj, subs = super(ResolveTimeStepping, self).visit(o, subs, **kwargs)
         return obj, subs
-
-
-class MergeOuterIterations(Transformer):
-    """
-    :class:`Transformer` that merges subsequent :class:`Iteration`
-    objects iff their dimenions agree.
-    """
-
-    def is_mergable(self, iter1, iter2):
-        """Defines if two :class:`Iteration` objects are mergeable.
-
-        Note: This currently does not(!) consider data dependencies
-        between the loops. A deeper analysis is required for this that
-        will be added soon.
-        """
-        if iter1.dim.is_Stepping:
-            # Aliasing only works one-way because we left-merge
-            if iter1.dim.parent == iter2.dim:
-                return True
-            if iter2.dim.is_Stepping and iter1.dim.parent == iter2.dim.parent:
-                return True
-        return iter1.dim == iter2.dim and iter1.bounds_symbolic == iter2.bounds_symbolic
-
-    def merge(self, iter1, iter2):
-        """Creates a new merged :class:`Iteration` object from two
-        loops along the same dimension.
-        """
-        newexpr = iter1.nodes + iter2.nodes
-        return Iteration(newexpr, dimension=iter1.dim,
-                         limits=iter1.limits,
-                         offsets=iter1.offsets)
-
-    def visit_Iteration(self, o):
-        rebuilt = self.visit(o.children)
-        ret = o._rebuild(*rebuilt, **o.args_frozen)
-        return ret
-
-    def visit_list(self, o):
-        head = self.visit(o[0])
-        if len(o) < 2:
-            return tuple([head])
-        body = self.visit(o[1:])
-        if head.is_Iteration and body[0].is_Iteration:
-            if self.is_mergable(head, body[0]):
-                newit = self.merge(head, body[0])
-                ret = self.visit([newit] + list(body[1:]))
-                return as_tuple(ret)
-        return tuple([head] + list(body))
-
-    visit_tuple = visit_list
 
 
 def printAST(node, verbose=True):

--- a/devito/ir/support/__init__.py
+++ b/devito/ir/support/__init__.py
@@ -1,2 +1,3 @@
 from devito.ir.support.basic import *  # noqa
+from devito.ir.support.domain import *  # noqa
 from devito.ir.support.stencil import *  # noqa

--- a/devito/ir/support/domain.py
+++ b/devito/ir/support/domain.py
@@ -1,0 +1,240 @@
+import abc
+from collections import OrderedDict
+
+from devito.tools import as_tuple
+
+__all__ = ['NullInterval', 'Interval', 'Space', 'IterationSpace']
+
+
+class AbstractInterval(object):
+
+    """
+    A representation of a closed interval on Z.
+    """
+
+    __metaclass__ = abc.ABCMeta
+
+    is_Null = False
+    is_Defined = False
+
+    def __init__(self, dim):
+        self.dim = dim
+
+    @classmethod
+    def _apply_op(cls, intervals, key):
+        """
+        Return a new :class:`Interval` resulting from the composite application
+        of the method ``key`` over the :class:`Interval`s in ``intervals``, i.e.:
+        ``intervals[0].key(intervals[1]).key(intervals[2])...``.
+        """
+        intervals = as_tuple(intervals)
+        partial = intervals[0]
+        for i in intervals[1:]:
+            partial = getattr(partial, key)(i)
+        return partial
+
+    @abc.abstractmethod
+    def _rebuild(self):
+        return
+
+    def intersection(self, o):
+        return self._rebuild()
+
+    @abc.abstractmethod
+    def union(self, o):
+        return self._rebuild()
+
+    def subtract(self, o):
+        return self._rebuild()
+
+    def negate(self):
+        return self._rebuild()
+
+    @abc.abstractmethod
+    def overlap(self, o):
+        return
+
+    def __eq__(self, o):
+        return type(self) == type(o) and self.dim == o.dim
+
+    def __hash__(self):
+        return hash(self.dim.name)
+
+
+class NullInterval(AbstractInterval):
+
+    is_Null = True
+
+    def __repr__(self):
+        return "%s[Null]" % self.dim
+
+    def _rebuild(self):
+        return NullInterval(self.dim)
+
+    def union(self, o):
+        if self.dim == o.dim:
+            return o._rebuild()
+        else:
+            return Space([self._rebuild(), o._rebuild()])
+
+    def overlap(self, o):
+        return False
+
+
+class Interval(AbstractInterval):
+
+    """
+    Interval(dim, lower, upper)
+
+    Create an :class:`Interval` of extent: ::
+
+        dim.extent + abs(upper - lower)
+    """
+
+    is_Defined = True
+
+    def __init__(self, dim, lower, upper):
+        assert isinstance(lower, int)
+        assert isinstance(upper, int)
+        super(Interval, self).__init__(dim)
+        self.lower = lower
+        self.upper = upper
+        self.min_extent = abs(upper - lower)
+        self.extent = dim.symbolic_size + self.min_extent
+
+    def __repr__(self):
+        return "%s[%s, %s]" % (self.dim, self.lower, self.upper)
+
+    def _rebuild(self):
+        return Interval(self.dim, self.lower, self.upper)
+
+    @property
+    def limits(self):
+        return (self.lower, self.upper)
+
+    def intersection(self, o):
+        if self.overlap(o):
+            return Interval(self.dim, max(self.lower, o.lower), min(self.upper, o.upper))
+        else:
+            return NullInterval(self.dim)
+
+    def union(self, o):
+        if self.overlap(o):
+            return Interval(self.dim, min(self.lower, o.lower), max(self.upper, o.upper))
+        elif o.is_Null and self.dim == o.dim:
+            return self._rebuild()
+        else:
+            return Space([self._rebuild(), o._rebuild()])
+
+    def subtract(self, o):
+        if self.dim != o.dim or o.is_Null:
+            return self._rebuild()
+        else:
+            return Interval(self.dim, self.lower - o.lower, self.upper - o.upper)
+
+    def negate(self):
+        return Interval(self.dim, -self.lower, -self.upper)
+
+    def overlap(self, o):
+        if self.dim != o.dim:
+            return False
+        try:
+            # In the "worst case scenario" the dimension extent is 0
+            # so we can just neglect it
+            min_extent = max(self.min_extent, o.min_extent)
+            return (self.lower <= o.lower and o.lower <= self.lower + min_extent) or\
+                (self.lower >= o.lower and self.lower <= o.lower + min_extent)
+        except AttributeError:
+            return False
+
+    def __eq__(self, o):
+        return super(Interval, self).__eq__(o) and\
+            self.lower == o.lower and self.upper == o.upper
+
+    def __hash__(self):
+        return hash((self.dim.name, self.lower, self.upper))
+
+
+class Space(object):
+
+    """
+    A bag of :class:`Interval`s.
+
+    The intervals input ordering is honored.
+    """
+
+    def __init__(self, intervals):
+        self.intervals = as_tuple(intervals)
+
+    def __repr__(self):
+        return "%s[%s]" % (self.__class__.__name__,
+                           ', '.join([repr(i) for i in self.intervals]))
+
+    def __eq__(self, o):
+        return set(self.intervals) == set(o.intervals)
+
+    def _construct(self, intervals):
+        return Space(intervals)
+
+    @property
+    def empty(self):
+        return len(self.intervals) == 0
+
+    @classmethod
+    def intersection_update(self, *spaces):
+        """
+        Compute the intersection of an iterable of :class:`Space`s. The returned
+        :class:`Space` contains one :class:`Interval` for each unique
+        :class:`Dimension` found in ``spaces``.
+
+        Example
+        -------
+        space0 = Space([Interval(x, 1, -1)])
+        space1 = Space([Interval(x, 2, -2), Interval(y, 3, -3)])
+        space2 = Space([Interval(y, 2, -2), Interval(z, 1, -1)])
+
+        res = Space.intersection_update(space0, space1, space2)
+        res --> Space([Interval(x, 2, -2), Interval(y, 3, -3), Interval(z, 1, -1)])
+        """
+        mapper = OrderedDict()
+        for i in spaces:
+            for interval in i.intervals:
+                mapper.setdefault(interval.dim, []).append(interval)
+        return Space([Interval._apply_op(v, 'intersection') for v in mapper.values()])
+
+    def intersection(self, *spaces):
+        mapper = OrderedDict([(i.dim, [i]) for i in self.intervals])
+        for i in spaces:
+            for interval in i.intervals:
+                mapper.get(interval.dim, []).append(interval)
+        return self._construct([Interval._apply_op(v, 'intersection')
+                                for v in mapper.values()])
+
+    def subtract(self, o):
+        mapper = OrderedDict([(i.dim, i) for i in o.intervals])
+        intervals = [i.subtract(mapper.get(i.dim, NullInterval(i.dim)))
+                     for i in self.intervals]
+        return self._construct(intervals)
+
+    def drop(self, d):
+        return self._construct([i._rebuild() for i in self.intervals
+                                if i.dim not in as_tuple(d)])
+
+    def negate(self):
+        return self._construct([i.negate() for i in self.intervals])
+
+
+class IterationSpace(Space):
+
+    """
+    A :class:`Space` associating one or more :class:`Dimension`s to a
+    :class:`Interval`. The interval is the data space, whereas the dimensions
+    are the objects used to traverse the data space.
+    """
+
+    def __init__(self, intervals, sub_iterators):
+        super(IterationSpace, self).__init__(intervals)
+        self.sub_iterators = sub_iterators
+
+    def _construct(self, intervals):
+        return IterationSpace(intervals, self.sub_iterators)

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -371,9 +371,11 @@ def retrieve_symbols(expressions):
     input = []
     for i in terms:
         try:
-            input.append(i.base.function)
+            function = i.base.function
         except AttributeError:
-            pass
+            continue
+        if function.is_Constant or function.is_TensorFunction:
+            input.append(function)
     input = filter_sorted(input, key=attrgetter('name'))
 
     output = [i.lhs.base.function for i in expressions if i.lhs.is_Indexed]

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -377,6 +377,7 @@ def retrieve_symbols(expressions):
     input = filter_sorted(input, key=attrgetter('name'))
 
     output = [i.lhs.base.function for i in expressions if i.lhs.is_Indexed]
+    output = filter_sorted(output, key=attrgetter('name'))
 
     indexeds = [i for i in terms if i.is_Indexed]
     dimensions = []

--- a/devito/symbolics/inspection.py
+++ b/devito/symbolics/inspection.py
@@ -1,11 +1,15 @@
 from collections import OrderedDict
+from operator import attrgetter
 
 from sympy import Indexed, cos, sin
 
+from devito.dimension import Dimension
 from devito.symbolics.search import retrieve_indexed, retrieve_ops, search
 from devito.symbolics.queries import q_timedimension
 from devito.logger import warning
-from devito.tools import flatten
+from devito.tools import flatten, filter_sorted, partial_order
+
+__all__ = ['count', 'estimate_cost', 'estimate_memory', 'dimension_sort']
 
 
 def count(exprs, query):
@@ -110,3 +114,31 @@ def estimate_memory(handle, mode='realistic'):
         return len(set(reads) | set(writes))
     else:
         return len(reads) + len(writes)
+
+
+def dimension_sort(expr, key=None):
+    """
+    Topologically sort the :class:`Dimension`s in ``expr``, based on the order
+    in which they are encountered when visiting ``expr``.
+
+    :param expr: The :class:`sympy.Eq` from which the :class:`Dimension`s are
+                 extracted. They can appear both as array indices or as free
+                 symbols.
+    :param key: A callable used as key to enforce a final ordering.
+    """
+    # Get the Indexed dimensions, in appearance order
+    constraints = [tuple(i.indices) for i in retrieve_indexed(expr, mode='all')]
+    for i, constraint in enumerate(list(constraints)):
+        normalized = []
+        for j in constraint:
+            found = [d for d in j.free_symbols if isinstance(d, Dimension)]
+            normalized.extend([d for d in found if d not in normalized])
+        constraints[i] = normalized
+    ordering = partial_order(constraints)
+
+    # Add any leftover free dimensions (not an Indexed' index)
+    dimensions = [i for i in expr.free_symbols if isinstance(i, Dimension)]
+    dimensions = filter_sorted(dimensions, key=attrgetter('name'))  # for determinism
+    ordering.extend([i for i in dimensions if i not in ordering])
+
+    return sorted(ordering, key=lambda i: not i.is_Time)

--- a/devito/symbolics/manipulation.py
+++ b/devito/symbolics/manipulation.py
@@ -1,10 +1,10 @@
 from collections import Iterable, OrderedDict
 
 import sympy
-from sympy import Number, Indexed, Function, Symbol, preorder_traversal
+from sympy import Number, Indexed, Function, Symbol
 
 from devito.symbolics.extended_sympy import Add, Mul, Eq
-from devito.symbolics.search import retrieve_indexed
+from devito.symbolics.search import retrieve_indexed, retrieve_functions
 from devito.dimension import Dimension
 from devito.tools import as_tuple, flatten
 
@@ -184,14 +184,15 @@ def as_symbol(expr):
 
 def indexify(expr):
     """
-    Convert functions into indexed matrix accesses in sympy expression.
-
-    :param expr: sympy function expression to be converted.
+    Given a SymPy expression, return a new SymPy expression in which all
+    :class:`AbstractFunction` objects have been converted into :class:`Indexed`
+    objects.
     """
-    replacements = {}
-
-    for e in preorder_traversal(expr):
-        if hasattr(e, 'indexed'):
-            replacements[e] = e.indexify()
-
-    return expr.xreplace(replacements)
+    mapper = {}
+    for i in retrieve_functions(expr):
+        try:
+            if i.is_AbstractFunction:
+                mapper[i] = i.indexify()
+        except AttributeError:
+            pass
+    return expr.xreplace(mapper)

--- a/devito/symbolics/manipulation.py
+++ b/devito/symbolics/manipulation.py
@@ -122,7 +122,7 @@ def xreplace_constrained(exprs, make, rule=None, costmodel=lambda e: True, repea
             if repeat and ret != root:
                 root = ret
             else:
-                rebuilt.append(expr.func(expr.lhs, ret))
+                rebuilt.append(expr.func(expr.lhs, ret, evaluate=False))
                 break
 
     # Post-process the output

--- a/devito/symbolics/queries.py
+++ b/devito/symbolics/queries.py
@@ -33,6 +33,10 @@ def q_indexed(expr):
     return expr.is_Indexed
 
 
+def q_function(expr):
+    return expr.is_Function
+
+
 def q_terminal(expr):
     return expr.is_Symbol or expr.is_Indexed
 

--- a/devito/symbolics/search.py
+++ b/devito/symbolics/search.py
@@ -1,7 +1,8 @@
-from devito.symbolics.queries import q_indexed, q_terminal, q_leaf, q_op, q_trigonometry
+from devito.symbolics.queries import (q_indexed, q_function, q_terminal,
+                                      q_leaf, q_op, q_trigonometry)
 
-__all__ = ['retrieve_indexed', 'retrieve_terminals', 'retrieve_ops',
-           'retrieve_trigonometry', 'search']
+__all__ = ['retrieve_indexed', 'retrieve_functions', 'retrieve_terminals',
+           'retrieve_ops', 'retrieve_trigonometry', 'search']
 
 
 class Search(object):
@@ -106,6 +107,13 @@ def retrieve_indexed(expr, mode='unique'):
     Shorthand to retrieve :class:`Indexed` objects in ``expr``.
     """
     return search(expr, q_indexed, mode, 'dfs')
+
+
+def retrieve_functions(expr, mode='unique'):
+    """
+    Shorthand to retrieve :class:`sympy.Function` objects in ``expr``.
+    """
+    return search(expr, q_function, mode, 'dfs')
 
 
 def retrieve_terminals(expr, mode='unique'):

--- a/devito/tools.py
+++ b/devito/tools.py
@@ -539,3 +539,17 @@ class GenericVisitor(object):
 
     def visit_object(self, o, **kwargs):
         return self.default_retval()
+
+
+class Bunch(object):
+    """
+    Bind together an arbitrary number of generic items. This is a mutable
+    alternative to a ``namedtuple``.
+
+    From: ::
+
+        http://code.activestate.com/recipes/52308-the-simple-but-handy-collector-of\
+        -a-bunch-of-named/?in=user-97991
+    """
+    def __init__(self, **kwargs):
+        self.__dict__.update(kwargs)

--- a/examples/seismic/source.py
+++ b/examples/seismic/source.py
@@ -29,7 +29,7 @@ class PointSource(SparseFunction):
 
     def __new__(cls, name, grid, ntime=None, npoint=None, data=None,
                 coordinates=None, **kwargs):
-        p_dim = kwargs.get('dimension', Dimension('p_%s' % name))
+        p_dim = kwargs.get('dimension', Dimension(name='p_%s' % name))
         npoint = npoint or coordinates.shape[0]
         if data is None:
             if ntime is None:

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -1,14 +1,14 @@
 import numpy as np
 import pytest
-from conftest import t, x, y, z, skipif_yask
+from conftest import skipif_yask
 from sympy import Derivative, simplify
 
 from devito import Grid, Function, TimeFunction
 
 
 @pytest.fixture
-def shape(xdim=20, ydim=30):
-    return (xdim, ydim)
+def shape(xdim=20, ydim=30, zdim=20):
+    return (xdim, ydim, zdim)
 
 
 @pytest.fixture
@@ -16,29 +16,50 @@ def grid(shape):
     return Grid(shape=shape)
 
 
+@pytest.fixture
+def x(grid):
+    return grid.dimensions[0]
+
+
+@pytest.fixture
+def y(grid):
+    return grid.dimensions[1]
+
+
+@pytest.fixture
+def z(grid):
+    return grid.dimensions[2]
+
+
+@pytest.fixture
+def t(grid):
+    return grid.stepping_dim
+
+
 @skipif_yask
-@pytest.mark.parametrize('SymbolType, dimension', [
+@pytest.mark.parametrize('SymbolType, dim', [
     (Function, x), (Function, y),
     (TimeFunction, x), (TimeFunction, y), (TimeFunction, t),
 ])
-def test_stencil_derivative(grid, shape, SymbolType, dimension):
+def test_stencil_derivative(grid, shape, SymbolType, dim):
     """Test symbolic behaviour when expanding stencil derivatives"""
+    i = dim(grid)  # issue fixtures+parametrize: github.com/pytest-dev/pytest/issues/349
     u = SymbolType(name='u', grid=grid)
     u.data[:] = 66.6
-    dx = u.diff(x)
-    dxx = u.diff(x, x)
+    di = u.diff(i)
+    dii = u.diff(i, i)
     # Check for sympy Derivative objects
-    assert(isinstance(dx, Derivative) and isinstance(dxx, Derivative))
-    s_dx = dx.as_finite_difference([x - x.spacing, x])
-    s_dxx = dxx.as_finite_difference([x - x.spacing, x, x + x.spacing])
+    assert(isinstance(di, Derivative) and isinstance(dii, Derivative))
+    s_di = di.as_finite_difference([i - i.spacing, i])
+    s_dii = dii.as_finite_difference([i - i.spacing, i, i + i.spacing])
     # Check stencil length of first and second derivatives
-    assert(len(s_dx.args) == 2 and len(s_dxx.args) == 3)
-    u_dx = s_dx.args[0].args[1]
-    u_dxx = s_dx.args[0].args[1]
+    assert(len(s_di.args) == 2 and len(s_dii.args) == 3)
+    u_di = s_di.args[0].args[1]
+    u_dii = s_di.args[0].args[1]
     # Ensure that devito meta-data survived symbolic transformation
-    assert(u_dx.shape[-2:] == shape and u_dxx.shape[-2:] == shape)
-    assert(np.allclose(u_dx.data, 66.6))
-    assert(np.allclose(u_dxx.data, 66.6))
+    assert(u_di._grid_shape_domain == shape and u_dii._grid_shape_domain == shape)
+    assert(np.allclose(u_di.data, 66.6))
+    assert(np.allclose(u_dii.data, 66.6))
 
 
 @skipif_yask
@@ -54,41 +75,39 @@ def test_preformed_derivatives(grid, SymbolType, derivative, dim):
 
 
 @skipif_yask
-@pytest.mark.parametrize('derivative, dimension', [
+@pytest.mark.parametrize('derivative, dim', [
     ('dx', x), ('dy', y), ('dz', z)
 ])
 @pytest.mark.parametrize('order', [1, 2, 4, 6, 8, 10, 12, 14, 16])
-def test_derivatives_space(derivative, dimension, order):
+def test_derivatives_space(grid, derivative, dim, order):
     """Test first derivative expressions against native sympy"""
-    grid = Grid(shape=(20, 20, 20))
+    dim = dim(grid)  # issue fixtures+parametrize: github.com/pytest-dev/pytest/issues/349
     u = TimeFunction(name='u', grid=grid, time_order=2, space_order=order)
     expr = getattr(u, derivative)
     # Establish native sympy derivative expression
     width = int(order / 2)
     if order == 1:
-        indices = [dimension, dimension + dimension.spacing]
+        indices = [dim, dim + dim.spacing]
     else:
-        indices = [(dimension + i * dimension.spacing)
-                   for i in range(-width, width + 1)]
-    s_expr = u.diff(dimension).as_finite_difference(indices)
+        indices = [(dim + i * dim.spacing) for i in range(-width, width + 1)]
+    s_expr = u.diff(dim).as_finite_difference(indices)
     assert(simplify(expr - s_expr) == 0)  # Symbolic equality
     assert(expr == s_expr)  # Exact equailty
 
 
 @skipif_yask
-@pytest.mark.parametrize('derivative, dimension', [
+@pytest.mark.parametrize('derivative, dim', [
     ('dx2', x), ('dy2', y), ('dz2', z)
 ])
 @pytest.mark.parametrize('order', [2, 4, 6, 8, 10, 12, 14, 16])
-def test_second_derivatives_space(derivative, dimension, order):
+def test_second_derivatives_space(grid, derivative, dim, order):
     """Test second derivative expressions against native sympy"""
-    grid = Grid(shape=(20, 20, 20))
+    dim = dim(grid)  # issue fixtures+parametrize: github.com/pytest-dev/pytest/issues/349
     u = TimeFunction(name='u', grid=grid, time_order=2, space_order=order)
     expr = getattr(u, derivative)
     # Establish native sympy derivative expression
     width = int(order / 2)
-    indices = [(dimension + i * dimension.spacing)
-               for i in range(-width, width + 1)]
-    s_expr = u.diff(dimension, dimension).as_finite_difference(indices)
+    indices = [(dim + i * dim.spacing) for i in range(-width, width + 1)]
+    s_expr = u.diff(dim, dim).as_finite_difference(indices)
     assert(simplify(expr - s_expr) == 0)  # Symbolic equality
     assert(expr == s_expr)  # Exact equailty

--- a/tests/test_dle.py
+++ b/tests/test_dle.py
@@ -13,9 +13,8 @@ from devito.dle import transform
 from devito.dle.backends import DevitoRewriter as Rewriter
 from devito import Grid, Function, TimeFunction, Eq, Operator
 from devito.ir.iet import (ELEMENTAL, Expression, Callable, Iteration, List, tagger,
-                           ResolveTimeStepping, SubstituteExpression,
-                           Transformer, FindNodes, analyze_iterations,
-                           retrieve_iteration_tree)
+                           ResolveTimeStepping, SubstituteExpression, Transformer,
+                           FindNodes, analyze_iterations, retrieve_iteration_tree)
 
 
 @pytest.fixture(scope="module")

--- a/tests/test_dle.py
+++ b/tests/test_dle.py
@@ -480,35 +480,6 @@ def test_loop_fission(simple_function_fissionable):
 
 
 @skipif_yask
-def test_padding(simple_function_with_paddable_arrays):
-    handle = transform(simple_function_with_paddable_arrays, mode='padding')
-    assert """\
-for (int i = 0; i < 3; i += 1)
-{
-  pa_dense[i] = a_dense[i];
-}
-void foo(float *restrict a_dense_vec, float *restrict b_dense_vec)
-{
-  float (*restrict a_dense) __attribute__((aligned(64))) = (float (*)) a_dense_vec;
-  float (*restrict b_dense) __attribute__((aligned(64))) = (float (*)) b_dense_vec;
-  for (int i = 0; i < 3; i += 1)
-  {
-    for (int j = 0; j < 5; j += 1)
-    {
-      for (int k = 0; k < 7; k += 1)
-      {
-        pa_dense[i] = b_dense[i] + pa_dense[i] + 5.0F;
-      }
-    }
-  }
-}
-for (int i = 0; i < 3; i += 1)
-{
-  a_dense[i] = pa_dense[i];
-}""" in str(handle.nodes)
-
-
-@skipif_yask
 @pytest.mark.parametrize("shape", [(41,), (20, 33), (45, 31, 45)])
 def test_composite_transformation(shape):
     wo_blocking, _ = _new_operator1(shape, dle='noop')

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -539,7 +539,7 @@ class TestArguments(object):
         grid = Grid(shape=(10, 10), dimensions=(i, j))
         original_coords = (1., 1.)
         new_coords = (2., 2.)
-        p_dim = Dimension('p_src')
+        p_dim = Dimension(name='p_src')
         u = TimeFunction(name='u', grid=grid, time_order=2, space_order=2)
         time = u.indices[0]
         src1 = SparseFunction(name='src1', grid=grid, dimensions=[time, p_dim],
@@ -926,7 +926,7 @@ class TestLoopScheduler(object):
         """
         grid = Grid(shape=shape, dimensions=dimensions, time_dimension=time)
         a = TimeFunction(name='a', grid=grid, time_order=2, space_order=2)
-        p_aux = Dimension(name='p_aux', size=10)
+        p_aux = Dimension(name='p_aux')
         b = Function(name='b', shape=shape + (10,), dimensions=dimensions + (p_aux,),
                      space_order=2)
         b.data[:] = 1.0

--- a/tests/test_symbol_caching.py
+++ b/tests/test_symbol_caching.py
@@ -137,8 +137,8 @@ def test_symbol_cache_aliasing_reverse():
 
 @skipif_yask
 def test_clear_cache(nx=1000, ny=1000):
-    clear_cache()
     grid = Grid(shape=(nx, ny), dtype=np.float64)
+    clear_cache()
     cache_size = len(_SymbolCache)
 
     for i in range(10):


### PR DESCRIPTION
Misc improvements and fixes. Worth noting:

* dropping lots of unused code (DLE's padding and its dependencies)
* Vastly better ``types`` hierarchy and refreshed documentation
* Better organisation of the IR 
* Add ``Interval`` and ``IterationSpace``, to be used in a subsequent PR. Tests attached

@mloubout this will fail on ``test_save.py``. I'll need your hotfix PR