### PR TITLE
MPI: initial support for SparseFunction and related operators

### DIFF
--- a/devito/dle/backends/parallelizer.py
+++ b/devito/dle/backends/parallelizer.py
@@ -57,7 +57,7 @@ class Ompizer(object):
             # Introduce the `omp atomic` pragmas
             exprs = FindNodes(Expression).visit(root)
             subs = {i: List(header=self.lang['atomic'], body=i)
-                    for i in exprs if i.is_increment}
+                    for i in exprs if i.is_Increment}
             handle = Transformer(subs).visit(root)
             mapper[root] = handle._rebuild(pragmas=root.pragmas + (parallel,))
         else:

--- a/devito/dse/backends/basic.py
+++ b/devito/dse/backends/basic.py
@@ -50,9 +50,11 @@ class BasicRewriter(AbstractRewriter):
         for e in cluster.exprs:
             if e.is_Increment and e.lhs.function.is_Input:
                 handle = Scalar(name=template(), dtype=e.dtype).indexify()
-                extracted = e.rhs.func(*[i for i in e.rhs.args if i != e.lhs])
-                processed.extend([Eq(handle, extracted),
-                                  e.func(e.lhs, handle + e.lhs)])
+                if e.rhs.is_Symbol:
+                    extracted = e.rhs
+                else:
+                    extracted = e.rhs.func(*[i for i in e.rhs.args if i != e.lhs])
+                processed.extend([Eq(handle, extracted), e.func(e.lhs, handle)])
             else:
                 processed.append(e)
 

--- a/devito/equation.py
+++ b/devito/equation.py
@@ -36,6 +36,11 @@ class Inc(Eq):
 
     is_Increment = True
 
+    def __str__(self):
+        return "Inc(%s, %s)" % (self.lhs, self.rhs)
+
+    __repr__ = __str__
+
 
 class Region(object):
 

--- a/devito/function.py
+++ b/devito/function.py
@@ -155,7 +155,14 @@ class TensorFunction(AbstractCachedFunction, ArgProvider):
                 # Allocate memory and initialize it. Note that we do *not* hold
                 # a reference to the user-provided buffer
                 self._initializer = None
-                self.data_allocated[:] = initializer
+                if len(initializer) > 0:
+                    self.data_allocated[:] = initializer
+                else:
+                    # This is a corner case -- we might get here, for example, when
+                    # running with MPI and some processes get 0-size arrays after
+                    # domain decomposition. We touch the data anyway to avoid the
+                    # case ``self._data is None``
+                    self.data
             else:
                 raise ValueError("`initializer` must be callable or buffer, not %s"
                                  % type(initializer))
@@ -1375,9 +1382,6 @@ class SparseFunction(AbstractSparseFunction):
                                                 dtype=self.dtype, dimensions=dimensions,
                                                 shape=(self.npoint, self.grid.dim),
                                                 space_order=0, initializer=coordinates)
-                if self.npoint == 0:
-                    # Make sure self._data is not None
-                    self._coordinates.data
 
     @property
     def coordinates(self):

--- a/devito/function.py
+++ b/devito/function.py
@@ -1093,7 +1093,7 @@ class AbstractSparseFunction(TensorFunction):
         """Return a tuple of argument names introduced by this function."""
         return tuple([self.name] + [x for x in self._child_functions])
 
-    def is_owned(self, point):
+    def _is_owned(self, point):
         """Return True if ``point`` is in self's local domain, False otherwise."""
         point = as_tuple(point)
         if len(point) != self.grid.dim:

--- a/devito/function.py
+++ b/devito/function.py
@@ -1373,7 +1373,7 @@ class SparseFunction(AbstractSparseFunction):
             super(SparseFunction, self).__init__(*args, **kwargs)
 
             # Set up sparse point coordinates
-            coordinates = kwargs.get('coordinates', kwargs.get('coordinate_data'))
+            coordinates = kwargs.get('coordinates', kwargs.get('coordinates_data'))
             if isinstance(coordinates, Function):
                 self._coordinates = coordinates
             else:
@@ -1388,7 +1388,7 @@ class SparseFunction(AbstractSparseFunction):
         return self._coordinates
 
     @property
-    def coordinate_data(self):
+    def coordinates_data(self):
         return self.coordinates.data
 
     @property
@@ -1617,7 +1617,7 @@ class SparseFunction(AbstractSparseFunction):
         # should never be written to
 
     # Pickling support
