### PR TITLE
symbolics: Fix xreplace_constrained when providing pure symbols

### DIFF
--- a/devito/dse/backends/advanced.py
+++ b/devito/dse/backends/advanced.py
@@ -14,7 +14,7 @@ from devito.types import Indexed, Scalar, Array
 class AdvancedRewriter(BasicRewriter):
 
     def _pipeline(self, state):
-        self._extract_time_invariants(state)
+        self._extract_time_invariants(state, costmodel=lambda e: e.is_Function)
         self._eliminate_inter_stencil_redundancies(state)
         self._eliminate_intra_stencil_redundancies(state)
         self._factorize(state)

--- a/devito/symbolics/manipulation.py
+++ b/devito/symbolics/manipulation.py
@@ -70,8 +70,6 @@ def xreplace_constrained(exprs, make, rule=None, costmodel=lambda e: True, repea
         assert callable(make) and callable(rule)
 
         def replace(expr):
-            if isinstance(make, dict):
-                return make[expr]
             temporary = found.get(expr)
             if temporary:
                 return temporary
@@ -118,8 +116,11 @@ def xreplace_constrained(exprs, make, rule=None, costmodel=lambda e: True, repea
         root = expr.rhs
 
         while True:
-            ret, _ = run(root)
-            if repeat and ret != root:
+            ret, flag = run(root)
+            if isinstance(make, dict) and root.is_Atom and flag:
+                rebuilt.append(expr.func(expr.lhs, replace(root), evaluate=False))
+                break
+            elif repeat and ret != root:
                 root = ret
             else:
                 rebuilt.append(expr.func(expr.lhs, ret, evaluate=False))


### PR DESCRIPTION
@mloubout this at least fixes the TTI compilation issue (shifted mode)
I cannot reproduce the segfault in aggressive mode though, and I tried really hard
anyway, let's start taking a look at this