### PR TITLE
Interpolation with precomputed coefficients

### DIFF
--- a/devito/dimension.py
+++ b/devito/dimension.py
@@ -240,9 +240,19 @@ class DefaultDimension(Dimension):
         newobj.default_value = kwargs.get('default_value', None)
         return newobj
 
-    def argument_defaults(self, size=None):
-        value = self.default_value
-        return {self.start_name: 0, self.end_name: value, self.size_name: value}
+    def _arg_defaults(self, start=None, size=None, alias=None):
+        """
+        Returns a map of default argument values defined by this dimension.
+
+        :param start: (Optional) known starting point as provided by
+                      data-carrying symbols.
+        :param size: (Optional) known size as provided by data-carrying symbols.
+        :param alias: (Optional) name under which to store values.
+        """
+        dim = alias or self
+        size = size or dim.default_value
+        return {dim.min_name: start or 0, dim.max_name: size, dim.size_name: size}
+    
 
 
 class DerivedDimension(Dimension):

--- a/devito/dimension.py
+++ b/devito/dimension.py
@@ -6,8 +6,8 @@ from devito.exceptions import InvalidArgument
 from devito.logger import warning
 from devito.types import AbstractSymbol, Scalar, Symbol
 
-__all__ = ['Dimension', 'SpaceDimension', 'TimeDimension', 'SteppingDimension',
-           'SubDimension', 'ConditionalDimension', 'dimensions']
+__all__ = ['Dimension', 'SpaceDimension', 'TimeDimension', 'DefaultDimension',
+           'SteppingDimension', 'SubDimension', 'ConditionalDimension']
 
 
 class Dimension(AbstractSymbol):
@@ -16,6 +16,7 @@ class Dimension(AbstractSymbol):
     is_Space = False
     is_Time = False
 
+    is_Default = False
     is_Derived = False
     is_NonlinearDerived = False
     is_Sub = False
@@ -228,6 +229,20 @@ class TimeDimension(Dimension):
     :param name: Name of the dimension symbol.
     :param spacing: Optional, symbol for the spacing along this dimension.
     """
+
+
+class DefaultDimension(Dimension):
+    is_Default = True
+
+    def __new__(cls, name, **kwargs):
+        newobj = sympy.Symbol.__new__(cls, name)
+        newobj._spacing = kwargs.get('spacing', Scalar(name='h_%s' % name))
+        newobj.default_value = kwargs.get('default_value', None)
+        return newobj
+
+    def argument_defaults(self, size=None):
+        value = self.default_value
+        return {self.start_name: 0, self.end_name: value, self.size_name: value}
 
 
 class DerivedDimension(Dimension):
@@ -480,7 +495,6 @@ class LoweredDimension(Dimension):
 def dimensions(names):
     """
     Shortcut for: ::
-
         dimensions('i j k') -> [Dimension('i'), Dimension('j'), Dimension('k')]
     """
     assert type(names) == str

--- a/devito/dimension.py
+++ b/devito/dimension.py
@@ -252,7 +252,6 @@ class DefaultDimension(Dimension):
         dim = alias or self
         size = size or dim.default_value
         return {dim.min_name: start or 0, dim.max_name: size, dim.size_name: size}
-    
 
 
 class DerivedDimension(Dimension):

--- a/devito/dimension.py
+++ b/devito/dimension.py
@@ -246,12 +246,12 @@ class DefaultDimension(Dimension):
     def __new__(cls, name, **kwargs):
         newobj = sympy.Symbol.__new__(cls, name)
         newobj._spacing = kwargs.get('spacing', Scalar(name='h_%s' % name))
-        newobj.default_value = kwargs.get('default_value', None)
+        newobj._default_value = kwargs.get('default_value', None)
         return newobj
 
     def _arg_defaults(self, start=None, size=None, alias=None):
         dim = alias or self
-        size = size or dim.default_value
+        size = size or dim._default_value
         return {dim.min_name: start or 0, dim.max_name: size, dim.size_name: size}
 
 

--- a/devito/dimension.py
+++ b/devito/dimension.py
@@ -121,7 +121,9 @@ class Dimension(AbstractSymbol):
         :param alias: (Optional) name under which to store values.
         """
         dim = alias or self