-    _pickle_kwargs = AbstractSparseFunction._pickle_kwargs + ['coordinate_data']
+    _pickle_kwargs = AbstractSparseFunction._pickle_kwargs + ['coordinates_data']
 
 
 class SparseTimeFunction(AbstractSparseTimeFunction, SparseFunction):

--- a/devito/function.py
+++ b/devito/function.py
@@ -1304,10 +1304,6 @@ class SparseFunction(AbstractSparseFunction):
         :param expr: The expression to interpolate.
         :param offset: Additional offset from the boundary for
                        absorbing boundary conditions.
-        :param u_t: (Optional) time index to use for indexing into
-                    field data in `expr`.
-        :param p_t: (Optional) time index to use for indexing into
-                    the sparse point data.
         :param cummulative: (Optional) If True, perform an increment rather
                             than an assignment. Defaults to False.
         """
@@ -1332,8 +1328,6 @@ class SparseFunction(AbstractSparseFunction):
         :param expr: The expression to inject.
         :param offset: Additional offset from the boundary for
                        absorbing boundary conditions.
-        :param u_t: (Optional) time index to use for indexing into `field`.
-        :param p_t: (Optional) time index to use for indexing into `expr`.
         """
         expr = indexify(expr)
         field = indexify(field)

--- a/devito/function.py
+++ b/devito/function.py
@@ -1513,11 +1513,9 @@ class SparseFunction(AbstractSparseFunction):
         # Substitute coordinate base symbols into the coefficients
         rhs = sum([expr.subs(vsub) * b.subs(subs)
                    for b, vsub in zip(self._coefficients, idx_subs)])
-
         lhs = self.subs(self_subs)
-        rhs = rhs + lhs if cummulative else rhs
 
-        return [Inc(lhs, rhs)] if cummulative else [Eq(lhs, rhs)]
+        return [Inc(lhs, rhs) if cummulative else Eq(lhs, rhs)]
 
     def inject(self, field, expr, offset=0):
         """Symbol for injection of an expression onto a grid
@@ -1535,8 +1533,7 @@ class SparseFunction(AbstractSparseFunction):
         subs, idx_subs = self._interpolation_indices(variables, offset)
 
         # Substitute coordinate base symbols into the coefficients
-        return [Inc(field.subs(vsub),
-                    field.subs(vsub) + expr.subs(subs).subs(vsub) * b.subs(subs))
+        return [Inc(field.subs(vsub), expr.subs(subs).subs(vsub) * b.subs(subs))
                 for b, vsub in zip(self._coefficients, idx_subs)]
 
     @property

--- a/devito/function.py
+++ b/devito/function.py
@@ -21,15 +21,15 @@ from devito.parameters import configuration
 from devito.symbolics import indexify, retrieve_indexed
 from devito.types import (AbstractCachedFunction, AbstractCachedSymbol,
                           OWNED, HALO, LEFT, RIGHT)
-from devito.tools import (Tag, ReducerMap, as_mapper, as_tuple, flatten, is_integer,
-                          prod, powerset)
+from devito.tools import (Tag, ReducerMap, ArgProvider, as_mapper, as_tuple,
+                          flatten, is_integer, prod, powerset)
 
 __all__ = ['Constant', 'Function', 'TimeFunction', 'SparseFunction',
            'SparseTimeFunction', 'PrecomputedSparseFunction',
            'PrecomputedSparseTimeFunction', 'Buffer']
 
 
-class Constant(AbstractCachedSymbol):
+class Constant(AbstractCachedSymbol, ArgProvider):
 
     """
     Symbol representing constant values in symbolic equations.
@@ -109,7 +109,7 @@ class Constant(AbstractCachedSymbol):
     _pickle_kwargs = AbstractCachedSymbol._pickle_kwargs + ['dtype', '_value']
 
 
