### PR TITLE
RFC: ALLOC_GUARD to raise segfaults rather than causing silent corruption

### DIFF
--- a/devito/data.py
+++ b/devito/data.py
@@ -209,7 +209,8 @@ class GuardAllocator(MemoryAllocator):
 
     def free(self, c_pointer, total_size):
         # unprotect it, since free() accesses it, I think...
-        self.lib.mprotect(c_pointer, total_size, ctypes.c_int(mmap.PROT_READ | mmap.PROT_WRITE))
+        self.lib.mprotect(c_pointer, total_size,
+                          ctypes.c_int(mmap.PROT_READ | mmap.PROT_WRITE))
         self.lib.free(c_pointer)
 
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -199,6 +199,7 @@ def test_oob_noguard():
     u = Function(name='u', grid=grid, space_order=0, allocator=ALLOC_FLAT)
     Operator(Eq(u[2000, 0], 1.0)).apply()
 
+
 @pytest.mark.skip(reason="will crash entire test suite")
 def test_oob_guard():
     """

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1,8 +1,9 @@
 from conftest import skipif_yask
-
+import pytest
 import numpy as np
 
-from devito import Grid, Function, TimeFunction
+from devito import (Grid, Function, TimeFunction,
+                    ALLOC_GUARD, Operator, Eq, ALLOC_FLAT)
 
 
 def test_basic_indexing():
@@ -185,3 +186,26 @@ def test_scalar_arg_substitution(t0, t1):
     assert t0 != 0
     assert t0.subs('t0', 2) == 2
     assert t0.subs('t0', t1) == t1
+
+
+@pytest.mark.skip(reason="will corrupt memory and risk crash")
+def test_oob_noguard():
+    """
+    Tests the guard page allocator.  This writes to memory it shouldn't,
+    and typically gets away with it.
+    """
+    # A tiny grid
+    grid = Grid(shape=(4, 4))
+    u = Function(name='u', grid=grid, space_order=0, allocator=ALLOC_FLAT)
+    Operator(Eq(u[2000, 0], 1.0)).apply()
+
+@pytest.mark.skip(reason="will crash entire test suite")
+def test_oob_guard():
+    """
+    Tests the guard page allocator.  This causes a segfault in the
+    test suite, deliberately.
+    """
+    # A tiny grid
+    grid = Grid(shape=(4, 4))
+    u = Function(name='u', grid=grid, space_order=0, allocator=ALLOC_GUARD)
+    Operator(Eq(u[2000, 0], 1.0)).apply()


### PR DESCRIPTION
I was motivated to add this after wasting time tracking down a mistake which turned out to be a stupid one (using `u.forward` on a `TimeFunction` with `time_order=0`), and getting errors like this:

```
Fatal Python error: GC object already tracked
```

or this:

```
Fatal Python error: XXX block stack underflow

Current thread 0x00007f4d9882f740 (most recent call first):
Aborted
```

or various others, all with useless tracebacks under gdb, since the memory had been corrupted long before the crash.

It adds a new allocator, the `GuardAllocator`, which inserts a 1MB (by default) padding both before and after every allocation, and sets `mprotect` to cause a segfault if the padding area is accessed.  This causes more crashes, but at least they crash where they should, and can be debugged.

It sets this to be the default allocator if `DEVITO_DEVELOP=1`.