### PR TITLE
Better SparseFunction

### DIFF
--- a/devito/base.py
+++ b/devito/base.py
@@ -34,6 +34,10 @@ class SparseFunction(with_metaclass(_BackendSelector, function.SparseFunction)):
     pass
 
 
+class SparseTimeFunction(with_metaclass(_BackendSelector, function.SparseTimeFunction)):
+    pass
+
+
 class Operator(with_metaclass(_BackendSelector, operator.Operator)):
     pass
 

--- a/devito/core/__init__.py
+++ b/devito/core/__init__.py
@@ -16,6 +16,7 @@ env_vars_mapper = {
 add_sub_configuration(core_configuration, env_vars_mapper)
 
 # The following used by backends.backendSelector
-from devito.function import Constant, Function, TimeFunction, SparseFunction  # noqa
+from devito.function import (Constant, Function, TimeFunction, SparseFunction,  # noqa
+                             SparseTimeFunction)
 from devito.core.operator import Operator  # noqa
 from devito.types import CacheManager  # noqa

--- a/devito/dimension.py
+++ b/devito/dimension.py
@@ -265,24 +265,6 @@ class SteppingDimension(DerivedDimension):
     :param parent: Parent dimension over which to loop in modulo fashion.
     """
 
-    def __new__(cls, name, parent, **kwargs):
-        newobj = DerivedDimension.__new__(cls, name, parent)
-        newobj._modulo = kwargs.get('modulo', 2)
-        return newobj
-
-    @property
-    def modulo(self):
-        return self._modulo
-
-    @modulo.setter
-    def modulo(self, val):
-        # TODO: this is an outrageous hack. TimeFunctions are updating this value
-        # at construction time.
-        self._modulo = val
-
-    def _hashable_content(self):
-        return (self.parent._hashable_content(), self.modulo)
-
     @property
     def symbolic_start(self):
         """

--- a/devito/function.py
+++ b/devito/function.py
@@ -1077,7 +1077,8 @@ class SparseFunction(Function, SparsePoints):
         if not isinstance(npoint, int) and npoint > 0:
             raise ValueError('SparseFunction requires parameter `npoint`')
 
-        kwargs['shape'] = (npoint,)
+        kwargs['shape'] = kwargs.get('shape', (npoint, ))
+
         return Function.__new__(cls, *args, **kwargs)
 
     def __init__(self, *args, **kwargs):
@@ -1092,6 +1093,7 @@ class SparseFunction(Function, SparsePoints):
 
             # A SparseFunction has empty halo region
             self._halo = tuple((0, 0) for i in range(self.ndim))
+            self.sparse_shape = kwargs.get('shape', (self.npoint, ))
 
     @classmethod
     def _indices(cls, **kwargs):
@@ -1106,7 +1108,7 @@ class SparseFunction(Function, SparsePoints):
 
     @property
     def shape_domain(self):
-        return (self.npoint,)
+        return self.sparse_shape
 
     def argument_defaults(self, alias=None):
         """

--- a/devito/function.py
+++ b/devito/function.py
@@ -433,12 +433,12 @@ class Function(TensorFunction):
 
             self.grid = kwargs.get('grid', None)
             if self.grid is None:
-                self._grid_shape_domain = kwargs.get('shape', None)
+                self._shape = kwargs.get('shape', None)
                 self.dtype = kwargs.get('dtype', np.float32)
-                if self._grid_shape_domain is None:
+                if self._shape is None:
                     raise ValueError("Function needs either 'shape' or 'grid' argument")
             else:
-                self._grid_shape_domain = self.grid.shape_domain
+                self._shape = self.grid.shape_domain
                 self.dtype = kwargs.get('dtype', self.grid.dtype)
 
             space_order = kwargs.get('space_order', 1)
@@ -557,7 +557,7 @@ class Function(TensorFunction):
 
     @property
     def shape_domain(self):
-        return tuple(i - j for i, j in zip(self._grid_shape_domain, self.staggered))
+        return tuple(i - j for i, j in zip(self._shape, self.staggered))
 
     @property
     def laplace(self):
@@ -719,7 +719,7 @@ class TimeFunction(Function):
         else:
             tsize = self.time_order + 1
         return (tsize,) +\
-            tuple(i - j for i, j in zip(self._grid_shape_domain, self.staggered[1:]))
+            tuple(i - j for i, j in zip(self._shape, self.staggered[1:]))
 
     @property
     def forward(self):

--- a/devito/function.py
+++ b/devito/function.py
@@ -685,9 +685,9 @@ class TimeFunction(Function):
                 self.indices[0].modulo = self.time_order + 1
                 self._shape = (self.time_order + 1,) + self._shape
 
-            # Adjust halo and padding regions
-            self._halo = ((0, 0),) + self._halo[1:]
-            self._padding = ((0, 0),) + self._padding[1:]
+            # No halo and padding regions along the time dimension
+            self._halo = ((0, 0),) + self._halo
+            self._padding = ((0, 0),) + self._padding
 
     @classmethod
     def _indices(cls, **kwargs):
@@ -799,7 +799,7 @@ class SparseFunction(TensorFunction):
             self.grid = grid
 
             # Shape (inferred if not explicitly provided)
-            self._shape = kwargs.get('shape', (kwargs.get('npoint'),))
+            self._shape = self.__shape_setup__(**kwargs)
 
             self.dtype = kwargs.get('dtype', self.grid.dtype)
             self.space_order = kwargs.get('space_order', 1)
@@ -829,6 +829,9 @@ class SparseFunction(TensorFunction):
             return dimensions
         else:
             return (Dimension(name='p'),)
+
+    def __shape_setup__(self, **kwargs):
+        return kwargs.get('shape', (kwargs.get('npoint'),))
 
     @property
     def shape_domain(self):
@@ -1090,9 +1093,6 @@ class SparseTimeFunction(SparseFunction):
                 raise ValueError('SparseTimeFunction requires int parameter `nt`')
             self.nt = nt
 
-            # Shape (inferred if not explicitly provided)
-            self._shape = kwargs.get('shape', (kwargs.get('nt'), kwargs.get('npoint'),))
-
     @classmethod
     def _indices(cls, **kwargs):
         """
@@ -1103,3 +1103,6 @@ class SparseTimeFunction(SparseFunction):
             return dimensions
         else:
             return (kwargs['grid'].time_dim, Dimension(name='p'))
+
+    def __shape_setup__(self, **kwargs):
+        return kwargs.get('shape', (kwargs.get('nt'), kwargs.get('npoint'),))

--- a/devito/function.py
+++ b/devito/function.py
@@ -792,7 +792,7 @@ class SparseFunction(TensorFunction):
             self.grid = grid
 
             self.dtype = kwargs.get('dtype', self.grid.dtype)
-            self.space_order = kwargs.get('space_order', 1)
+            self.space_order = kwargs.get('space_order', 0)
 
             # Set up coordinates of sparse points
             coordinates = Function(name='%s_coords' % self.name,

--- a/devito/function.py
+++ b/devito/function.py
@@ -313,16 +313,6 @@ class TensorFunction(SymbolicFunction):
         return tuple(d for d in self.indices if d.is_Space)
 
     @property
-    def rank(self):
-        """Return the number of dimensions."""
-        return len(self.dimensions)
-
-    @property
-    def ndim(self):
-        """Return the number of spatial dimensions."""
-        return len(self.space_dimensions)
-
-    @property
     def staggered(self):
         return self._staggered
 
@@ -696,8 +686,8 @@ class TimeFunction(Function):
                 self._shape = (self.time_order + 1,) + self._shape
 
             # Adjust halo and padding regions
-            self._halo = ((0, 0),) + self._halo
-            self._padding = ((0, 0),) + self._padding
+            self._halo = ((0, 0),) + self._halo[1:]
+            self._padding = ((0, 0),) + self._padding[1:]
 
     @classmethod
     def _indices(cls, **kwargs):
@@ -824,10 +814,10 @@ class SparseFunction(TensorFunction):
             self.coordinates = coordinates
 
             # Halo region
-            self._halo = tuple((0, 0) for i in range(self.rank))
+            self._halo = tuple((0, 0) for i in range(self.ndim))
 
             # Padding region
-            self._padding = tuple((0, 0) for i in range(self.rank))
+            self._padding = tuple((0, 0) for i in range(self.ndim))
 
     @classmethod
     def _indices(cls, **kwargs):

--- a/devito/function.py
+++ b/devito/function.py
@@ -118,8 +118,6 @@ class TensorFunction(SymbolicFunction):
         if not self._cached():
             self.name = kwargs.get('name')
 
-            self.indices = self._indices(**kwargs)
-
             # Staggered mask
             self._staggered = kwargs.get('staggered', tuple(0 for _ in self.indices))
             if len(self.staggered) != len(self.indices):
@@ -536,7 +534,7 @@ class Function(TensorFunction):
                                  (dim.name, dim2.name)))
 
     @classmethod