-class TensorFunction(AbstractCachedFunction):
+class TensorFunction(AbstractCachedFunction, ArgProvider):
 
     """
     Utility class to encapsulate all symbolic types that represent

--- a/devito/function.py
+++ b/devito/function.py
@@ -424,9 +424,10 @@ class TensorFunction(AbstractCachedFunction):
 
     def _halo_exchange(self):
         """Perform the halo exchange with the neighboring processes."""
-        if self.grid.distributor.nprocs == 1 or not self._is_halo_dirty:
+        if MPI.COMM_WORLD.size == 1:
+            # Nothing to do
             return
-        if self.grid.distributor.nprocs > 1 and self.grid is None:
+        if MPI.COMM_WORLD.size > 1 and self.grid is None:
             raise RuntimeError("`%s` cannot perfom a halo exchange as it has "
                                "no Grid attached" % self.name)
         if self._in_flight:

--- a/devito/function.py
+++ b/devito/function.py
@@ -480,8 +480,8 @@ class TensorFunction(AbstractCachedFunction):
         args = ReducerMap({key.name: self._data_buffer})
 
         # Collect default dimension arguments from all indices
-        for i, s, o, k in zip(self.indices, self.shape, self.staggered, key.indices):
-            args.update(i._arg_defaults(start=0, size=s+o, alias=k))
+        for i, s, o in zip(key.indices, self.shape, self.staggered):
+            args.update(i._arg_defaults(start=0, size=s+o))
 
         # Add MPI-related data structures
         if self.grid is not None:

--- a/devito/function.py
+++ b/devito/function.py
@@ -422,9 +422,9 @@ class TensorFunction(AbstractCachedFunction):
 
     def _halo_exchange(self):
         """Perform the halo exchange with the neighboring processes."""
-        if MPI.COMM_WORLD.size == 1 or not self._is_halo_dirty:
+        if self.grid.distributor.nprocs == 1 or not self._is_halo_dirty:
             return
-        if MPI.COMM_WORLD.size > 1 and self.grid is None:
+        if self.grid.distributor.nprocs > 1 and self.grid is None:
             raise RuntimeError("`%s` cannot perfom a halo exchange as it has "
                                "no Grid attached" % self.name)
         if self._in_flight:

--- a/devito/function.py
+++ b/devito/function.py
@@ -1195,6 +1195,9 @@ class AbstractSparseFunction(TensorFunction):
 
         return values
 
+    def _arg_apply(self, data):
+        self._dist_gather(data)
+
     # Pickling support
     _pickle_kwargs = TensorFunction._pickle_kwargs + ['npoint', 'space_order']
 

--- a/devito/function.py
+++ b/devito/function.py
@@ -1375,6 +1375,9 @@ class SparseFunction(AbstractSparseFunction):
                                                 dtype=self.dtype, dimensions=dimensions,
                                                 shape=(self.npoint, self.grid.dim),
                                                 space_order=0, initializer=coordinates)
+                if self.npoint == 0:
+                    # Make sure self._data is not None
+                    self._coordinates.data
 
     @property
     def coordinates(self):

--- a/devito/function.py
+++ b/devito/function.py
@@ -1233,7 +1233,7 @@ class SparseFunction(AbstractSparseFunction):
     :param grid: :class:`Grid` object defining the computational domain.
     :param coordinates: (Optional) coordinate data for the sparse points.
     :param space_order: (Optional) discretisation order for space derivatives.
-    :param shape: (Optional) shape of the function. Defaults to ``(npoints,)``.
+    :param shape: (Optional) shape of the function. Defaults to ``(npoint,)``.
     :param dimensions: (Optional) symbolic dimensions that define the
                        data layout and function indices of this symbol.
     :param dtype: (Optional) data type of the buffered data.
@@ -1440,7 +1440,7 @@ class SparseTimeFunction(AbstractSparseTimeFunction, SparseFunction):
                         Default to 0.
     :param time_order: (Optional) discretisation order for time derivatives.
                        Default to 1.
-    :param shape: (Optional) shape of the function. Defaults to ``(nt, npoints,)``.
+    :param shape: (Optional) shape of the function. Defaults to ``(nt, npoint,)``.
     :param dimensions: (Optional) symbolic dimensions that define the
                        data layout and function indices of this symbol.
     :param dtype: (Optional) Data type of the buffered data.
@@ -1540,7 +1540,7 @@ class PrecomputedSparseFunction(AbstractSparseFunction):
                         Default to 0.
     :param time_order: (Optional) discretisation order for time derivatives.
                        Default to 1.
-    :param shape: (Optional) shape of the function. Defaults to ``(nt, npoints,)``.
+    :param shape: (Optional) shape of the function. Defaults to ``(nt, npoint,)``.
     :param dimensions: (Optional) symbolic dimensions that define the
                        data layout and function indices of this symbol.
     :param dtype: (Optional) data type of the buffered data.
@@ -1694,7 +1694,7 @@ class PrecomputedSparseTimeFunction(AbstractSparseTimeFunction,
                         Default to 0.
     :param time_order: (Optional) discretisation order for time derivatives.
                        Default to 1.
-    :param shape: (Optional) shape of the function. Defaults to ``(nt, npoints,)``.
+    :param shape: (Optional) shape of the function. Defaults to ``(nt, npoint,)``.
     :param dimensions: (Optional) symbolic dimensions that define the
                        data layout and function indices of this symbol.
     :param dtype: (Optional) data type of the buffered data.

--- a/devito/function.py
+++ b/devito/function.py
@@ -1050,8 +1050,8 @@ class AbstractSparseFunction(TensorFunction):
             npoint = kwargs.get('npoint')
             if not isinstance(npoint, int):
                 raise TypeError('SparseFunction needs `npoint` int argument')
-            if npoint <= 0:
-                raise ValueError('`npoint` must be > 0')
+            if npoint < 0:
+                raise ValueError('`npoint` must be >= 0')
             self.npoint = npoint
 
             # A Grid must have been provided
@@ -1207,7 +1207,7 @@ class SparseFunction(AbstractSparseFunction):
             coordinates = kwargs.get('coordinates')
             if isinstance(coordinates, Function):
                 self._coordinates = coordinates
-            else:
+            elif coordinates is not None:
                 dimensions = (self.indices[-1], Dimension(name='d'))
                 self._coordinates = Function(name='%s_coords' % self.name,
                                              dtype=self.dtype, dimensions=dimensions,

--- a/devito/function.py
+++ b/devito/function.py
@@ -1103,6 +1103,23 @@ class AbstractSparseFunction(TensorFunction):
         return all(distributor.glb_to_loc(d, p) is not None
                    for d, p in zip(self.grid.dimensions, point))
 
+    def _scatter(self):
+        """
+        Return a ``numpy.ndarray`` containing logically owned data only. This
+        requires distributing physically owned data to the MPI ranks that
+        logically own it.
+        """
+        if self.coordinates._data is None:
+            raise ValueError("No coordinates attached to this SparseFunction")
+        targets = self.grid.distributor.glb_to_rank(self.gridpoints)
+        from IPython import embed; embed()
+
+    def _gather(self):
+        """
+        TODO
+        """
+        pass
+
     @property
     def gridpoints(self):
         """The *reference* grid point corresponding to each sparse point."""

--- a/devito/grid.py
+++ b/devito/grid.py
@@ -139,6 +139,15 @@ class Grid(ArgProvider):
         return dict(zip(self.spacing_symbols, self.spacing))
 
     @property
+    def origin_domain(self):
+        """
+        Origin of the local (per-process) physical domain.
+        """
+        grid_origin = [min(i) for i in self.distributor.glb_numb]
+        assert len(grid_origin) == len(self.spacing)
+        return tuple(i*h for i, h in zip(grid_origin, self.spacing))
+
+    @property
     def shape(self):
         """Shape of the physical domain."""
         return self._shape

--- a/devito/ir/iet/nodes.py
+++ b/devito/ir/iet/nodes.py
@@ -24,8 +24,8 @@ from devito.types import AbstractFunction, Symbol, Indexed
 
 __all__ = ['Node', 'Block', 'Denormals', 'Expression', 'Element', 'Callable',
            'Call', 'Conditional', 'Iteration', 'List', 'LocalExpression',
-           'TimedList', 'MetaCall', 'ArrayCast', 'ForeignExpression',
-           'Section', 'HaloSpot', 'IterationTree', 'ExpressionBundle']
+           'TimedList', 'MetaCall', 'ArrayCast', 'ForeignExpression', 'Section',
+           'HaloSpot', 'IterationTree', 'ExpressionBundle', 'Increment']
 
 # First-class IET nodes
 
@@ -39,6 +39,7 @@ class Node(Signer):
     is_Iteration = False
     is_IterationFold = False
     is_Expression = False
+    is_Increment = False
     is_ForeignExpression = False
     is_Callable = False
     is_Call = False
@@ -296,16 +297,16 @@ class Expression(Node):
         return not self.is_scalar
 
     @property
-    def is_increment(self):
-        """
-        Return True if the write is actually an associative and commutative increment.
-        """
-        return self.expr.is_Increment
-
-    @property
     def free_symbols(self):
         """Return all :class:`Symbol` objects used by this :class:`Expression`."""
         return tuple(self.expr.free_symbols)
+
+
+class Increment(Expression):
+
+    """A node representing a += increment."""
+
+    is_Increment = True
 
 
 class Iteration(Node):
@@ -750,7 +751,7 @@ class ForeignExpression(Expression):
             return None
 
     @property
-    def is_increment(self):
+    def is_Increment(self):
         return self._is_increment
 
     @property

--- a/devito/ir/iet/scheduler.py
+++ b/devito/ir/iet/scheduler.py
@@ -2,10 +2,10 @@ from collections import OrderedDict
 
 from devito.cgen_utils import Allocator
 from devito.dimension import ConditionalDimension
-from devito.ir.iet import (Expression, LocalExpression, Element, Iteration, List,
-                           Conditional, Section, HaloSpot, ExpressionBundle, MetaCall,
-                           MapExpressions, Transformer, FindNodes, FindSymbols,
-                           XSubs, iet_analyze, filter_iterations)
+from devito.ir.iet import (Expression, Increment, LocalExpression, Element, Iteration,
+                           List, Conditional, Section, HaloSpot, ExpressionBundle,
+                           MetaCall, MapExpressions, Transformer, FindNodes,
+                           FindSymbols, XSubs, iet_analyze, filter_iterations)
 from devito.symbolics import IntDiv, xreplace_indices
 from devito.tools import as_mapper
 
@@ -42,7 +42,7 @@ def iet_make(stree):
             return List(body=queues.pop(i))
 
         elif i.is_Exprs:
-            exprs = [Expression(e) for e in i.exprs]
+            exprs = [Increment(e) if e.is_Increment else Expression(e) for e in i.exprs]
             body = [ExpressionBundle(i.shape, i.ops, i.traffic, body=exprs)]
 
         elif i.is_Conditional:

--- a/devito/ir/iet/visitors.py
+++ b/devito/ir/iet/visitors.py
@@ -203,6 +203,10 @@ class CGen(Visitor):
         return c.Assign(ccode(o.expr.lhs, dtype=o.dtype),
                         ccode(o.expr.rhs, dtype=o.dtype))
 
+    def visit_Increment(self, o):
+        return c.Statement("%s += %s" % (ccode(o.expr.lhs, dtype=o.dtype),
+                                         ccode(o.expr.rhs, dtype=o.dtype)))
+
     def visit_LocalExpression(self, o):
         return c.Initializer(c.Value(c.dtype_to_ctype(o.dtype),
                              ccode(o.expr.lhs, dtype=o.dtype)),

--- a/devito/ir/support/basic.py
+++ b/devito/ir/support/basic.py
@@ -672,13 +672,17 @@ class Scope(object):
         for i, e in enumerate(exprs):
             # reads
             for j in retrieve_terminals(e.rhs):
-                v = self.reads.setdefault(j.base.function, [])
+                v = self.reads.setdefault(j.function, [])
                 mode = 'R' if not q_inc(e) else 'RI'
                 v.append(TimedAccess(j, mode, i, e.ispace.directions))
             # write
-            v = self.writes.setdefault(e.lhs.base.function, [])
+            v = self.writes.setdefault(e.lhs.function, [])
             mode = 'W' if not q_inc(e) else 'WI'
             v.append(TimedAccess(e.lhs, mode, i, e.ispace.directions))
+            # if an increment, we got one implicit read
+            if q_inc(e):
+                v = self.reads.setdefault(e.lhs.function, [])
+                v.append(TimedAccess(e.lhs, 'RI', i, e.ispace.directions))
 
     def getreads(self, function):
         return as_tuple(self.reads.get(function))

--- a/devito/mpi/distributed.py
+++ b/devito/mpi/distributed.py
@@ -94,8 +94,7 @@ class Distributor(object):
     @property
     def glb_ranges(self):
         """Return the global ranges of this process' domain section."""
