### PR TITLE
Rethink loop generation before domain-allocation switch (PART 2)

### DIFF
--- a/devito/dle/backends/advanced.py
+++ b/devito/dle/backends/advanced.py
@@ -158,9 +158,9 @@ class DevitoRewriter(BasicRewriter):
                 dim = blocked.setdefault(i, Dimension(name=name))
                 block_size = dim.symbolic_size
                 iter_size = i.dim.symbolic_extent
-                start = i.limits[0] - i.offsets[0]
-                finish = i.dim.symbolic_end - i.offsets[1]
-                innersize = iter_size - (-i.offsets[0] + i.offsets[1])
+                start = i.limits[0] + i.offsets[0]
+                finish = i.dim.symbolic_end + i.offsets[1]
+                innersize = iter_size + (-i.offsets[0] + i.offsets[1])
                 finish = finish - (innersize % block_size)
                 inter_block = Iteration([], dim, [start, finish, block_size],
                                         properties=PARALLEL)
@@ -177,7 +177,7 @@ class DevitoRewriter(BasicRewriter):
                 # This will be used for remainder loops, executed when any
                 # dimension size is not a multiple of the block size.
                 start = inter_block.limits[1]
-                finish = i.dim.symbolic_end - i.offsets[1]
+                finish = i.dim.symbolic_end + i.offsets[1]
                 remainder = i._rebuild([], limits=[start, finish, 1], offsets=None)
                 remainders.append(remainder)
 

--- a/devito/dle/blocking_utils.py
+++ b/devito/dle/blocking_utils.py
@@ -241,7 +241,7 @@ class IterationFold(Iteration):
             start, end, incr = args.pop('limits')
         except TypeError:
             start, end, incr = self.limits