-    def _indices(cls, **kwargs):
+    def __indices_setup__(cls, **kwargs):
         """Return the default dimension indices for a given data shape
 
         :param grid: :class:`Grid` that defines the spatial domain.
@@ -690,7 +688,7 @@ class TimeFunction(Function):
             self._padding = ((0, 0),) + self._padding
 
     @classmethod
-    def _indices(cls, **kwargs):
+    def __indices_setup__(cls, **kwargs):
         """Return the default dimension indices for a given data shape
 
         :param grid: :class:`Grid` object from which to infer the data
@@ -712,8 +710,7 @@ class TimeFunction(Function):
 
         assert(isinstance(time_dim, Dimension) and time_dim.is_Time)
 
-        _indices = Function._indices(**kwargs)
-        return tuple([time_dim] + list(_indices))
+        return (time_dim,) + Function.__indices_setup__(**kwargs)
 
     @property
     def forward(self):
@@ -820,7 +817,7 @@ class SparseFunction(TensorFunction):
             self._padding = tuple((0, 0) for i in range(self.ndim))
 
     @classmethod
-    def _indices(cls, **kwargs):
+    def __indices_setup__(cls, **kwargs):
         """
         Return the default dimension indices for a given data shape.
         """
@@ -1094,7 +1091,7 @@ class SparseTimeFunction(SparseFunction):
             self.nt = nt
 
     @classmethod