-        Range = namedtuple('Range', 'left right')
-        return EnrichedTuple(*[Range(min(i), max(i) + 1) for i in self.glb_numb],
+        return EnrichedTuple(*[range(min(i), max(i) + 1) for i in self.glb_numb],
                              getters=self.dimensions)
 
     @property

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -113,7 +113,7 @@ class Operator(Callable):
         # Finish instantiation
         super(Operator, self).__init__(self.name, iet, 'int', parameters, ())
 
-    def prepare_arguments(self, **kwargs):
+    def _prepare_arguments(self, **kwargs):
         """
         Process runtime arguments passed to ``.apply()` and derive
         default values for any remaining arguments.
@@ -172,20 +172,20 @@ class Operator(Callable):
 
         # Check all user-provided keywords are known to the Operator
         for k, v in kwargs.items():
-            if k not in self.known_arguments:
+            if k not in self._known_arguments:
                 raise ValueError("Unrecognized argument %s=%s passed to `apply`" % (k, v))
 
         return args
 
     @cached_property
-    def known_arguments(self):
+    def _known_arguments(self):
         """Return an iterable of arguments that can be passed to ``apply``
         when running the operator."""
         ret = set.union(*[set(i._arg_names) for i in self.input + self.dimensions])
         return tuple(sorted(ret))
 
     def arguments(self, **kwargs):
-        args = self.prepare_arguments(**kwargs)
+        args = self._prepare_arguments(**kwargs)
         # Check all arguments are present
         for p in self.parameters:
             if args.get(p.name) is None:

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -177,6 +177,13 @@ class Operator(Callable):
 
         return args
 
+    def _postprocess_arguments(self, args):
+        """
+        Process runtime arguments upon returning from ``.apply()``.
+        """
+        finalized = {p.name: p._arg_apply(args[p.name]) for p in self.output}
+        return {k: finalized.get(k, v) for k, v in args.items()}
+
     @cached_property
     def _known_arguments(self):
         """Return an iterable of arguments that can be passed to ``apply``
@@ -395,6 +402,9 @@ class OperatorRunnable(Operator):
         # Invoke kernel function with args
         arg_values = [args[p.name] for p in self.parameters]
         self.cfunction(*arg_values)
+
+        # Post-process runtime arguments
+        args = self._postprocess_arguments(args)
 
         # Output summary of performance achieved
         return self._profile_output(args)

--- a/devito/tools/abc.py
+++ b/devito/tools/abc.py
@@ -68,11 +68,18 @@ class ArgProvider(object):
                                   self.__class__)
 
     @abc.abstractmethod
