### PR TITLE
bugfix: clear_cache() was missing from the RTM tutorial and misplaced…

### DIFF
--- a/examples/seismic/tutorials/02_rtm.ipynb
+++ b/examples/seismic/tutorials/02_rtm.ipynb
@@ -465,13 +465,17 @@
    ],
    "source": [
     "# Run imaging loop over shots\n",
-    "from devito import Function\n",
+    "from devito import Function, clear_cache\n",
     "\n",
     "# Create image symbol and instantiate the previously defined imaging operator\n",
     "image = Function(name='image', grid=model.grid)\n",
     "op_imaging = ImagingOperator(model, image)\n",
     "\n",
     "for i in range(nshots):\n",
+    "    # Important: We force previous wavefields to be destroyed,\n",
+    "    # so that we may reuse the memory.\n",
+    "    clear_cache()\n",
+    "    \n",
     "    print('Imaging source %d out of %d' % (i+1, nshots))\n",
     "    \n",
     "    # Update source location\n",
@@ -556,7 +560,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.5"
   },
   "widgets": {
    "state": {},

--- a/examples/seismic/tutorials/03_fwi.ipynb
+++ b/examples/seismic/tutorials/03_fwi.ipynb
@@ -369,11 +369,7 @@
     "# Create FWI gradient kernel \n",
     "from devito import Function, clear_cache\n",
     "import scipy\n",
-    "def fwi_gradient(m_in):\n",
-    "    # Important: We force previous wavefields to be destroyed,\n",
-    "    # so that we may reuse the memory.\n",
-    "    clear_cache()\n",
-    "    \n",
+    "def fwi_gradient(m_in):    \n",
     "    # Create symbols to hold the gradient and residual\n",
     "    grad = Function(name=\"grad\", grid=model.grid)\n",
     "    residual = Receiver(name='rec', grid=model.grid,\n",
@@ -382,6 +378,10 @@
     "    objective = 0.\n",
     "    \n",
     "    for i in range(nshots):\n",
+    "        # Important: We force previous wavefields to be destroyed,\n",
+    "        # so that we may reuse the memory.\n",
+    "        clear_cache()\n",
+    "\n",
     "        # Update source location\n",
     "        src.coordinates.data[0, :] = source_locations[i, :]\n",
     "        \n",
@@ -634,7 +634,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.4"
+   "version": "3.6.5"
   },
   "widgets": {
    "state": {},


### PR DESCRIPTION
… in the FWI tutorial.