-        return {dim.min_name: start or 0, dim.max_name: size, dim.size_name: size}
+        values = {dim.min_name: start or 0, dim.max_name: size, dim.size_name: size}
+        values = {k: values[k] for k in values if values[k] is not None}
+        return values
 
     def _arg_infers(self, args, interval, **kwargs):
         """
@@ -137,12 +139,19 @@ class Dimension(AbstractSymbol):
         :param kwargs: Dictionary of user-provided argument overrides.
         """
         infs = {}
+        defaults = self._arg_defaults()
 
         if not interval:
             return infs
 
+        if self.min_name not in args and self.min_name in defaults:
+            args[self.min_name] = defaults[self.min_name]
+
         if self.min_name in args:
             infs[self.min_name] = args[self.min_name] - min(interval.lower, 0)
+
+        if self.max_name not in args and self.max_name in defaults:
+            args[self.max_name] = defaults[self.max_name]
 
         if self.max_name in args:
             infs[self.max_name] = args[self.max_name] - (1 + max(interval.upper, 0))

--- a/devito/dimension.py
+++ b/devito/dimension.py
@@ -241,14 +241,6 @@ class DefaultDimension(Dimension):
         return newobj
 
     def _arg_defaults(self, start=None, size=None, alias=None):
-        """
-        Returns a map of default argument values defined by this dimension.
-
-        :param start: (Optional) known starting point as provided by
-                      data-carrying symbols.
-        :param size: (Optional) known size as provided by data-carrying symbols.
-        :param alias: (Optional) name under which to store values.
-        """
         dim = alias or self
         size = size or dim.default_value
         return {dim.min_name: start or 0, dim.max_name: size, dim.size_name: size}
@@ -504,6 +496,7 @@ class LoweredDimension(Dimension):
 def dimensions(names):
     """
     Shortcut for: ::
+
         dimensions('i j k') -> [Dimension('i'), Dimension('j'), Dimension('k')]
     """
     assert type(names) == str

--- a/devito/dimension.py
+++ b/devito/dimension.py
@@ -7,7 +7,7 @@ from devito.logger import warning
 from devito.types import AbstractSymbol, Scalar, Symbol
 
 __all__ = ['Dimension', 'SpaceDimension', 'TimeDimension', 'DefaultDimension',
-           'SteppingDimension', 'SubDimension', 'ConditionalDimension']
+           'SteppingDimension', 'SubDimension', 'ConditionalDimension', 'dimensions']
 
 
 class Dimension(AbstractSymbol):

--- a/devito/function.py
+++ b/devito/function.py
@@ -747,8 +747,14 @@ class TimeFunction(Function):
 
 
 class AbstractSparseFunction(TensorFunction):
+    """
+    An abstract class to define behaviours common to any kind of sparse
+    functions, whether using precomputed coefficients or computing them
+    on the fly. This is an internal class only and should never be
+    instantiated.
+    """
     # Symbols that are encapsulated within this symbol (e.g. coordinates)
-    child_functions = []
+    _child_functions = []
 
     def __init__(self, *args, **kwargs):
         if not self._cached():
@@ -797,7 +803,7 @@ class AbstractSparseFunction(TensorFunction):
         """
         key = alias or self
         args = super(AbstractSparseFunction, self)._arg_defaults(alias=alias)
-        for child_name in self.child_functions:
+        for child_name in self._child_functions:
             child = getattr(self, child_name)
             args.update(child._arg_defaults(alias=getattr(key, child_name)))
         return args
@@ -805,7 +811,7 @@ class AbstractSparseFunction(TensorFunction):
     @property
     def _arg_names(self):
         """Return a tuple of argument names introduced by this function."""
-        return tuple([self.name] + [x for x in self.child_functions])
+        return tuple([self.name] + [x for x in self._child_functions])
 
 
 class SparseFunction(AbstractSparseFunction):
@@ -836,7 +842,7 @@ class SparseFunction(AbstractSparseFunction):
     """
 
     is_SparseFunction = True