+    def _arg_apply(self, *args, **kwargs):
+        """
+        Change self's state using information in ``args`` and ``kwargs``.
+        """
+        pass  # no-op
+
+    @abc.abstractmethod
     def _arg_check(self, *args, **kwargs):
         """
         Raises an exception if an argument value is illegal.
         """
-        raise NotImplementedError('%s does not support argument check' % self.__class__)
+        pass  # no-op
 
 
 class Signer(object):

--- a/devito/types.py
+++ b/devito/types.py
@@ -595,7 +595,14 @@ class AbstractCachedFunction(AbstractFunction, Cached):
                 if side is LEFT:
                     end = offset + extent
                 else:
-                    end = (offset + extent) or None  # The end point won't be 0
+                    if extent == 0:
+                        # The region is empty
+                        assert offset == 0
+                        end = 0
+                    else:
+                        # The region is non-empty (e.g., offset=-1, extent=1), so
+                        # to reach the end point we must use None, not 0
+                        end = (offset + extent) or None
                 index_array.append(slice(offset, end))
             else:
                 index_array.append(slice(None))

--- a/devito/yask/dle.py
+++ b/devito/yask/dle.py
@@ -25,7 +25,7 @@ class YaskOmpizer(Ompizer):
             # Turn increments into atomic increments
             subs = {}
             for e in FindNodes(Expression).visit(root):