-    def _indices(cls, **kwargs):
+    def __indices_setup__(cls, **kwargs):
         """
         Return the default dimension indices for a given data shape.
         """

--- a/devito/ir/iet/scheduler.py
+++ b/devito/ir/iet/scheduler.py
@@ -66,10 +66,11 @@ def iet_make(clusters, dtype):
             for i in needed:
                 uindices = []
                 for j, offs in cluster.ispace.sub_iterators.get(i.dim, []):
+                    modulo = len(offs)
                     for n, o in enumerate(filter_ordered(offs)):
                         name = "%s%d" % (j.name, n)
                         vname = Scalar(name=name, dtype=np.int32)
-                        value = (i.dim + o) % j.modulo
+                        value = (i.dim + o) % modulo
                         uindices.append(UnboundedIndex(vname, value, value, j, j + o))
                 iters.append(Iteration([], i.dim, i.dim.limits, offsets=i.limits,
                                        uindices=uindices))

--- a/devito/types.py
+++ b/devito/types.py
@@ -64,7 +64,7 @@ class Basic(object):
     is_TensorFunction = False
     is_Function = False
     is_TimeFunction = False
-    is_CompositeFunction = False
+    is_SparseTimeFunction = False
     is_SparseFunction = False
 
     # Basic symbolic object properties
@@ -231,23 +231,25 @@ class AbstractFunction(sympy.Function, Basic):
 
     The sub-hierarchy is structured as follows
 
-                            AbstractFunction
-                                   |
-                         AbstractCachedFunction
-                                   |
-                 -------------------------------------
-                 |                                   |
-            SymbolicData                      SymbolicFunction
-                 |                                   |
-               Array                           TensorFunction
-                                                     |
-                                                 Function
-                                                     |
-                                            --------------------
-                                            |                  |
-                                      TimeFunction     CompositeFunction
-                                                               |
-                                                         SparseFunction
+                          AbstractFunction
+                                 |
+                       AbstractCachedFunction
+                                 |
+               -------------------------------------
+               |                                   |
+          SymbolicData                      SymbolicFunction
+               |                                   |
+             Array                           TensorFunction
+                                                   |
+                                                Function
+                                                   |
+                                     ------------------------------
+                                     |                            |
+                               TimeFunction   SparsePoints        |
+                                     |             |              |
+                                     |   -----------------------  |
+                                     |   |                     |  |
+                            SparseTimeFunction            SparseFunction
 
     There are four relevant :class:`AbstractFunction` sub-types: ::
 