-    child_functions = ['coordinates']
+    _child_functions = ['coordinates']
 
     def __init__(self, *args, **kwargs):
         if not self._cached():
@@ -1097,7 +1103,7 @@ class SparseTimeFunction(SparseFunction):
 
 class PrecomputedSparseFunction(AbstractSparseFunction):
     is_PrecomputedSparseFunction = True
-    child_functions = ['gridpoints', 'coefficients']
+    _child_functions = ['gridpoints', 'coefficients']
 
     def __init__(self, *args, **kwargs):
         if not self._cached():

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -129,6 +129,9 @@ class Operator(Callable):
         args = ReducerMap()
         args.update([p._arg_values(**kwargs) for p in self.input if p.name in kwargs])
         args.update([p._arg_defaults() for p in self.input if p.name not in args])
+        for p in self.dimensions:
+            if p.name not in args:
+                args.update(p._arg_defaults())
         args = args.reduce_all()
 
         # Handle dimensions (first adjust data-carriers-induced defaults, then overrides)

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -129,9 +129,6 @@ class Operator(Callable):
         args = ReducerMap()
         args.update([p._arg_values(**kwargs) for p in self.input if p.name in kwargs])
         args.update([p._arg_defaults() for p in self.input if p.name not in args])
-        for p in self.dimensions:
-            if p.name not in args:
-                args.update(p._arg_defaults())
         args = args.reduce_all()
 
         # Handle dimensions (first adjust data-carriers-induced defaults, then overrides)

--- a/devito/tools.py
+++ b/devito/tools.py
@@ -5,7 +5,7 @@ import inspect
 from collections import Callable, Iterable, OrderedDict, Hashable, Mapping
 from functools import partial, wraps, reduce
 from itertools import chain, combinations, product, zip_longest
-from operator import attrgetter
+from operator import attrgetter, mul
 from subprocess import DEVNULL, PIPE, Popen, CalledProcessError, check_output
 import cpuinfo
 from distutils import version
@@ -16,6 +16,10 @@ from devito.logger import error
 from devito.parameters import configuration
 
 __all__ = ['memoized_func', 'memoized_meth', 'infer_cpu', 'sweep', 'silencio']
+
+
+def prod(iterable):
+    return reduce(mul, iterable, 1)
 
 
 def as_tuple(item, type=None, length=None):

--- a/devito/tools.py
+++ b/devito/tools.py
@@ -630,6 +630,9 @@ class ReducerMap(MultiDict):
         """
         candidates = [x for x in self.getall(key) if x is not None]
 
+        if len(candidates) == 0:
+            return None
+
         def compare_to_first(v):
             first = candidates[0]
             if isinstance(first, np.ndarray) or isinstance(v, np.ndarray):

--- a/devito/tools.py
+++ b/devito/tools.py
@@ -669,3 +669,7 @@ class ReducerMap(MultiDict):
         Returns a dictionary with reduced/unique values for all keys.
         """
         return {k: self.reduce(key=k) for k in self}
+
+    def extend(self, mapping):
+        filtered = {k: mapping[k] for k in mapping if mapping[k] is not None}
+        super(ReducerMap, self).extend(filtered)

--- a/devito/tools.py
+++ b/devito/tools.py
@@ -628,10 +628,7 @@ class ReducerMap(MultiDict):
 
         :param key: Key for which to retrieve a unique value
         """
-        candidates = [x for x in self.getall(key) if x is not None]
-
-        if len(candidates) == 0:
-            return None
+        candidates = self.getall(key)
 
         def compare_to_first(v):
             first = candidates[0]
@@ -669,7 +666,3 @@ class ReducerMap(MultiDict):
         Returns a dictionary with reduced/unique values for all keys.
         """
         return {k: self.reduce(key=k) for k in self}