-                if not e.is_increment:
+                if not e.is_Increment:
                     continue
                 # Try getting the increment components
                 try:

--- a/devito/yask/utils.py
+++ b/devito/yask/utils.py
@@ -44,9 +44,9 @@ def make_grid_accesses(node, yk_grid_objs):
         if e.write.from_YASK:
             args = [rhs]
             args += [ListInitializer([INT(make_grid_gets(i)) for i in lhs.indices])]
-            handle = make_sharedptr_funcall(namespace['code-grid-put'], args,
-                                            yk_grid_objs[e.write.name])
-            processed = ForeignExpression(handle, e.dtype, is_Increment=e.is_increment)
+            call = namespace['code-grid-add' if e.is_Increment else 'code-grid-put']
+            handle = make_sharedptr_funcall(call, args, yk_grid_objs[e.write.name])
+            processed = ForeignExpression(handle, e.dtype, is_Increment=e.is_Increment)
         else:
             # Writing to a scalar temporary
             processed = Expression(e.expr.func(lhs, rhs))

--- a/examples/checkpointing/checkpoint.py
+++ b/examples/checkpointing/checkpoint.py
@@ -18,7 +18,7 @@ class CheckpointOperator(Operator):
     def __init__(self, op, **kwargs):
         self.op = op
         self.args = kwargs
