### PR TITLE
Small updates to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 ![Build Status](https://travis-ci.org/opesci/devito.svg?branch=master)
 ![Code Coverage](https://codecov.io/gh/opesci/devito/branch/master/graph/badge.svg)
 
-[Devito](http://www.opesci.org/devito-public) is a software to
+[Devito](http://www.devitoproject.org) is a software to
 implement optimised finite difference (FD) computation from
 high-level symbolic problem definitions. Starting from symbolic
 equations defined in [SymPy](http://www.sympy.org/en/index.html),
@@ -12,8 +12,8 @@ compilation to execute FD kernels on multiple computer platforms.
 
 Devito is part of the [OPESCI](http://www.opesci.org) seismic imaging
 project. A general overview of Devito features and capabilities can be
-found [here](http://www.opesci.org/devito-public), including a
-detailed [API documentation](http://www.opesci.org/devito).
+found [here](http://www.devitoproject.org), including a
+detailed [API documentation](http://www.devitoproject.org).
 
 ## Get in touch
 

--- a/examples/PERFORMANCE.md
+++ b/examples/PERFORMANCE.md
@@ -183,8 +183,8 @@ on how auto-tuning is getting along.
    reader is invited to get in touch with the development team if struggling
    with this matter.
  * The DSE `aggressive` mode will not work with backend compilers that are not
-   Intel. This is a known bug in GCC, which breaks when trying to compile the
-   legal OpenMP code that Devito generates. This is issue #320 on GitHub.
+   Intel. This is a known
+   issue[https://github.com/opesci/devito/issues/320] in devito.
 
 # Do not hesitate to contact us
 


### PR DESCRIPTION
Change opesci.org to devitoproject.org throughout. Change `PERFORMANCE.md` to reflect the fact that 320 is a devito bug, not a GCC bug. 