-
-    def extend(self, mapping):
-        filtered = {k: mapping[k] for k in mapping if mapping[k] is not None}
-        super(ReducerMap, self).extend(filtered)

--- a/devito/tools.py
+++ b/devito/tools.py
@@ -628,7 +628,7 @@ class ReducerMap(MultiDict):
 
         :param key: Key for which to retrieve a unique value
         """
-        candidates = self.getall(key)
+        candidates = [x for x in self.getall(key) if x is not None]
 
         def compare_to_first(v):
             first = candidates[0]

--- a/devito/types.py
+++ b/devito/types.py
@@ -68,6 +68,7 @@ class Basic(object):
     is_TimeFunction = False
     is_SparseTimeFunction = False
     is_SparseFunction = False
+    is_PrecomputedSparseFunction = False
 
     # Basic symbolic object properties
     is_Scalar = False

--- a/examples/checkpointing/checkpoint.py
+++ b/examples/checkpointing/checkpoint.py
@@ -18,7 +18,7 @@ class CheckpointOperator(Operator):
     def __init__(self, op, **kwargs):
         self.op = op
         self.args = kwargs
-        op_default_args = self.op.prepare_arguments()
+        op_default_args = self.op.prepare_arguments(**kwargs)
         self.start_offset = op_default_args[self.t_arg_names['t_start']]
 
     def _prepare_args(self, t_start, t_end):

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -76,12 +76,12 @@ def test_precomputed_interpolation():
     #  because we interpolate across 2 neighbouring points in each dimension
 
     def init(data):
-        for i in range(shape[0]):
-            for j in range(shape[1]):
+        for i in range(data.shape[0]):
+            for j in range(data.shape[1]):
                 data[i, j] = sin(grid.spacing[0]*i) + sin(grid.spacing[1]*j)
         return data
 
-    m = Function(name='m', grid=grid, initializer=init)
+    m = Function(name='m', grid=grid, initializer=init, space_order=0)
 
     gridpoints, coefficients = precompute_linear_interpolation(points, grid, origin)
 

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -53,6 +53,10 @@ def custom_points(grid, ranges, npoints, name='points'):
 
 
 def precompute_linear_interpolation(points, grid, origin):
+    """ Sample precompute function that, given point and grid information
+        precomputes gridpoints and coefficients according to a linear
+        scheme to be used in PrecomputedSparseFunction.
+    """
     gridpoints = [tuple(floor((point[i]-origin[i])/grid.spacing[i])
                         for i in range(len(point))) for point in points]
 
@@ -66,7 +70,11 @@ def precompute_linear_interpolation(points, grid, origin):
     return gridpoints, coefficients
 
 
+@skipif_yask
 def test_precomputed_interpolation():
+    """ Test interpolation with PrecomputedSparseFunction which accepts
+        precomputed values for coefficients
+    """
     shape = (101, 101)
     points = [(.05, .9), (.01, .8), (0.07, 0.84)]
     origin = (0, 0)


### PR DESCRIPTION
This PR:
- Adds (brings back) a `FixedDimension` class, used when the size of a dimension is known at the time of creation
- Adds a `PrecomputedSparseFunction` class that can do interpolation of sparse points using precomputed coefficients - this can be used to implement arbitrary interpolation schemes. 
- Adds a test for the new `PrecomputedSparseFunction` class by precomputing coefficients using a bilinear scheme

~This branch currently does not pass tests due to a DSE bug where symbols used as indices for `Indexed` types are not found by the visitors. @FabioLuporini could you look into this please. An alternate branch `interpolation2` has a few hacks in place to work around the bug and passes this test.~