@@ -255,8 +257,8 @@ class AbstractFunction(sympy.Function, Basic):
                  Usually, it is only created internally by Devito (e.g., by the DSE).
         * Function: A space-varying discrete function, which carries user data.
         * TimeFunction: A time-varying discrete function, which carries user data.
-        * CompositeFunction: A nest of :class:`Function` objects. This comes in handy
-                             to express sparse functions.
+        * Sparse*Function: A :class:`Function` representing "sparse" points, i.e.
+                           points that are not aligned with the computational grid.
     """
 
     is_AbstractFunction = True

--- a/devito/types.py
+++ b/devito/types.py
@@ -241,24 +241,25 @@ class AbstractFunction(sympy.Function, Basic):
                |                                   |
              Array                           TensorFunction
                                                    |
-                                                Function
-                                                   |
                                      ------------------------------
                                      |                            |
-                               TimeFunction   SparsePoints        |
-                                     |             |              |
-                                     |   -----------------------  |
-                                     |   |                     |  |
-                            SparseTimeFunction            SparseFunction
+                                  Function                  SparseFunction
+                                     |                            |
+                                TimeFunction              SparseTimeFunction
 
-    There are four relevant :class:`AbstractFunction` sub-types: ::
+    There are five relevant :class:`AbstractFunction` sub-types: ::
 
         * Array: Like any :class:`SymbolicData`, an array does not carry data.
                  Usually, it is only created internally by Devito (e.g., by the DSE).
         * Function: A space-varying discrete function, which carries user data.
-        * TimeFunction: A time-varying discrete function, which carries user data.
-        * Sparse*Function: A :class:`Function` representing "sparse" points, i.e.
-                           points that are not aligned with the computational grid.
+        * TimeFunction: A time- and space-varying discrete function, which carries
+                        user data.
+        * SparseFunction: A space-varying discrete function representing "sparse"
+                          points, i.e. points that are not aligned with the
+                          computational grid.
+        * SparseTimeFunction: A time- and space-varying function representing "sparse"
+                          points, i.e. points that are not aligned with the
+                          computational grid.
     """
 
     is_AbstractFunction = True

--- a/devito/types.py
+++ b/devito/types.py
@@ -173,6 +173,10 @@ class AbstractSymbol(sympy.Symbol, Basic):
         return ()
 
     @property
+    def ndim(self):
+        return 0
+
+    @property
     def symbolic_shape(self):
         return ()
 
@@ -303,7 +307,7 @@ class AbstractCachedFunction(AbstractFunction, Cached):
         return []
 
     @property
-    def dim(self):
+    def ndim(self):
         """Return the rank of the object."""
         return len(self.shape)
 

--- a/devito/yask/__init__.py
+++ b/devito/yask/__init__.py
@@ -110,7 +110,7 @@ add_sub_configuration(yask_configuration, env_vars_mapper)
 
 # The following used by backends.backendSelector
 from devito.yask.function import Constant, Function, TimeFunction  # noqa
-from devito.function import SparseFunction  # noqa
+from devito.function import SparseFunction, SparseTimeFunction  # noqa
 from devito.yask.operator import Operator  # noqa
 from devito.yask.types import CacheManager  # noqa
 

--- a/examples/seismic/source.py
+++ b/examples/seismic/source.py
@@ -1,5 +1,5 @@
 from devito import Dimension
-from devito.function import SparseFunction
+from devito.function import SparseTimeFunction
 from devito.logger import error
 
 import numpy as np
@@ -11,7 +11,7 @@ except:
 __all__ = ['PointSource', 'Receiver', 'Shot', 'RickerSource', 'GaborSource']
 
 
