### PR TITLE
allow max == min-1 for 0-sized loops

### DIFF
--- a/devito/dimension.py
+++ b/devito/dimension.py
@@ -188,7 +188,8 @@ class Dimension(AbstractSymbol):
             raise InvalidArgument("OOB detected due to %s=%d" % (self.max_name,
                                                                  args[self.max_name]))
 
-        if args[self.max_name] < args[self.min_name]:
+        # Allow the specific case of max=min-1, which disables the loop
+        if args[self.max_name] < args[self.min_name]-1:
             raise InvalidArgument("Illegal max=%s < min=%s"
                                   % (args[self.max_name], args[self.min_name]))
 

--- a/devito/dimension.py
+++ b/devito/dimension.py
@@ -5,6 +5,7 @@ from cached_property import cached_property
 
 from devito.exceptions import InvalidArgument
 from devito.types import AbstractSymbol, Scalar, Symbol
+from devito.logger import debug
 
 __all__ = ['Dimension', 'SpaceDimension', 'TimeDimension', 'DefaultDimension',
            'SteppingDimension', 'SubDimension', 'ConditionalDimension', 'dimensions']
@@ -192,6 +193,10 @@ class Dimension(AbstractSymbol):
         if args[self.max_name] < args[self.min_name]-1:
             raise InvalidArgument("Illegal max=%s < min=%s"
                                   % (args[self.max_name], args[self.min_name]))
+        elif args[self.max_name] == args[self.min_name]-1:
+            debug("%s=%d and %s=%d might cause no iterations along Dimension %s",
+                  self.min_name, args[self.min_name],
+                  self.max_name, args[self.max_name], self.name)
 
 
 class SpaceDimension(Dimension):


### PR DESCRIPTION
Since the change to inclusive bounds, `d_s==d_e` is no longer a zero-iteration loop.  The ability to have these is very handy, e.g. for disabling a receiver or source loop without needing to recompile the Operator.

This patch pretty much does what it says in the title - allows the specific case of `d_M==d_m-1`, to express this intention.  Open to suggestions for something more elegant.