### PR TITLE
compiler: Make clang behave similarly to gcc

### DIFF
--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -210,6 +210,10 @@ class ClangCompiler(Compiler):
     CC = 'clang'
     CPP = 'clang++'
 
+    def __init__(self, *args, **kwargs):
+        super(ClangCompiler, self).__init__(*args, **kwargs)
+        self.cflags += ['-march=native', '-Wno-unused-result', '-Wno-unused-variable']
+
 
 class IntelCompiler(Compiler):
     """Set of standard compiler flags for the Intel toolchain."""


### PR DESCRIPTION
This should shut off clang when unused variables are encountered (yes, we still occasionally generate some)

@mloubout can you check on your Mac that this doesn't break jit in any stupid way