### PR TITLE
dependence tests to use function index (i.e. parent) dimension

### DIFF
--- a/devito/ir/iet/analysis.py
+++ b/devito/ir/iet/analysis.py
@@ -80,8 +80,9 @@ def mark_parallel(analysis):
             # (d_1, ..., d_i) = 0
             is_sequential = False
             for dep in analysis.scopes[i].d_all:
-                if not ((dims[:-1] and any(dep.is_carried(d) for d in dims[:-1])) or
-                        all(dep.is_independent(d) for d in dims)):
+                test0 = dims[:-1] and any(dep.is_carried(d) for d in dims[:-1])
+                test1 = all(dep.is_independent(d) for d in dims)
+                if not (test0 or test1):
                     is_sequential = True
                     break
             properties[i] = SEQUENTIAL if is_sequential else PARALLEL

--- a/devito/ir/support/basic.py
+++ b/devito/ir/support/basic.py
@@ -477,7 +477,11 @@ class Dependence(object):
     def is_carried(self, dim=None):
         """Return True if a dimension-carried dependence, False otherwise."""
         try:
-            return (self.distance > 0) if dim is None else self.cause == dim
+            if dim is None:
+                return self.distance > 0
+            else:
+                testdim = dim.parent if dim.is_Sub else dim
+                return self.cause == testdim
         except TypeError:
             # Conservatively assume this is a carried dependence
             return True
@@ -488,7 +492,8 @@ class Dependence(object):
             if dim is None or self.source.is_irregular or self.sink.is_irregular:
                 return self.distance == 0
             else:
-                return self.cause != dim
+                testdim = dim.parent if dim.is_Sub else dim
+                return self.cause != testdim
         except TypeError:
             # Conservatively assume this is not dimension-independent
             return False


### PR DESCRIPTION
proposed fix for #508 

I think this might implicitly assume that functions are never indexed by subdimensions - which I guess seems reasonable...  probably?

There is still more work to do:

* tests
* fixing this case, which could be parallel over `xi` but isn't.

```
    for (int xi = xi_s + 1; xi < xi_e - 1; xi += 1)
    {
      for (int yl = yl_s; yl < yl_e - 1; yl += 1)
      {
        u[time + 1][xi][yl] = a*u[time + 1][xi][yl + 1] + b*u[time][xi][yl + 1] + c*u[time][xi][yl];
      }
      for (int yr = yr_s + 1; yr < yr_e; yr += 1)
      {
        u[time + 1][xi][yr] = a*u[time + 1][xi][yr - 1] + b*u[time][xi][yr - 1] + c*u[time][xi][yr];
      }
    }
```

Interestingly, I think this one legitimately fails to meet either of the criteria:

```
             # (d_1, ..., d_{i-1}) > 0, OR
             # (d_1, ..., d_i) = 0
```

However, I can't see how it's unsafe.