### PR TITLE
examples/cfd: fixup execution counts to match the presence of output

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -82,6 +82,8 @@ install:
   - conda env create -q -f environment.yml python=$TRAVIS_PYTHON_VERSION
   - source activate devito
   - pip install -e .
+  # Dump all package versions
+  - conda list
 
 before_script:
   - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config

--- a/examples/cfd/01_convection_revisited.ipynb
+++ b/examples/cfd/01_convection_revisited.ipynb
@@ -262,7 +262,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -345,7 +345,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {


### PR DESCRIPTION
Since the commit referenced below, nbval doesn't like it if a cell says it hasn't been executed but still has output.  I guess nbval recently got updated in conda, and so now everything in travis is failing as a result.

https://github.com/computationalmodelling/nbval/commit/4f2c983b51f6a5fb2a94d5e1344b96cd1872d351#diff-806fb60ab15974e9a2fe3495b18ac7d9
