### PR TITLE
Travis separate compilers

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,15 +12,35 @@ matrix:
   include:
     - os: linux
       python: "3.6"
+      addons:
+        apt:
+          packages:
+            - gcc-4.9
+            - g++-4.9
       env: DEVITO_ARCH=gcc-4.9 DEVITO_OPENMP=0
     - os: linux
       python: "3.6"
+      addons:
+        apt:
+          packages:
+            - gcc-5
+            - g++-5
       env: DEVITO_ARCH=gcc-5 DEVITO_OPENMP=0
     - os: linux
       python: "3.6"
+      addons:
+        apt:
+          packages:
+            - gcc-4.9
+            - g++-4.9
       env: DEVITO_ARCH=gcc-4.9 DEVITO_OPENMP=1 OMP_NUM_THREADS=2
     - os: linux
       python: "3.6"
+      addons:
+        apt:
+          packages:
+            - gcc-7
+            - g++-7
       env: DEVITO_ARCH=gcc-7 DEVITO_OPENMP=0 DEVITO_BACKEND=yask
   allow_failures:
     - os: linux
@@ -34,13 +54,6 @@ addons:
   apt:
     sources:
       - ubuntu-toolchain-r-test     # For gcc 4.9, 5 and 7
-    packages:
-      - gcc-4.9
-      - g++-4.9
-      - gcc-5
-      - g++-5
-      - gcc-7
-      - g++-7
 
 before_install:
   # Setup anaconda

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ matrix:
       python: "3.6"
       addons:
         apt:
+          sources:
+            - ubuntu-toolchain-r-test     # For gcc 4.9, 5 and 7
           packages:
             - gcc-4.9
             - g++-4.9
@@ -22,6 +24,8 @@ matrix:
       python: "3.6"
       addons:
         apt:
+          sources:
+            - ubuntu-toolchain-r-test     # For gcc 4.9, 5 and 7
           packages:
             - gcc-5
             - g++-5
@@ -30,6 +34,8 @@ matrix:
       python: "3.6"
       addons:
         apt:
+          sources:
+            - ubuntu-toolchain-r-test     # For gcc 4.9, 5 and 7
           packages:
             - gcc-4.9
             - g++-4.9
@@ -38,6 +44,8 @@ matrix:
       python: "3.6"
       addons:
         apt:
+          sources:
+            - ubuntu-toolchain-r-test     # For gcc 4.9, 5 and 7
           packages:
             - gcc-7
             - g++-7


### PR DESCRIPTION
This PR unrolls the apt-package specs in the travis file for each builder in the build matrix. This means we now only install one compiler version per builder, rather than all of them, dropping the apt-install time from ~10min to about 1-2min. 