-class PointSource(SparseFunction):
+class PointSource(SparseTimeFunction):
     """Symbolic data object for a set of sparse point sources
 
     :param name: Name of the symbol representing this source
@@ -38,11 +38,11 @@ class PointSource(SparseFunction):
         else:
             ntime = ntime or data.shape[0]
 
-        # Create the underlying SparseFunction object
-        obj = SparseFunction.__new__(cls, name=name, grid=grid,
-                                     dimensions=[grid.time_dim, p_dim],
-                                     npoint=npoint, nt=ntime,
-                                     coordinates=coordinates, **kwargs)
+        # Create the underlying SparseTimeFunction object
+        obj = SparseTimeFunction.__new__(cls, name=name, grid=grid,
+                                         dimensions=[grid.time_dim, p_dim],
+                                         npoint=npoint, nt=ntime,
+                                         coordinates=coordinates, **kwargs)
 
         # If provided, copy initial data into the allocated buffer
         if data is not None:

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -57,7 +57,7 @@ def test_stencil_derivative(grid, shape, SymbolType, dim):
     u_di = s_di.args[0].args[1]
     u_dii = s_di.args[0].args[1]
     # Ensure that devito meta-data survived symbolic transformation
-    assert(u_di._grid_shape_domain == shape and u_dii._grid_shape_domain == shape)
+    assert(u_di._shape == shape and u_dii._shape == shape)
     assert(np.allclose(u_di.data, 66.6))
     assert(np.allclose(u_dii.data, 66.6))
 

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -57,7 +57,8 @@ def test_stencil_derivative(grid, shape, SymbolType, dim):
     u_di = s_di.args[0].args[1]
     u_dii = s_di.args[0].args[1]
     # Ensure that devito meta-data survived symbolic transformation
-    assert(u_di._shape == shape and u_dii._shape == shape)
+    assert(u_di.grid.shape == shape and u_dii.grid.shape == shape)
+    assert(u_di.shape == u.shape and u_dii.shape == u.shape)
     assert(np.allclose(u_di.data, 66.6))
     assert(np.allclose(u_dii.data, 66.6))
 

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -8,7 +8,7 @@ import numpy as np
 import pytest
 
 from devito import (clear_cache, Grid, Eq, Operator, Constant, Function, Backward,
-                    Forward, TimeFunction, SparseFunction, Dimension, configuration,
+                    Forward, TimeFunction, SparseTimeFunction, Dimension, configuration,
                     error, INTERIOR)
 from devito.foreign import Operator as OperatorForeign
 from devito.ir.iet import (Expression, Iteration, FindNodes, IsPerfectIteration,
@@ -323,7 +323,7 @@ class TestArguments(object):
         """
         grid = Grid(shape=(5, 6, 7))
         f = TimeFunction(name='f', grid=grid)
-        s = SparseFunction(name='s', grid=grid, npoint=3, nt=4)
+        s = SparseTimeFunction(name='s', grid=grid, npoint=3, nt=4)
         s.coordinates.data[:, 0] = np.arange(0., 3.)
         s.coordinates.data[:, 1] = np.arange(1., 4.)
         s.coordinates.data[:, 2] = np.arange(2., 5.)
@@ -540,10 +540,10 @@ class TestArguments(object):
         p_dim = Dimension(name='p_src')
         u = TimeFunction(name='u', grid=grid, time_order=2, space_order=2)
         time = u.indices[0]
-        src1 = SparseFunction(name='src1', grid=grid, dimensions=[time, p_dim],
-                              npoint=1, nt=10, coordinates=original_coords)
-        src2 = SparseFunction(name='src1', grid=grid, dimensions=[time, p_dim],
-                              npoint=1, nt=10, coordinates=new_coords)
+        src1 = SparseTimeFunction(name='src1', grid=grid, dimensions=[time, p_dim],
+                                  npoint=1, nt=10, coordinates=original_coords)
+        src2 = SparseTimeFunction(name='src1', grid=grid, dimensions=[time, p_dim],
+                                  npoint=1, nt=10, coordinates=new_coords)
         op = Operator(src1.inject(u, src1))
 
         # Move the source from the location where the setup put it so we can test

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -469,24 +469,28 @@ class TestArguments(object):
         a.data[:] = 1.
         op(t=1)
         assert (a.data[0] == 4.).all()
