### PR TITLE
dse: extend pow_to_mul to handle negative integer powers

### DIFF
--- a/devito/symbolics/extended_sympy.py
+++ b/devito/symbolics/extended_sympy.py
@@ -9,7 +9,7 @@ from sympy.functions.elementary.trigonometric import TrigonometricFunction
 
 from devito.tools import Pickable, as_tuple
 
-__all__ = ['FrozenExpr', 'Eq', 'CondEq', 'CondNe', 'Mul', 'Add', 'IntDiv',
+__all__ = ['FrozenExpr', 'Eq', 'CondEq', 'CondNe', 'Mul', 'Add', 'Pow', 'IntDiv',
            'FunctionFromPointer', 'FieldFromPointer', 'FieldFromComposite',
            'ListInitializer', 'Byref', 'Macro', 'taylor_sin', 'taylor_cos',
            'bhaskara_sin', 'bhaskara_cos']
@@ -81,6 +81,10 @@ class Mul(sympy.Mul, FrozenExpr):
 
 
 class Add(sympy.Add, FrozenExpr):
+    pass
+
+
+class Pow(sympy.Pow, FrozenExpr):
     pass
 
 

--- a/devito/symbolics/manipulation.py
+++ b/devito/symbolics/manipulation.py
@@ -3,7 +3,7 @@ from collections import Iterable, OrderedDict, namedtuple
 import sympy
 from sympy import Number, Indexed, Symbol, LM, LC
 
-from devito.symbolics.extended_sympy import Add, Mul, Eq, FrozenExpr
+from devito.symbolics.extended_sympy import Add, Mul, Pow, Eq, FrozenExpr
 from devito.symbolics.search import retrieve_indexed, retrieve_functions
 from devito.dimension import Dimension
 from devito.tools import as_tuple, flatten
@@ -26,6 +26,9 @@ def freeze_expression(expr):
     elif expr.is_Mul:
         rebuilt_args = [freeze_expression(e) for e in expr.args]
         return Mul(*rebuilt_args, evaluate=False)
+    elif expr.is_Pow:
+        rebuilt_args = [freeze_expression(e) for e in expr.args]
+        return Pow(*rebuilt_args, evaluate=False)
     elif expr.is_Equality:
         rebuilt_args = [freeze_expression(e) for e in expr.args]
         if isinstance(expr, FrozenExpr):
@@ -160,11 +163,15 @@ def pow_to_mul(expr):
         return expr
     elif expr.is_Pow:
         base, exp = expr.as_base_exp()
-        if exp <= 0 or not exp.is_integer:
-            # Cannot handle powers containing non-integer non-positive exponents
+        if exp > 10 or exp < -10 or int(exp) != exp or exp == 0:
+            # Large and non-integer powers remain untouched
             return expr
-        else:
+        elif exp > 0:
             return sympy.Mul(*[base]*exp, evaluate=False)
+        else:
+            # sympy represents 1/x as Pow(x,-1)
+            posexpr = sympy.Mul(*[base]*(-exp), evaluate=False)
+            return sympy.Pow(posexpr, -1, evaluate=False)
     else:
         return expr.func(*[pow_to_mul(i) for i in expr.args], evaluate=False)
 

--- a/devito/symbolics/manipulation.py
+++ b/devito/symbolics/manipulation.py
@@ -163,8 +163,8 @@ def pow_to_mul(expr):
         return expr
     elif expr.is_Pow:
         base, exp = expr.as_base_exp()
-        if exp > 10 or exp < -10 or int(exp) != exp or exp == 0:
-            # Large and non-integer powers remain untouched
+        if exp > 10 or exp < -10 or int(exp) != exp or exp == 0 or exp == -1:
+            # Large and non-integer powers remain untouched, as do reciprocals
             return expr
         elif exp > 0:
             return sympy.Mul(*[base]*exp, evaluate=False)

--- a/environment.yml
+++ b/environment.yml
@@ -5,7 +5,7 @@ channels:
 dependencies:
   - python>=3.6
   - numpy==1.14
-  - sympy==1.1
+  - sympy==1.2
   - cgen
   - scipy
   - mpi4py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 numpy==1.14
-sympy>=1.1
+sympy>=1.2
 scipy
 mpi4py
 matplotlib

--- a/tests/test_dse.py
+++ b/tests/test_dse.py
@@ -297,7 +297,7 @@ def test_graph_isindex(fa, fb, fc, t0, t1, t2, exprs, expected):
     ('fa[x]**2 + fb[x]**3', 'fa[x]*fa[x] + fb[x]*fb[x]*fb[x]'),
     ('3*fa[x]**4', '3*(fa[x]*fa[x]*fa[x]*fa[x])'),
     ('fa[x]**2', 'fa[x]*fa[x]'),
-    ('1/(fa[x]**2)', 'fa[x]**(-2)'),
+    ('1/(fa[x]**2)', '1/(fa[x]*fa[x])'),
     ('1/(fa[x] + fb[x])', '1/(fa[x] + fb[x])'),
     ('3*sin(fa[x])**2', '3*(sin(fa[x])*sin(fa[x]))'),
 ])


### PR DESCRIPTION
When C code is written, sympy Pow operations remaining in the expressions are converted to pow().  This is a double-valued function, and I have seen it inadvertently cause whole expressions to be evaluated as doubles rather than as floats.

pow_to_mul already converts most such powers into chains of multiplications, and this PR extends that to negative powers, which often appear in 2nd-derivative operators, e.g. as ``pow(h_x,-2)``.  It also adds some sanity checks/limits.

Please comment, in particular on how I should handle the (possibly nonexistent) case of exp=0.0