### PR TITLE
Initialise Jenkins configuration

### DIFF
--- a/Dockerfile.jenkins
+++ b/Dockerfile.jenkins
@@ -1,0 +1,109 @@
+FROM ubuntu:xenial
+
+# This DockerFile is looked after by
+MAINTAINER Tim Greaves <tim.greaves@imperial.ac.uk>
+
+# Add the ubuntu-toolchain-r test ppa
+RUN echo "deb http://ppa.launchpad.net/ubuntu-toolchain-r/test/ubuntu xenial main" > /etc/apt/sources.list.d/ubuntu-toolchain-r-ppa-xenial.list
+
+# Import the Launchpad PPA public key
+RUN gpg --keyserver keyserver.ubuntu.com --recv 1E9377A2BA9EF27F
+RUN gpg --export --armor BA9EF27F | apt-key add -
+
+# Upgrade to the most recent package set
+RUN apt-get update
+RUN apt-get -y dist-upgrade
+
+# Needed for the conda and devito installs later
+RUN apt-get -y install wget bzip2 git make
+
+# Default gcc version to install; can be overridden in Jenkinsfile
+ARG gccvers=4.9
+ENV DEVITO_ARCH=gcc-$gccvers
+
+# Install gcc/g++
+RUN apt-get -y install gcc-$gccvers g++-$gccvers
+
+# Set up alternatives
+RUN update-alternatives --install /usr/bin/gcc gcc /usr/bin/gcc-$gccvers 10
+RUN update-alternatives --install /usr/bin/g++ g++ /usr/bin/g++-$gccvers 10
+RUN update-alternatives --install /usr/bin/gcov gcov /usr/bin/gcov-$gccvers 10
+RUN update-alternatives --install /usr/bin/ar ar /usr/bin/gcc-ar-$gccvers 10
+RUN update-alternatives --install /usr/bin/nm nm /usr/bin/gcc-nm-$gccvers 10
+RUN update-alternatives --install /usr/bin/cpp cpp /usr/bin/cpp-$gccvers 10
+RUN update-alternatives --install /usr/bin/ranlib ranlib /usr/bin/gcc-ranlib-$gccvers 10
+RUN if [ -f /usr/bin/gcov-dump-$gccvers ] ; then \
+      update-alternatives --install /usr/bin/gcov-dump gcov-dump /usr/bin/gcov-dump-$gccvers 10 ; \
+    fi
+RUN if [ -f /usr/bin/gcov-tool-$gccvers ] ; then \
+      update-alternatives --install /usr/bin/gcov-tool gcov-tool /usr/bin/gcov-tool-$gccvers 10 ; \
+    fi
+
+# Set up for Miniconda
+WORKDIR /tmp
+RUN wget https://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh
+RUN bash miniconda.sh -b -p /usr/local/miniconda
+ENV PATH /usr/local/miniconda/bin:$PATH
+RUN conda config --set always_yes yes --set changeps1 no
+RUN conda update -q conda
+RUN ln -s /usr/local/miniconda/etc/profile.d/conda.sh /etc/profile.d/conda.sh
+# Debugging step to finish
+RUN conda info -a
+
+# Add working version of devito to image
+WORKDIR /usr/local/devito
+# Obscure syntax: 'recursively add all the contents of docker's working directory to
+#  the working directory in the container
+ADD . / ./
+
+# Install devito into the image
+RUN conda env create -q -f environment.yml python
+# *** NOTE TO FUTURE DEVELOPERS REUSING THIS JENKINSFILE FOR DEPLOYMENT ***
+# Normal activation of virtualenv doesn't persist; set environment explicitly so that
+#  when Jenkins runs the container it will start up with the devito virtualenv active.
+#  Note that this may not be ideal for non-Jenkins-intended containers, BUT does need
+#  to be present before the devito install as 'RUN source activate devito' doesn't
+#  persist into the next RUN and devito will end up being installed into base instead
+#  of into the devito virtualenv. On the other hand, defaulting to a devito virtualenv
+#  in a devito container seems like a pretty sensible thing to happen...
+ENV CONDA_DEFAULT_ENV="devito"
+ENV CONDA_EXE="/usr/local/miniconda/bin/conda"
+ENV CONDA_PREFIX="/usr/local/miniconda/envs/devito"
+ENV CONDA_PROMPT_MODIFIER="(devito) "
+ENV CONDA_PYTHON_EXE="/usr/local/miniconda/bin/python"
+ENV CONDA_SHLVL="1"
+ENV PATH="/usr/local/miniconda/envs/devito/bin:$PATH"
+# Now install devito into the virtualenv
+RUN pip install -e .
+# Add in parallel testing
+RUN pip install pytest-xdist
+# Debugging step to finish
+RUN conda list
+
+# Disable key checking for github.com
+RUN echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> /etc/ssh/config
+
+# Devito back-end set at build-time for Jenkins images
+WORKDIR /usr/localwhich python ; python --version ; gcc --version
+ARG DEVITO_BACKEND
+RUN if [ "x$DEVITO_BACKEND" = "xyask" ] ; then \
+      conda install swig ; \
+      apt-get -y install make ; \
+      git clone https://github.com/opesci/yask.git ; \
+      make -C yask/ compiler compiler-api ; \
+      pip install -e yask/ ; \
+    fi
+
+# Extra environment to get click using utf8
+ENV LC_ALL=C.UTF-8
+ENV LANG=C.UTF-8
+
+# Ensure Matplotlib doesn't look for interactive backends that need
+#  extra libraries (ie, libGL) to be present
+ENV MPLBACKEND=PS
+
+# Codecov token to push coverage reports
+ENV CODECOV_TOKEN=67a18b2a-77f0-4722-9c88-bc1a098473ce
+
+# By default, start the container in the devito directory
+WORKDIR /usr/local/devito

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,68 @@
+/* Main pipeline is declarative; buildAndTest method embeds some scripted. When it's possible to 
+     use the docker.build() method in declarative pipeline, buildAndTest should be rewritten into
+     declarative to futureproof this Jenkinsfile. At present, this isn't supported */
+       
+pipeline {
+    // Run on an agent which supports docker
+    agent { label 'dockerhost' }
+    stages {
+        // So we can easily pass container ID to testing, build and test in one stage
+        stage('Build and Test') {
+            // ... but independent test builds can run in parallel
+            parallel {
+                // For each combination of parameters required, build and test
+                stage('Build and test gcc-4.9 container') { steps { buildAndTest('4.9') } }
+                // Note that null needs to be passed as groovy doesn't allow VAR=VAL when calling a method
+                stage('Build and test gcc-4.9 OpenMP container') { steps { buildAndTest('4.9', null, '1', '2') } }
+                stage('Build and test gcc-5 container') { steps { buildAndTest('5') } }
+                stage('Build and test gcc-7 container') { steps { buildAndTest('7', 'yask') } }
+            }
+        }
+    }
+}               
+
+// Scripted pipeline method for building and testing a docker container with devito
+def buildAndTest (def gccvers, def DEVITO_BACKEND=null, def DEVITO_OPENMP=0, def OMP_NUM_THREADS=1) {
+    // Switch into scripted pipeline
+    script {
+        // If we're specifying a backend, pass it through, and label the container appropriately
+        BACKEND_ARG = DEVITO_BACKEND ? "--build-arg DEVITO_BACKEND=${DEVITO_BACKEND}" : ''
+        BACKEND_SUFFIX = DEVITO_BACKEND ? "-${DEVITO_BACKEND}" : ''
+        OPENMP_SUFFIX = (DEVITO_OPENMP=='1') ? "-openmp" : ''
+        /* Now build the container, saving the returned image value to run with testing
+           Note that the context directory has to be the final parameter passed */
+        def customImage = 
+             docker.build("opesci/devito-jenkins:gcc${gccvers}${BACKEND_SUFFIX}${OPENMP_SUFFIX}-${env.BUILD_ID}", 
+                         "--no-cache -f Dockerfile.jenkins --build-arg gccvers=${gccvers} ${BACKEND_ARG} .")
+        // If the build succeeded, push the container to dockerhub for debugging purposes
+        customImage.push()
+        // Also push a latest tagged version for easy reference
+        customImage.push('gcc${gccvers}${BACKEND_SUFFIX}${OPENMP_SUFFIX}-latest')
+        // Using the built container, run tests
+        customImage.inside("-e DEVITO_OPENMP=${DEVITO_OPENMP} -e OMP_NUM_THREADS=${OMP_NUM_THREADS}") {
+            sh "flake8 --builtins=ArgumentError ."
+            sh "py.test -n 2 -vs --cov"
+            // Additional seismic operator tests
+            if ( DEVITO_BACKEND!='yask' ) {
+                sh "DEVITO_BACKEND=foreign py.test -vs tests/test_operator.py -k TestForeign"
+                sh "python examples/seismic/benchmark.py test -P tti -so 4 -a -d 20 20 20 -n 5"
+                sh "python examples/seismic/benchmark.py test -P acoustic -a"
+                sh "python examples/seismic/acoustic/acoustic_example.py --full"
+                sh "python examples/seismic/acoustic/acoustic_example.py --constant --full"
+                sh "python examples/seismic/acoustic/gradient_example.py"
+                sh "python examples/misc/linalg.py mat-vec mat-mat-sum transpose-mat-vec"
+                sh "python examples/seismic/tti/tti_example.py -a"
+                sh "python examples/checkpointing/checkpointing_example.py"
+                // Test tutorial notebooks for the website using nbval
+                sh "py.test -vs --nbval examples/seismic/tutorials"
+                sh "py.test -vs --nbval examples/cfd"
+            }
+            // Now run coverage
+            sh "codecov"
+            // Now build documentation
+            sh "sphinx-apidoc -f -o docs/ examples/"
+            sh "sphinx-apidoc -f -o docs/ devito/ devito/yask/*"
+            sh "make -C docs/ html"
+        }
+    }
+}

--- a/examples/seismic/tutorials/05_dask.ipynb
+++ b/examples/seismic/tutorials/05_dask.ipynb
@@ -249,6 +249,7 @@
    },
    "outputs": [],
    "source": [
+    "#NBVAL_IGNORE_OUTPUT\n",
     "import numpy as np\n",
     "from distributed import Client\n",
     "\n",


### PR DESCRIPTION
This PR adds two files for Jenkins configuration:
- Jenkinsfile, which defines the Jenkins pipeline
- Dockerfile.jenkins, which is used by the Jenkins pipeline as build rules for the Jenkins test image

The functionality *should* be identical to Travis-CI apart from the automatic doctr gh-pages push that happens on Travis and needs to be re-implemented on Jenkins.

One additional fix is included, ignoring output for a tutorial example which causes a fail on Jenkins

Worth noting is that as well as running the CI it pushes a test environment image out to dockerhub, giving the option of locally running tests in an identical environment to that which Jenkins uses. This could also do with some refinement going forwards in terms of the docker image labelling.