+        assert (a.data[1] == 1.).all()
 
         # Override with symbol (different name)
         a1 = TimeFunction(name='a1', grid=grid)
         a1.data[:] = 2.
         op(t=1, a=a1)
         assert (a1.data[0] == 5.).all()
+        assert (a1.data[1] == 2.).all()
 
         # Override with symbol (same name as original)
         a2 = TimeFunction(name='a', grid=grid)
         a2.data[:] = 3.
         op(t=1, a=a2)
         assert (a2.data[0] == 6.).all()
+        assert (a2.data[1] == 3.).all()
 
         # Override with user-allocated numpy data
         a3 = np.zeros_like(a.data)
         a3[:] = 4.
         op(t=1, a=a3)
         assert (a3[0] == 7.).all()
+        assert (a3[1] == 4.).all()
 
     def test_dimension_size_infer(self, nt=100):
         """Test that the dimension sizes are being inferred correctly"""

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -398,7 +398,7 @@ class TestArguments(object):
         Test runtime start/end overrides for :class:`TimeFunction` dimensions.
         """
         grid = Grid(shape=(5, 6, 7))
-        f = TimeFunction(name='f', grid=grid, time_order=2)
+        f = TimeFunction(name='f', grid=grid, time_order=0)
 
         # Suppress DLE to work around a know bug with GCC and OpenMP:
         # https://github.com/opesci/devito/issues/320
@@ -419,7 +419,7 @@ class TestArguments(object):
         self.verify_arguments(arguments, expected)
         # Verify execution
         op(**args)
-        mask = np.ones((3, 5, 6, 7), dtype=np.bool)
+        mask = np.ones((1, 5, 6, 7), dtype=np.bool)
         mask[:, 1:3, 2:4, 3:5] = False
         assert (f.data[mask] == 0.).all()
         assert (f.data[:, 1:3, 2:4, 3:5] == 1.).all()
@@ -467,26 +467,26 @@ class TestArguments(object):
 
         # Run with default value
         a.data[:] = 1.
-        op(t=2)
-        assert (a.data[:] == 4.).all()
+        op(t=1)
+        assert (a.data[0] == 4.).all()
 
         # Override with symbol (different name)
         a1 = TimeFunction(name='a1', grid=grid)
         a1.data[:] = 2.
-        op(t=2, a=a1)
-        assert (a1.data[:] == 5.).all()
+        op(t=1, a=a1)
+        assert (a1.data[0] == 5.).all()
 
         # Override with symbol (same name as original)
         a2 = TimeFunction(name='a', grid=grid)
         a2.data[:] = 3.
-        op(t=2, a=a2)
-        assert (a2.data[:] == 6.).all()
+        op(t=1, a=a2)
+        assert (a2.data[0] == 6.).all()
 
         # Override with user-allocated numpy data
         a3 = np.zeros_like(a.data)
         a3[:] = 4.
-        op(t=2, a=a3)
-        assert (a3[:] == 7.).all()
+        op(t=1, a=a3)
+        assert (a3[0] == 7.).all()
 
     def test_dimension_size_infer(self, nt=100):
         """Test that the dimension sizes are being inferred correctly"""

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -460,37 +460,33 @@ class TestArguments(object):
         Test runtime data overrides for :class:`TimeFunction` symbols.
         """
         grid = Grid(shape=(5, 6, 7))
-        a = TimeFunction(name='a', grid=grid)
+        a = TimeFunction(name='a', grid=grid, save=2)
         # Suppress DLE to work around a know bug with GCC and OpenMP:
         # https://github.com/opesci/devito/issues/320
         op = Operator(Eq(a, a + 3), dle=None)
 
         # Run with default value
         a.data[:] = 1.
-        op(t=1)
-        assert (a.data[0] == 4.).all()
-        assert (a.data[1] == 1.).all()
+        op(t=2)
+        assert (a.data[:] == 4.).all()
 
         # Override with symbol (different name)
         a1 = TimeFunction(name='a1', grid=grid)
         a1.data[:] = 2.
-        op(t=1, a=a1)
-        assert (a1.data[0] == 5.).all()
-        assert (a1.data[1] == 2.).all()
+        op(t=2, a=a1)
+        assert (a1.data[:] == 5.).all()
 
         # Override with symbol (same name as original)
         a2 = TimeFunction(name='a', grid=grid)
         a2.data[:] = 3.