-        op_default_args = self.op.prepare_arguments(**kwargs)
+        op_default_args = self.op._prepare_arguments(**kwargs)
         self.start_offset = op_default_args[self.t_arg_names['t_start']]
 
     def _prepare_args(self, t_start, t_end):

--- a/examples/seismic/acoustic/operators.py
+++ b/examples/seismic/acoustic/operators.py
@@ -149,10 +149,9 @@ def GradientOperator(model, source, receiver, space_order=4, save=True,
     eqn = iso_stencil(v, m, s, damp, kernel, forward=False)
 
     if kernel == 'OT2':
-        gradient_update = Inc(grad, grad - u.dt2 * v)
+        gradient_update = Inc(grad, - u.dt2 * v)
     elif kernel == 'OT4':
-        gradient_update = Inc(grad, grad - (u.dt2 +
-                                            s**2 / 12.0 * u.laplace2(m**(-2))) * v)
+        gradient_update = Inc(grad, - (u.dt2 + s**2 / 12.0 * u.laplace2(m**(-2))) * v)
     # Add expression for receiver injection
     receivers = rec.inject(field=v.backward, expr=rec * s**2 / m,
                            offset=model.nbpml)

--- a/examples/seismic/model.py
+++ b/examples/seismic/model.py
@@ -410,11 +410,11 @@ def initialize_function(function, data, nbpml):
         try:
             glb_range = glb_ranges[d]
 
-            lslice = min(glb_range.left, max(glb_range.left - o.left, 0))
-            rslice = max(glb_range.right, min(glb_range.right + o.right, glb_shape[d]))
+            lslice = min(glb_range.start, max(glb_range.start - o.left, 0))
+            rslice = max(glb_range.stop, min(glb_range.stop + o.right, glb_shape[d]))
 
-            lpad = o.left - glb_range.left if lslice == 0 else 0
-            rpad = o.right - (rslice - glb_range.right) if rslice == glb_shape[d] else 0
+            lpad = o.left - glb_range.start if lslice == 0 else 0
+            rpad = o.right - (rslice - glb_range.stop) if rslice == glb_shape[d] else 0
 
             data_slices.append((lslice, rslice))
             pad_widths.append((lpad, rpad))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -319,7 +319,8 @@ def pytest_runtest_setup(item):
         # this test isn't run on only one process
         dummy_test = lambda *args, **kwargs: True
         if item.cls is not None:
-            setattr(item.cls, item.name, dummy_test)
+            attr = item.originalname or item.name
+            setattr(item.cls, attr, dummy_test)
         else:
             item.obj = dummy_test
 

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -480,12 +480,12 @@ else
 }"""
 
     @pytest.mark.parametrize('exprs,atomic,parallel', [
-        (['Inc(u[gp[p, 0]+rx, gp[p, 1]+ry], u[gp[p, 0]+rx, gp[p, 1]+ry] + cx*cy*src)'],
+        (['Inc(u[gp[p, 0]+rx, gp[p, 1]+ry], cx*cy*src)'],
          ['p', 'rx', 'ry'], []),
-        (['Eq(rcv, 0)', 'Inc(rcv, rcv + cx*cy)'],
+        (['Eq(rcv, 0)', 'Inc(rcv, cx*cy)'],
          ['rx', 'ry'], ['time', 'p']),
         (['Eq(v.forward, u+1)', 'Eq(rcv, 0)',
-          'Inc(rcv, rcv + v[t, gp[p, 0]+rx, gp[p, 1]+ry]*cx*cy)'],
+          'Inc(rcv, v[t, gp[p, 0]+rx, gp[p, 1]+ry]*cx*cy)'],
          ['rx', 'ry'], ['x', 'y', 'p']),
         (['Eq(v.forward, v[t+1, x+1, y]+v[t, x, y]+v[t, x+1, y])'],
          [], ['y']),
@@ -495,7 +495,7 @@ else
          [], ['x']),
         (['Eq(v.forward, v[t+1, x, y-1]+v[t, x, y]+v[t, x, y-1])'],
          [], ['x']),
-        (['Eq(v.forward, v+1)', 'Inc(u, u+v)'],
+        (['Eq(v.forward, v+1)', 'Inc(u, v)'],
          [], ['x', 'y'])
     ])
     def test_iteration_parallelism_2d(self, exprs, atomic, parallel):
@@ -533,13 +533,12 @@ else
         assert all(not i.is_Parallel for i in iters if i.dim.name not in parallel)
 
     @pytest.mark.parametrize('exprs,atomic,parallel', [
-        (['Inc(u[gp[p, 0]+rx, gp[p, 1]+ry, gp[p, 2]+rz],'
-          ' u[gp[p, 0]+rx, gp[p, 1]+ry, gp[p, 2]+rz] + cx*cy*cz*src)'],
+        (['Inc(u[gp[p, 0]+rx, gp[p, 1]+ry, gp[p, 2]+rz], cx*cy*cz*src)'],
          ['p', 'rx', 'ry', 'rz'], []),
-        (['Eq(rcv, 0)', 'Inc(rcv, rcv + cx*cy*cz)'],
+        (['Eq(rcv, 0)', 'Inc(rcv, cx*cy*cz)'],
          ['rx', 'ry', 'rz'], ['time', 'p']),
         (['Eq(v.forward, u+1)', 'Eq(rcv, 0)',
-          'Inc(rcv, rcv + v[t, gp[p, 0]+rx, gp[p, 1]+ry, gp[p, 2]+rz]*cx*cy*cz)'],
+          'Inc(rcv, v[t, gp[p, 0]+rx, gp[p, 1]+ry, gp[p, 2]+rz]*cx*cy*cz)'],
          ['rx', 'ry', 'rz'], ['x', 'y', 'z', 'p']),
         (['Eq(v.forward, v[t+1, x+1, y, z]+v[t, x, y, z]+v[t, x+1, y, z])'],
          [], ['y', 'z']),

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -895,4 +895,4 @@ class TestIsotropicAcoustic(object):
 
 if __name__ == "__main__":
     configuration['mpi'] = True
-    TestOperatorAdvanced().test_injection_no_stencil_wtime()
+    TestSparseFunction().test_scatter_gather()

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -358,7 +358,7 @@ class TestSparseFunction(object):
     @pytest.mark.parametrize('coords,expected', [
         ([(1., 1.), (1., 3.), (3., 1.), (3., 3.)], (0, 1, 2, 3)),
     ])
-    def test_sparse_point_owner(self, coords, expected):
+    def test_ownership(self, coords, expected):
         """Given a sparse point ``p`` with known coordinates, this test checks
         that the MPI rank owning ``p`` is retrieved correctly."""
         grid = Grid(shape=(4, 4), extent=(4.0, 4.0))
@@ -366,7 +366,7 @@ class TestSparseFunction(object):
         sf = SparseFunction(name='sf', grid=grid, npoint=4, coordinates=coords)
 
         assert len(sf.gridpoints) == len(expected)
-        assert all(sf.is_owned(i) == (j == grid.distributor.myrank)
+        assert all(sf._is_owned(i) == (j == grid.distributor.myrank)
                    for i, j in zip(sf.gridpoints, expected))
 
     def test_sparse_point_scatter(self):

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -571,7 +571,7 @@ class TestOperatorSimple(object):
         g = Function(name='g', grid=grid)
 
         op = Operator([Eq(f.forward, f[t, x-1] + f[t, x+1] + 1.),
-                       Inc(f[t+1, i], f[t+1, i] + 1.),  # no halo update as it's an Inc
+                       Inc(f[t+1, i], 1.),  # no halo update as it's an Inc
                        Eq(g, f[t, j] + 1)])  # access `f` at `t`, not `t+1`!
 
         calls = FindNodes(Call).visit(op)

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -459,7 +459,7 @@ class TestOperatorSimple(object):
         op = Operator(Eq(f.forward, f[time, x-1] + f[time, x+1] + 1))
         op.apply()
 
-        time_M = op.prepare_arguments()['time_M']
+        time_M = op._prepare_arguments()['time_M']
 
         assert np.all(f.data_ro_domain[1] == 3.)
         glb_pos_map = f.grid.distributor.glb_pos_map


### PR DESCRIPTION
The title is self-explanatory

At this stage I think it's more important to state what's **missing**:
* support for SparseFunction injection/interpolation when these operators have a stencil, implying that a same sparse point may need to be communicated to more than one MPI rank
* use cached_property for _dist_* methdos, as they are expensive. The cached value needs to be invalidated upon an access to ``coordinates.data``
* tests of the above features

Once we have all of the above, in theory we can run some fairly advanced examples (wave equations)