-        folds = tuple(Iteration(nodes, limits=[start+ofs[0], end+ofs[1], incr], **args)
+        folds = tuple(Iteration(nodes, limits=[start-ofs[0], end-ofs[1], incr], **args)
                       for ofs, nodes in self.folds)
 
         return folds + as_tuple(root)

--- a/devito/dse/backends/advanced.py
+++ b/devito/dse/backends/advanced.py
@@ -142,7 +142,7 @@ class AdvancedRewriter(BasicRewriter):
             expression = Eq(Indexed(function, *indices), origin)
             ispace = cluster.ispace.subtract(alias.anti_stencil.boxify().negate())
             if all(time_invariants[i] for i in alias.aliased):
-                ispace = ispace.drop(g.time_indices)
+                ispace = ispace.drop([i.dim for i in ispace.intervals if i.dim.is_Time])
             alias_clusters.append(Cluster([expression], ispace))
             # Update substitution rules
             for aliased, distance in alias.with_distance:

--- a/devito/dse/transformer.py
+++ b/devito/dse/transformer.py
@@ -68,4 +68,4 @@ def rewrite(clusters, mode='advanced'):
             # only consists of a few points
             processed.extend(BasicRewriter(False).run(cluster))
 
-    return groupby(processed)
+    return groupby(processed).finalize()

--- a/devito/exceptions.py
+++ b/devito/exceptions.py
@@ -14,10 +14,6 @@ class InvalidOperator(DevitoError):
     pass
 
 
-class StencilOperationError(DevitoError):
-    pass
-
-
 class VisitorException(DevitoError):
     pass
 

--- a/devito/ir/__init__.py
+++ b/devito/ir/__init__.py
@@ -1,3 +1,4 @@
 from devito.ir.clusters import *  # noqa
 from devito.ir.iet import *  # noqa
 from devito.ir.support import *  # noqa
+from devito.ir.equations import *  # noqa

--- a/devito/ir/clusters/algorithms.py
+++ b/devito/ir/clusters/algorithms.py
@@ -189,7 +189,7 @@ def clusterize(exprs):
     for i, e1 in enumerate(exprs):
         trace = [e2 for e2 in exprs[:i] if Scope([e2, e1]).has_dep] + [e1]
         trace.extend([e2 for e2 in exprs[i+1:] if Scope([e1, e2]).has_dep])
-        mapper[e1] = Bunch(trace=trace, ispace=e1.dspace.negate())
+        mapper[e1] = Bunch(trace=trace, ispace=e1.ispace)
 
     # Derive the iteration spaces
     queue = list(mapper)

--- a/devito/ir/clusters/cluster.py
+++ b/devito/ir/clusters/cluster.py
@@ -3,7 +3,7 @@ from collections import defaultdict
 from sympy import Eq
 from cached_property import cached_property
 
-from devito.ir.support import Box
+from devito.ir.support import Space
 from devito.ir.clusters.graph import FlowGraph
 
 __all__ = ["Cluster", "ClusterGroup"]
@@ -18,7 +18,7 @@ class PartialCluster(object):
     A PartialCluster is mutable.
 
     :param exprs: The ordered sequence of expressions computing a tensor.
-    :param ispace: An object of type :class:`Box`, representing the iteration
+    :param ispace: An object of type :class:`Space`, representing the iteration
                    space of the cluster.
     """
 
@@ -115,8 +115,8 @@ class ClusterGroup(list):
         Return the union of all Clusters' iteration spaces.
         """
         if not self:
-            return Box([])
-        return Box.intersection_update(*[i.ispace for i in self])
+            return Space([])
+        return Space.intersection_update(*[i.ispace for i in self])
 
     def unfreeze(self):
         """

--- a/devito/ir/equations/__init__.py
+++ b/devito/ir/equations/__init__.py
@@ -1,0 +1,1 @@
+from devito.ir.equations.equation import *  # noqa

--- a/devito/ir/equations/equation.py
+++ b/devito/ir/equations/equation.py
@@ -1,0 +1,66 @@
+from collections import OrderedDict
+
+import sympy
+
+from devito.ir.support import Interval, IterationSpace, Stencil
+from devito.symbolics import dimension_sort, indexify
+
+__all__ = ['Eq']
+
+
+class Eq(sympy.Eq):
+
+    """
+    A new SymPy equation with an associated iteration space.
+
+    All :class:`Function` objects within ``expr`` get indexified and thus turned
+    into objects of type :class:`types.Indexed`.
+
+    An iteration space is an object of type :class:`Space`. It represents the
+    data points accessed by the equation along each :class:`Dimension`. The
+    :class:`Dimension`s are extracted directly from the equation.
+    """
+
+    def __new__(cls, input_expr, subs=None):
+        # Sanity check
+        assert isinstance(input_expr, sympy.Eq)
+
+        # Indexification
+        expr = indexify(input_expr)
+
+        # Apply caller-provided substitution
+        if subs is not None:
+            expr = expr.xreplace(subs)
+
+        expr = super(Eq, cls).__new__(cls, expr.lhs, expr.rhs, evaluate=False)
+        expr.is_Increment = getattr(input_expr, 'is_Increment', False)
+
+        # Get the accessed data points
+        stencil = Stencil(expr)
+
+        # Well-defined dimension ordering
+        ordering = dimension_sort(expr, key=lambda i: not i.is_Time)
+
+        # Split actual Intervals (the data spaces) from the "derived" iterators,
+        # to build an IterationSpace
+        iterators = OrderedDict()
+        for i in ordering:
+            if i.is_Derived:
+                iterators.setdefault(i.parent, []).append(stencil.entry(i))
+            else:
+                iterators.setdefault(i, [])
+        intervals = []
+        for k, v in iterators.items():
+            offs = set.union(set(stencil.get(k)), *[i.ofs for i in v])
+            intervals.append(Interval(k, min(offs), max(offs)).negate())
+        expr.ispace = IterationSpace(intervals, iterators)
+
+        return expr
+
+    @property
+    def is_Scalar(self):
+        return self.lhs.is_Symbol
+
+    @property
+    def is_Tensor(self):
+        return self.lhs.is_Indexed

--- a/devito/ir/equations/equation.py
+++ b/devito/ir/equations/equation.py
@@ -1,14 +1,14 @@
 from collections import OrderedDict
 
-import sympy
+from sympy import Eq
 
 from devito.ir.support import Interval, IterationSpace, Stencil
 from devito.symbolics import dimension_sort, indexify
 
-__all__ = ['Eq']
+__all__ = ['LoweredEq']
 
 
-class Eq(sympy.Eq):
+class LoweredEq(Eq):
 
     """
     A new SymPy equation with an associated iteration space.
@@ -23,7 +23,8 @@ class Eq(sympy.Eq):
 
     def __new__(cls, input_expr, subs=None):
         # Sanity check
-        assert isinstance(input_expr, sympy.Eq)
+        assert type(input_expr) != LoweredEq
+        assert isinstance(input_expr, Eq)
 
         # Indexification
         expr = indexify(input_expr)
@@ -32,7 +33,7 @@ class Eq(sympy.Eq):
         if subs is not None:
             expr = expr.xreplace(subs)
 
-        expr = super(Eq, cls).__new__(cls, expr.lhs, expr.rhs, evaluate=False)
+        expr = super(LoweredEq, cls).__new__(cls, expr.lhs, expr.rhs, evaluate=False)
         expr.is_Increment = getattr(input_expr, 'is_Increment', False)
 
         # Get the accessed data points

--- a/devito/ir/iet/__init__.py
+++ b/devito/ir/iet/__init__.py
@@ -3,3 +3,4 @@ from devito.ir.iet.nodes import *  # noqa
 from devito.ir.iet.visitors import *  # noqa
 from devito.ir.iet.utils import *  # noqa
 from devito.ir.iet.analysis import *  # noqa
+from devito.ir.iet.scheduler import *  # noqa

--- a/devito/ir/iet/analysis.py
+++ b/devito/ir/iet/analysis.py
@@ -13,7 +13,7 @@ from devito.ir.iet import (Iteration, SEQUENTIAL, PARALLEL, VECTOR, WRAPPABLE,
 from devito.ir.support import Scope
 from devito.tools import as_tuple, filter_ordered
 
-__all__ = ['analyze_iterations']
+__all__ = ['iet_analyze']
 
 
 class Analysis(object):
@@ -39,7 +39,7 @@ def propertizer(func):
     return wrapper
 
 
-def analyze_iterations(iet):
+def iet_analyze(iet):
     """
     Attach :class:`IterationProperty` to :class:`Iteration` objects within
     ``nodes``. The recognized IterationProperty decorators are listed in

--- a/devito/ir/iet/nodes.py
+++ b/devito/ir/iet/nodes.py
@@ -3,7 +3,7 @@
 from __future__ import absolute_import
 
 import inspect
-from collections import Iterable, OrderedDict
+from collections import Iterable, OrderedDict, namedtuple
 
 import cgen as c
 from sympy import Eq, Indexed, Symbol
@@ -19,7 +19,7 @@ import devito.types as types
 
 __all__ = ['Node', 'Block', 'Denormals', 'Expression', 'Element', 'Callable',
            'Call', 'Iteration', 'List', 'LocalExpression', 'TimedList',
-           'UnboundedIndex']
+           'UnboundedIndex', 'MetaCall']
 
 
 class Node(object):
@@ -523,7 +523,17 @@ class UnboundedIndex(object):
     add a non-linear traversal of the iteration space.
     """
 
-    def __init__(self, index, start=0, step=None):
+    def __init__(self, index, start=0, step=None, dim=None, expr=None):
         self.index = index
         self.start = start
         self.step = index + 1 if step is None else step
+        self.dim = dim
+        self.expr = expr
+
+
+MetaCall = namedtuple('MetaCall', 'root local')
+"""
+Metadata for :class:`Callable`s. ``root`` is a pointer to the callable
+Iteration/Expression tree. ``local`` is a boolean indicating whether the
+definition of the callable is known or not.
+"""

--- a/devito/ir/iet/nodes.py
+++ b/devito/ir/iet/nodes.py
@@ -241,7 +241,7 @@ class Iteration(Node):
     :param limits: Limits for the iteration space, either the loop size or a
                    tuple of the form (start, finish, stepping).
     :param index: Symbol to be used as iteration variable.
-    :param offsets: Optional map list of offsets to honour in the loop.
+    :param offsets: A 2-tuple of start and end offsets to honour in the loop.
     :param properties: A bag of :class:`IterationProperty` objects, decorating
                        the Iteration (sequential, parallel, vectorizable, ...).
     :param pragmas: A bag of pragmas attached to this Iteration.
@@ -271,15 +271,13 @@ class Iteration(Node):
         # Generate loop limits
         if isinstance(limits, Iterable):
             assert(len(limits) == 3)
-            self.limits = list(limits)
+            self.limits = tuple(limits)
         else:
-            self.limits = list((0, limits, 1))
+            self.limits = (0, limits, 1)
 
         # Record offsets to later adjust loop limits accordingly
-        self.offsets = [0, 0]
-        for off in (offsets or {}):
-            self.offsets[0] = min(self.offsets[0], int(off))
-            self.offsets[1] = max(self.offsets[1], int(off))
+        self.offsets = (0, 0) if offsets is None else as_tuple(offsets)
+        assert len(self.offsets) == 2
 
         # Track this Iteration's properties, pragmas and unbounded indices
         properties = as_tuple(properties)
@@ -361,7 +359,7 @@ class Iteration(Node):
         except TypeError:
             # Already a symbolic expression
             pass
-        return (start - as_symbol(self.offsets[0]), end - as_symbol(self.offsets[1]))
+        return (start + as_symbol(self.offsets[0]), end + as_symbol(self.offsets[1]))
 
     @property
     def extent_symbolic(self):
@@ -392,8 +390,8 @@ class Iteration(Node):
         lower = start if start is not None else self.limits[0]
         upper = finish if finish is not None else self.limits[1]
 
-        lower = lower - self.offsets[0]
-        upper = upper - self.offsets[1]
+        lower = lower + self.offsets[0]
+        upper = upper + self.offsets[1]
 
         return (lower, upper)
 

--- a/devito/ir/iet/scheduler.py
+++ b/devito/ir/iet/scheduler.py
@@ -1,0 +1,158 @@
+from collections import OrderedDict
+
+import numpy as np
+
+from devito.cgen_utils import Allocator
+from devito.dimension import LoweredDimension
+from devito.ir.iet import (Expression, LocalExpression, Element, Iteration, List,
+                           UnboundedIndex, MetaCall, MapExpressions, Transformer,
+                           NestedTransformer, SubstituteExpression, iet_analyze,
+                           compose_nodes, filter_iterations, retrieve_iteration_tree)
+from devito.tools import filter_ordered, flatten
+from devito.types import Scalar
+
+__all__ = ['iet_build', 'iet_insert_C_decls']
+
+
+def iet_build(clusters, dtype):
+    """
+    Create an Iteration/Expression tree (IET) given an iterable of :class:`Cluster`s.
+    The nodes in the returned IET are decorated with properties deriving from
+    data dependence analysis.
+    """
+    # Clusters -> Iteration/Expression tree
+    iet = iet_make(clusters, dtype)
+
+    # Data dependency analysis. Properties are attached directly to nodes
+    iet = iet_analyze(iet)
+
+    # Substitute derived dimensions (e.g., t -> t0, t + 1 -> t1)
+    # This is postponed up to this point to ease /iet_analyze/'s life
+    subs = {}
+    for tree in retrieve_iteration_tree(iet):
+        uindices = flatten(i.uindices for i in tree)
+        subs.update({i.expr: LoweredDimension(name=i.index.name, origin=i.expr)
+                     for i in uindices})
+    iet = SubstituteExpression(subs).visit(iet)
+
+    return iet
+
+
+def iet_make(clusters, dtype):
+    """
+    Create an Iteration/Expression tree (IET) given an iterable of :class:`Cluster`s.
+
+    :param clusters: The iterable :class:`Cluster`s for which the IET is built.
+    :param dtype: The data type of the scalar expressions.
+    """
+    processed = []
+    schedule = OrderedDict()
+    for cluster in clusters:
+        if not cluster.ispace.empty:
+            root = None
+            intervals = cluster.ispace.intervals
+
+            # Can I reuse any of the previously scheduled Iterations ?
+            index = 0
+            for i0, i1 in zip(intervals, list(schedule)):
+                if i0 != i1 or i0.dim in clusters.atomics[cluster]:
+                    break
+                root = schedule[i1]
+                index += 1
+            needed = intervals[index:]
+
+            # Build Iterations, including any necessary unbounded index
+            iters = []
+            for i in needed:
+                uindices = []
+                for j, offs in cluster.ispace.sub_iterators.get(i.dim, []):
+                    for n, o in enumerate(filter_ordered(offs)):
+                        name = "%s%d" % (j.name, n)
+                        vname = Scalar(name=name, dtype=np.int32)
+                        value = (i.dim + o) % j.modulo
+                        uindices.append(UnboundedIndex(vname, value, value, j, j + o))
+                iters.append(Iteration([], i.dim, i.dim.limits, offsets=i.limits,
+                                       uindices=uindices))
+
+            # Build Expressions
+            exprs = [Expression(v, np.int32 if cluster.trace.is_index(k) else dtype)
+                     for k, v in cluster.trace.items()]
+
+            # Compose Iterations and Expressions
+            body, tree = compose_nodes(iters + [exprs], retrieve=True)
+
+            # Update the current scheduling
+            scheduling = OrderedDict(zip(needed, tree))
+            if root is None:
+                processed.append(body)
+                schedule = scheduling
+            else:
+                nodes = list(root.nodes) + [body]
+                mapper = {root: root._rebuild(nodes, **root.args_frozen)}
+                transformer = Transformer(mapper)
+                processed = list(transformer.visit(processed))
+                schedule = OrderedDict(list(schedule.items())[:index] +
+                                       list(scheduling.items()))
+                for k, v in list(schedule.items()):
+                    schedule[k] = transformer.rebuilt.get(v, v)
+        else:
+            # No Iterations are needed
+            processed.extend([Expression(e, dtype) for e in cluster.exprs])
+
+    return List(body=processed)
+
+
+def iet_insert_C_decls(iet, func_table):
+    """
+    Given an Iteration/Expression tree ``iet``, build a new tree with the
+    necessary symbol declarations. Declarations are placed as close as
+    possible to the first symbol use.
+
+    :param iet: The input Iteration/Expression tree.
+    :param func_table: A mapper from callable names to :class:`Callable`s
+                       called from within ``iet``.
+    """
+    # Resolve function calls first
+    scopes = []
+    me = MapExpressions()
+    for k, v in me.visit(iet).items():
+        if k.is_Call:
+            func = func_table[k.name]
+            if func.local:
+                scopes.extend(me.visit(func.root, queue=list(v)).items())
+        else:
+            scopes.append((k, v))
+
+    # Determine all required declarations
+    allocator = Allocator()
+    mapper = OrderedDict()
+    for k, v in scopes:
+        if k.is_scalar:
+            # Inline declaration
+            mapper[k] = LocalExpression(**k.args)
+        elif k.write._mem_external:
+            # Nothing to do, variable passed as kernel argument
+            continue
+        elif k.write._mem_stack:
+            # On the stack, as established by the DLE
+            key = lambda i: not i.is_Parallel
+            site = filter_iterations(v, key=key, stop='asap') or [iet]
+            allocator.push_stack(site[-1], k.write)
+        else:
+            # On the heap, as a tensor that must be globally accessible
+            allocator.push_heap(k.write)
+
+    # Introduce declarations on the stack
+    for k, v in allocator.onstack:
+        mapper[k] = tuple(Element(i) for i in v)
+    iet = NestedTransformer(mapper).visit(iet)
+    for k, v in list(func_table.items()):
+        if v.local:
+            func_table[k] = MetaCall(Transformer(mapper).visit(v.root), v.local)
+
+    # Introduce declarations on the heap (if any)
+    if allocator.onheap:
+        decls, allocs, frees = zip(*allocator.onheap)
+        iet = List(header=decls + allocs, body=iet, footer=frees)
+
+    return iet

--- a/devito/ir/iet/visitors.py
+++ b/devito/ir/iet/visitors.py
@@ -193,7 +193,7 @@ class CGen(Visitor):
 
         # Start
         if o.offsets[0] != 0:
-            start = "%s + %s" % (o.limits[0], -o.offsets[0])
+            start = str(o.limits[0] + o.offsets[0])
             try:
                 start = eval(start)
             except (NameError, TypeError):
@@ -203,7 +203,7 @@ class CGen(Visitor):
 
         # Bound
         if o.offsets[1] != 0:
-            end = "%s - %s" % (o.limits[1], o.offsets[1])
+            end = str(o.limits[1] + o.offsets[1])
             try:
                 end = eval(end)
             except (NameError, TypeError):

--- a/devito/ir/support/basic.py
+++ b/devito/ir/support/basic.py
@@ -489,6 +489,7 @@ class DependenceGroup(list):
     @property
     def cause(self):
         ret = [i.cause for i in self if i.cause is not None]
+        ret.extend([i.parent for i in ret if i.is_Derived])
         return tuple(filter_sorted(ret, key=lambda i: i.name))
 
     @property

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -1,6 +1,6 @@
 from __future__ import absolute_import
 
-from collections import OrderedDict, namedtuple
+from collections import OrderedDict
 from operator import attrgetter
 
 import ctypes
@@ -8,7 +8,6 @@ import numpy as np
 import sympy
 
 from devito.arguments import ArgumentEngine
-from devito.cgen_utils import Allocator
 from devito.compiler import jit_compile, load
 from devito.dimension import Dimension
 from devito.dle import transform
@@ -18,10 +17,7 @@ from devito.function import Forward, Backward
 from devito.logger import bar, info
 from devito.ir.equations import Eq
 from devito.ir.clusters import clusterize
-from devito.ir.iet import (Element, Expression, Callable, Iteration, List,
-                           LocalExpression, MapExpressions, ResolveTimeStepping,
-                           SubstituteExpression, Transformer, NestedTransformer,
-                           analyze_iterations, compose_nodes, filter_iterations)
+from devito.ir.iet import (Callable, List, MetaCall, iet_build, iet_insert_C_decls)
 from devito.parameters import configuration
 from devito.profiling import create_profile
 from devito.symbolics import retrieve_terminals
@@ -96,18 +92,11 @@ class Operator(Callable):
         clusters = clusterize(expressions)
         clusters = rewrite(clusters, mode=set_dse_mode(dse))
 
-        # Wrap expressions with Iterations according to dimensions
-        nodes = self._schedule_expressions(clusters)
-
-        # Data dependency analysis. Properties are attached directly to nodes
-        nodes = analyze_iterations(nodes)
+        # Lower Clusters to an Iteration/Expression tree (IET)
+        nodes = iet_build(clusters, self.dtype)
 
         # Introduce C-level profiling infrastructure
         nodes, self.profiler = self._profile_sections(nodes, parameters)
-
-        # Resolve and substitute dimensions for loop index variables
-        nodes, subs = ResolveTimeStepping().visit(nodes)
-        nodes = SubstituteExpression(subs=subs).visit(nodes)
 
         # Translate into backend-specific representation (e.g., GPU, Yask)
         nodes = self._specialize(nodes, parameters)
@@ -118,15 +107,15 @@ class Operator(Callable):
         # Update the Operator state based on the DLE
         self.dle_arguments = dle_state.arguments
         self.dle_flags = dle_state.flags
-        self.func_table.update(OrderedDict([(i.name, FunMeta(i, True))
+        self.func_table.update(OrderedDict([(i.name, MetaCall(i, True))
                                             for i in dle_state.elemental_functions]))
         parameters.extend([i.argument for i in self.dle_arguments])
         self.dimensions.extend([i.argument for i in self.dle_arguments
                                 if isinstance(i.argument, Dimension)])
         self._includes.extend(list(dle_state.includes))
 
-        # Introduce all required C declarations
-        nodes = self._insert_declarations(dle_state.nodes)
+        # Introduce the required symbol declarations
+        nodes = iet_insert_C_decls(dle_state.nodes, self.func_table)
 
         # Initialise ArgumentEngine
         self.argument_engine = ArgumentEngine(clusters.ispace, parameters,
@@ -201,106 +190,10 @@ class Operator(Callable):
         best block sizes when loop blocking is in use."""
         return arguments
 
-    def _schedule_expressions(self, clusters):
-        """Create an Iteartion/Expression tree given an iterable of
-        :class:`Cluster` objects."""
-
-        # Build the Iteration/Expression tree
-        processed = []
-        schedule = OrderedDict()
-        for i in clusters:
-            # Build the Expression objects to be inserted within an Iteration tree
-            expressions = [Expression(v, np.int32 if i.trace.is_index(k) else self.dtype)
-                           for k, v in i.trace.items()]
-
-            if not i.ispace.empty:
-                root = None
-                entries = i.ispace.intervals
-
-                # Can I reuse any of the previously scheduled Iterations ?
-                index = 0
-                for j0, j1 in zip(entries, list(schedule)):
-                    if j0 != j1 or j0.dim in clusters.atomics[i]:
-                        break
-                    root = schedule[j1]
-                    index += 1
-                needed = entries[index:]
-
-                # Build and insert the required Iterations
-                iters = [Iteration([], j.dim, j.dim.limits, offsets=j.limits)
-                         for j in needed]
-                body, tree = compose_nodes(iters + [expressions], retrieve=True)
-                scheduling = OrderedDict(zip(needed, tree))
-                if root is None:
-                    processed.append(body)
-                    schedule = scheduling
-                else:
-                    nodes = list(root.nodes) + [body]
-                    mapper = {root: root._rebuild(nodes, **root.args_frozen)}
-                    transformer = Transformer(mapper)
-                    processed = list(transformer.visit(processed))
-                    schedule = OrderedDict(list(schedule.items())[:index] +
-                                           list(scheduling.items()))
-                    for k, v in list(schedule.items()):
-                        schedule[k] = transformer.rebuilt.get(v, v)
-            else:
-                # No Iterations are needed
-                processed.extend(expressions)
-
-        return List(body=processed)
-
     def _specialize(self, nodes, parameters):
         """Transform the Iteration/Expression tree into a backend-specific
         representation, such as code to be executed on a GPU or through a
         lower-level tool."""
-        return nodes
-
-    def _insert_declarations(self, nodes):
-        """Populate the Operator's body with the necessary variable declarations."""
-
-        # Resolve function calls first
-        scopes = []
-        me = MapExpressions()
-        for k, v in me.visit(nodes).items():
-            if k.is_Call:
-                func = self.func_table[k.name]
-                if func.local:
-                    scopes.extend(me.visit(func.root, queue=list(v)).items())
-            else:
-                scopes.append((k, v))
-
-        # Determine all required declarations
-        allocator = Allocator()
-        mapper = OrderedDict()
-        for k, v in scopes:
-            if k.is_scalar:
-                # Inline declaration
-                mapper[k] = LocalExpression(**k.args)
-            elif k.write._mem_external:
-                # Nothing to do, variable passed as kernel argument
-                continue
-            elif k.write._mem_stack:
-                # On the stack, as established by the DLE
-                key = lambda i: not i.is_Parallel
-                site = filter_iterations(v, key=key, stop='asap') or [nodes]
-                allocator.push_stack(site[-1], k.write)
-            else:
-                # On the heap, as a tensor that must be globally accessible
-                allocator.push_heap(k.write)
-
-        # Introduce declarations on the stack
-        for k, v in allocator.onstack:
-            mapper[k] = tuple(Element(i) for i in v)
-        nodes = NestedTransformer(mapper).visit(nodes)
-        for k, v in list(self.func_table.items()):
-            if v.local:
-                self.func_table[k] = FunMeta(Transformer(mapper).visit(v.root), v.local)
-
-        # Introduce declarations on the heap (if any)
-        if allocator.onheap:
-            decls, allocs, frees = zip(*allocator.onheap)
-            nodes = List(header=decls + allocs, body=nodes, footer=frees)
-
         return nodes
 
 
@@ -391,13 +284,6 @@ def retrieve_symbols(expressions):
 
 
 # Misc helpers
-
-
-FunMeta = namedtuple('FunMeta', 'root local')
-"""
-Metadata for functions called by an Operator. ``local = True`` means that
-the function was generated by Devito itself.
-"""
 
 
 def set_dse_mode(mode):

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -15,7 +15,7 @@ from devito.dse import rewrite
 from devito.exceptions import InvalidOperator
 from devito.function import Forward, Backward
 from devito.logger import bar, info
-from devito.ir.equations import Eq
+from devito.ir.equations import LoweredEq
 from devito.ir.clusters import clusterize
 from devito.ir.iet import (Callable, List, MetaCall, iet_build, iet_insert_C_decls)
 from devito.parameters import configuration
@@ -75,7 +75,7 @@ class Operator(Callable):
         self.func_table = OrderedDict()
 
         # Expression lowering and analysis
-        expressions = [Eq(e, subs=subs) for e in expressions]
+        expressions = [LoweredEq(e, subs=subs) for e in expressions]
         self.dtype = retrieve_dtype(expressions)
         self.input, self.output, self.dimensions = retrieve_symbols(expressions)
 

--- a/devito/yask/operator.py
+++ b/devito/yask/operator.py
@@ -9,9 +9,9 @@ from devito.compiler import jit_compile
 from devito.dimension import LoweredDimension
 from devito.types import Object
 from devito.logger import yask as log, yask_warning as warning
-from devito.ir.iet import (Element, IsPerfectIteration, Transformer,
+from devito.ir.iet import (Element, MetaCall, IsPerfectIteration, Transformer,
                            filter_iterations, retrieve_iteration_tree)
-from devito.operator import OperatorRunnable, FunMeta
+from devito.operator import OperatorRunnable
 from devito.tools import flatten
 
 from devito.yask import nfac, namespace, exit, configuration
@@ -73,7 +73,7 @@ class Operator(OperatorRunnable):
                 nodes = Transformer({tree[1]: funcall}).visit(nodes)
 
                 # Track /funcall/ as an external function call
-                self.func_table[namespace['code-soln-run']] = FunMeta(None, False)
+                self.func_table[namespace['code-soln-run']] = MetaCall(None, False)
 
                 # JIT-compile the newly-created YASK kernel
                 local_grids += [i for i in transform.mapper if i.is_Array]

--- a/tests/test_dse.py
+++ b/tests/test_dse.py
@@ -6,11 +6,10 @@ import pytest
 from conftest import x, y, z, time, skipif_yask  # noqa
 
 from devito import Eq  # noqa
-from devito.operator import make_stencils
-from devito.ir import Stencil, clusterize, FlowGraph
+from devito.ir import Stencil, clusterize, FlowGraph, Eq as ir_Eq
 from devito.dse import rewrite, common_subexprs_elimination, collect
 from devito.symbolics import (xreplace_constrained, iq_timeinvariant, iq_timevarying,
-                              estimate_cost, pow_to_mul, indexify)
+                              estimate_cost, pow_to_mul)
 from devito.types import Scalar
 from examples.seismic.acoustic import AcousticWaveSolver
 from examples.seismic import demo_model, RickerSource, GaborSource, Receiver
@@ -108,10 +107,8 @@ def test_tti_clusters_to_graph():
 
     expressions = solver.op_fwd('centered').args['expressions']
     subs = solver.op_fwd('centered').args['subs']
-    expressions = [indexify(s) for s in expressions]
-    expressions = [s.xreplace(subs) for s in expressions]
-    stencils = make_stencils(expressions)
-    clusters = clusterize(expressions, stencils)
+    expressions = [ir_Eq(e, subs=subs) for e in expressions]
+    clusters = clusterize(expressions)
     assert len(clusters) == 3
 
     main_cluster = clusters[0]

--- a/tests/test_dse.py
+++ b/tests/test_dse.py
@@ -6,7 +6,7 @@ import pytest
 from conftest import x, y, z, time, skipif_yask  # noqa
 
 from devito import Eq  # noqa
-from devito.ir import Stencil, clusterize, FlowGraph, Eq as ir_Eq
+from devito.ir import Stencil, clusterize, FlowGraph, LoweredEq
 from devito.dse import rewrite, common_subexprs_elimination, collect
 from devito.symbolics import (xreplace_constrained, iq_timeinvariant, iq_timevarying,
                               estimate_cost, pow_to_mul)
@@ -107,7 +107,7 @@ def test_tti_clusters_to_graph():
 
     expressions = solver.op_fwd('centered').args['expressions']
     subs = solver.op_fwd('centered').args['subs']
-    expressions = [ir_Eq(e, subs=subs) for e in expressions]
+    expressions = [LoweredEq(e, subs=subs) for e in expressions]
     clusters = clusterize(expressions)
     assert len(clusters) == 3
 

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -845,10 +845,13 @@ class TestLoopScheduler(object):
                              tu.base, tv.base, tw.base)
         op = Operator([eq1, eq2, eq3], dse='noop', dle='noop', time_axis=axis)
         trees = retrieve_iteration_tree(op)
-        assert len(trees) == len(expected)
-        assert ["".join(i.dim.name for i in j) for j in trees] == expected
         iters = FindNodes(Iteration).visit(op)
-        assert "".join(i.dim.name for i in iters) == visit
+        assert len(trees) == len(expected)
+        # mapper just makes it quicker to write out the test parametrization
+        mapper = {'time': 't'}
+        assert ["".join(mapper.get(i.dim.name, i.dim.name) for i in j)
+                for j in trees] == expected
+        assert "".join(mapper.get(i.dim.name, i.dim.name) for i in iters) == visit
 
     def test_expressions_imperfect_loops(self, ti0, ti1, ti2, t0):
         """

--- a/tests/test_visitors.py
+++ b/tests/test_visitors.py
@@ -58,31 +58,31 @@ def block3(exprs, iters):
 def test_printAST(block1, block2, block3):
     str1 = printAST(block1)
     assert str1 in """
-<Iteration i::i::[0, 3, 1]::[0, 0]>
-  <Iteration j::j::[0, 5, 1]::[0, 0]>
-    <Iteration k::k::[0, 7, 1]::[0, 0]>
+<Iteration i::i::(0, 3, 1)::(0, 0)>
+  <Iteration j::j::(0, 5, 1)::(0, 0)>
+    <Iteration k::k::(0, 7, 1)::(0, 0)>
       <Expression a[i] = a[i] + b[i] + 5.0>
 """
 
     str2 = printAST(block2)
     assert str2 in """
-<Iteration i::i::[0, 3, 1]::[0, 0]>
+<Iteration i::i::(0, 3, 1)::(0, 0)>
   <Expression a[i] = a[i] + b[i] + 5.0>
-  <Iteration j::j::[0, 5, 1]::[0, 0]>
-    <Iteration k::k::[0, 7, 1]::[0, 0]>
+  <Iteration j::j::(0, 5, 1)::(0, 0)>
+    <Iteration k::k::(0, 7, 1)::(0, 0)>
       <Expression a[i] = -a[i] + b[i]>
 """
 
     str3 = printAST(block3)
     assert str3 in """
-<Iteration i::i::[0, 3, 1]::[0, 0]>
-  <Iteration s::s::[0, 4, 1]::[0, 0]>
+<Iteration i::i::(0, 3, 1)::(0, 0)>
+  <Iteration s::s::(0, 4, 1)::(0, 0)>
     <Expression a[i] = a[i] + b[i] + 5.0>
-  <Iteration j::j::[0, 5, 1]::[0, 0]>
-    <Iteration k::k::[0, 7, 1]::[0, 0]>
+  <Iteration j::j::(0, 5, 1)::(0, 0)>
+    <Iteration k::k::(0, 7, 1)::(0, 0)>
       <Expression a[i] = -a[i] + b[i]>
       <Expression a[i] = 4*a[i]*b[i]>
-  <Iteration q::q::[0, 4, 1]::[0, 0]>
+  <Iteration q::q::(0, 4, 1)::(0, 0)>
     <Expression a[i] = 8.0*a[i] + 6.0/b[i]>
 """
 
@@ -291,8 +291,8 @@ def test_nested_transformer(exprs, iters, block2):
     mapper = {target_loop: iters[3](target_loop.nodes[0]),
               target_expr: exprs[3]}
     processed = NestedTransformer(mapper).visit(block2)
-    assert printAST(processed) == """<Iteration i::i::[0, 3, 1]::[0, 0]>
+    assert printAST(processed) == """<Iteration i::i::(0, 3, 1)::(0, 0)>
   <Expression a[i] = a[i] + b[i] + 5.0>
-  <Iteration s::s::[0, 4, 1]::[0, 0]>
-    <Iteration k::k::[0, 7, 1]::[0, 0]>
+  <Iteration s::s::(0, 4, 1)::(0, 0)>
+    <Iteration k::k::(0, 7, 1)::(0, 0)>
       <Expression a[i] = 8.0*a[i] + 6.0/b[i]>"""


### PR DESCRIPTION
~The diff is huge, but mainly because this PR needs #468 to go in first. I'm filing it just to show progress is being made.~

EDIT: Ready for review

OK, so, this took a while because I basically had to rethink (simplify) and cleanup the process that lowers equations down to loops. Main features of the PR are

- ``ir.Eq`` is now a first-class citizen in the compiler; it represents a "lowered equation". It is attached an ``IterationSpace``
- ``clusterize`` now groups ``ir.Eq``s and doesn't need stencils anymore; the required information is carried by the equations themselves, through ``IterationSpace``.
- ``Stencil`` is now less powerful, as ``IterationSpace`` does (in a much better and cleaner way) most of the job. 
- an ``IterationSpace`` carries ``sub_iterators``. In essence, a sub_iterator is a mapper from "main" to "derived" dimensions used within the iteration space. 
- ``ResolveIterationVariable`` has been dropped. The used-to-be ``_schedule_expressions``, now moved to the free function ``iet_make`` within ``ir/iet``, does all the job. This is vastly better then before, as now we *construct the loops as soon as we have the necessary information, rather than building them once and then applying a Transformer visitor (``ResolveIterationVariable``) to them*. In particular, we exploit the ``sub_iterator`` information carried by the clusters' iteration spaces. Eventually, this makes adding/supporting further derived dimensions much simpler (@navjotk ), as now we don't need stupid dimension mappers all over the place anymore