### PR TITLE
Move interpolation to its own module

### DIFF
--- a/devito/function.py
+++ b/devito/function.py
@@ -833,7 +833,7 @@ class SparseFunction(TensorFunction):
     @property
     def point_symbols(self):
         """Symbol for coordinate value in each dimension of the point"""
-        return sympy.symbols('px, py, pz')
+        return sympy.symbols('px, py, pz')[:self.grid.dim]
 
     @property
     def point_increments(self):

--- a/devito/interpolators.py
+++ b/devito/interpolators.py
@@ -58,12 +58,12 @@ class LinearInterpolator(GenericInterpolator):
 
         elif self.ndim == 3:
             A = sympy.Matrix([[1, x1, y1, z1, x1*y1, x1*z1, y1*z1, x1*y1*z1],
-                              [1, x1, y2, z1, x1*y2, x1*z1, y2*z1, x1*y2*z1],
-                              [1, x2, y1, z1, x2*y1, x2*z1, y2*z1, x2*y1*z1],
                               [1, x1, y1, z2, x1*y1, x1*z2, y1*z2, x1*y1*z2],
-                              [1, x2, y2, z1, x2*y2, x2*z1, y2*z1, x2*y2*z1],
+                              [1, x1, y2, z1, x1*y2, x1*z1, y2*z1, x1*y2*z1],
                               [1, x1, y2, z2, x1*y2, x1*z2, y2*z2, x1*y2*z2],
+                              [1, x2, y1, z1, x2*y1, x2*z1, y1*z1, x2*y1*z1],
                               [1, x2, y1, z2, x2*y1, x2*z2, y1*z2, x2*y1*z2],
+                              [1, x2, y2, z1, x2*y2, x2*z1, y2*z1, x2*y2*z1],
                               [1, x2, y2, z2, x2*y2, x2*z2, y2*z2, x2*y2*z2]])
 
             p = sympy.Matrix([[1],

--- a/devito/interpolators.py
+++ b/devito/interpolators.py
@@ -1,0 +1,106 @@
+from itertools import product as crossproduct
+from abc import ABCMeta
+
+import sympy
+
+from devito.tools import prod
+
+
+class GenericInterpolator(metaclass=ABCMeta):
+    def __init__(self, point_symbols, dimensions, r):
+        assert(isinstance(r, int))
+        self.r = r
+        self.point_symbols = point_symbols
+        self.dimensions = dimensions
+        self.ndim = len(dimensions)
+        # Make sure we have a coefficient for every point
+        assert(len(self.point_increments) == len(self.coefficients))
+
+    @property
+    def point_increments(self):
+        """Index increments in each dimension for each point symbol"""
+        r = self.r
+        ndim = self.ndim
+        return list(crossproduct(*[[i for i in range(-r + 1, r + 1)]
+                                   for d in range(ndim)]))
+
+
+class LinearInterpolator(GenericInterpolator):
+    def __init__(self, point_symbols, dimensions):
+        super(LinearInterpolator, self).__init__(point_symbols, dimensions, 1)
+
+    @property
+    def coefficients(self):
+        """Symbolic expression for the coefficients for sparse point
+        interpolation according to:
+        https://en.wikipedia.org/wiki/Bilinear_interpolation.
+
+        :returns: List of coefficients, eg. [b_11, b_12, b_21, b_22]
+        """
+        # Grid indices corresponding to the corners of the cell
+        x1, y1, z1, x2, y2, z2 = sympy.symbols('x1, y1, z1, x2, y2, z2')
+        # Coordinate values of the sparse point
+        px, py, pz = self.point_symbols
+        if self.ndim == 2:
+            A = sympy.Matrix([[1, x1, y1, x1*y1],
+                              [1, x1, y2, x1*y2],
+                              [1, x2, y1, x2*y1],
+                              [1, x2, y2, x2*y2]])
+
+            p = sympy.Matrix([[1],
+                              [px],
+                              [py],
+                              [px*py]])
+
+            # Map to reference cell
+            x, y = self.dimensions
+            reference_cell = {x1: 0, y1: 0, x2: x.spacing, y2: y.spacing}
+
+        elif self.ndim == 3:
+            A = sympy.Matrix([[1, x1, y1, z1, x1*y1, x1*z1, y1*z1, x1*y1*z1],
+                              [1, x1, y2, z1, x1*y2, x1*z1, y2*z1, x1*y2*z1],
+                              [1, x2, y1, z1, x2*y1, x2*z1, y2*z1, x2*y1*z1],
+                              [1, x1, y1, z2, x1*y1, x1*z2, y1*z2, x1*y1*z2],
+                              [1, x2, y2, z1, x2*y2, x2*z1, y2*z1, x2*y2*z1],
+                              [1, x1, y2, z2, x1*y2, x1*z2, y2*z2, x1*y2*z2],
+                              [1, x2, y1, z2, x2*y1, x2*z2, y1*z2, x2*y1*z2],
+                              [1, x2, y2, z2, x2*y2, x2*z2, y2*z2, x2*y2*z2]])
+
+            p = sympy.Matrix([[1],
+                              [px],
+                              [py],
+                              [pz],
+                              [px*py],
+                              [px*pz],
+                              [py*pz],
+                              [px*py*pz]])
+
+            # Map to reference cell
+            x, y, z = self.dimensions
+            reference_cell = {x1: 0, y1: 0, z1: 0, x2: x.spacing,
+                              y2: y.spacing, z2: z.spacing}
+        else:
+            raise NotImplementedError('Interpolation coefficients not implemented '
+                                      'for %d dimensions.' % self.grid.dim)
+
+        A = A.subs(reference_cell)
+        coeffs = A.inv().T.dot(p)
+        return coeffs
+
+
+class LanczosInterpolator(GenericInterpolator):
+    def __init__(self, point_symbols, dimensions, a):
+        super(LanczosInterpolator, self).__init__(point_symbols, dimensions, a)
+
+    @property
+    def coefficients(self):
+        x, a = sympy.symbols("x a")
+        f = sympy.sinc(x)*sympy.sinc(x/a)
+        vectors = []
+        for dim in self.point_symbols:
+            vector = []
+            for i in range(-self.r+1, self.r+1):
+                vector.append(f.subs(x, dim-i).subs(a, self.r))
+            vectors.append(vector)
+
+        return [prod(list(c)) for c in list(crossproduct(*vectors))]

--- a/devito/tools.py
+++ b/devito/tools.py
@@ -18,6 +18,7 @@ __all__ = ['memoized_func', 'memoized_meth', 'infer_cpu', 'sweep', 'silencio']
 def prod(iterable):
     return reduce(mul, iterable, 1)
 
+
 def as_tuple(item, type=None, length=None):
     """
     Force item to a tuple.

--- a/devito/tools.py
+++ b/devito/tools.py
@@ -3,16 +3,20 @@ import os
 import ctypes
 import inspect
 from collections import Callable, Iterable, OrderedDict, Hashable
-from functools import partial, wraps
+from functools import partial, wraps, reduce
 from itertools import chain, combinations, product, zip_longest
 from subprocess import DEVNULL, PIPE, Popen, CalledProcessError, check_output
 import cpuinfo
 from distutils import version
+from operator import mul
 
 from devito.parameters import configuration
 
 __all__ = ['memoized_func', 'memoized_meth', 'infer_cpu', 'sweep', 'silencio']
 
+
+def prod(iterable):
+    return reduce(mul, iterable, 1)
 
 def as_tuple(item, type=None, length=None):
     """


### PR DESCRIPTION
This PR pulls the specifics of the interpolation method out into its own class called `LinearInterpolator` in `interpolators.py`. 

Also adds a currently experimental `LanczosInterpolator`. This is a WIP not currently passing the adjoint test and needs additional testing anyway. 