-        op(t=1, a=a2)
-        assert (a2.data[0] == 6.).all()
-        assert (a2.data[1] == 3.).all()
+        op(t=2, a=a2)
+        assert (a2.data[:] == 6.).all()
 
         # Override with user-allocated numpy data
         a3 = np.zeros_like(a.data)
         a3[:] = 4.
-        op(t=1, a=a3)
-        assert (a3[0] == 7.).all()
-        assert (a3[1] == 4.).all()
+        op(t=2, a=a3)
+        assert (a3[:] == 7.).all()
 
     def test_dimension_size_infer(self, nt=100):
         """Test that the dimension sizes are being inferred correctly"""

--- a/tests/test_symbol_caching.py
+++ b/tests/test_symbol_caching.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 from conftest import skipif_yask
 
-from devito import (Grid, Function, TimeFunction, SparseFunction, Constant,
+from devito import (Grid, Function, TimeFunction, SparseTimeFunction, Constant,
                     Operator, Eq, clear_cache)
 from devito.types import _SymbolCache
 
@@ -198,11 +198,11 @@ def test_operator_leakage_function():
 def test_operator_leakage_sparse():
     """
     Test to ensure that :class:`Operator` creation does not cause
-    memory leaks for :class:`SparseFunction` symbols.
+    memory leaks for :class:`SparseTimeFunction` symbols.
     """
     grid = Grid(shape=(5, 6))
     a = Function(name='a', grid=grid)
-    s = SparseFunction(name='s', grid=grid, npoint=1, nt=1)
+    s = SparseTimeFunction(name='s', grid=grid, npoint=1, nt=1)
     w_a = weakref.ref(a)
     w_s = weakref.ref(s)
 

--- a/tests/test_yask.py
+++ b/tests/test_yask.py
@@ -6,7 +6,7 @@ import pytest  # noqa
 pexpect = pytest.importorskip('yask')  # Run only if YASK is available
 
 from devito import (Eq, Grid, Operator, Constant, Function, TimeFunction,
-                    SparseFunction, Backward, configuration, clear_cache)  # noqa
+                    SparseTimeFunction, Backward, configuration, clear_cache)  # noqa
 from devito.ir.iet import retrieve_iteration_tree  # noqa
 from devito.yask.wrappers import contexts  # noqa
 
@@ -212,7 +212,7 @@ class TestOperatorSimple(object):
         grid = Grid(shape=(4, 4, 4))
         x, y, z = grid.dimensions
         t = grid.stepping_dim
-        p = SparseFunction(name='points', grid=grid, nt=1, npoint=4)
+        p = SparseTimeFunction(name='points', grid=grid, nt=1, npoint=4)
         u = TimeFunction(name='yu4D', grid=grid, space_order=0)
         for i in range(4):
             for j in range(4):
@@ -275,7 +275,7 @@ class TestOperatorSimple(object):
         """
         grid = Grid(shape=(4, 4, 4))
         c = Constant(name='c', value=2.)
-        p = SparseFunction(name='points', grid=grid, nt=1, npoint=1)
+        p = SparseTimeFunction(name='points', grid=grid, nt=1, npoint=1)
         u = TimeFunction(name='yu4D', grid=grid, space_order=0)
         u.data[:] = 0.
         op = Operator([Eq(u.forward, u + c), Eq(p.indexed[0, 0], 1. + c)])


### PR DESCRIPTION
Distinguish between ``SparseFunction`` and ``SparseTimeFunction``. Significant use of inheritance to avoid redundant code. 

~Should go in after #481 and #482 ~
A requirement for the domain-allocation switch, as I need to see the ``time_order`` value in all time functions (including the sparse ones, indeed)

~EDIT: this PR is open to debate of course~

EDIT: turns out I had to do deeper clean up and changes. I think the function hierarchy now looks way better. One caveat is that now modulo buffered iteration works in a slightly different way -- better in my view.
If you say that a time function has for example ``time_order=3`` **and** your equations are actually usually a number of slots ``N`` such that ``N < 3 + 1``, then only those ``N`` slots will be iterated over. Look at the small changes that I made to the arguments tests in ``test_operator.py`` for practical examples.