### PR TITLE
explicitly test for the most common cases in q_affine

### DIFF
--- a/devito/symbolics/queries.py
+++ b/devito/symbolics/queries.py
@@ -3,6 +3,7 @@ from sympy import Eq, diff, cos, sin, nan
 from devito.dimension import Dimension
 from devito.tools import as_tuple
 
+
 __all__ = ['q_leaf', 'q_indexed', 'q_terminal', 'q_trigonometry', 'q_op',
            'q_terminalop', 'q_sum_of_product', 'q_indirect', 'q_timedimension',
            'q_affine', 'q_linear', 'q_identity', 'q_inc', 'q_scalar',
@@ -107,6 +108,18 @@ def q_affine(expr, vars):
     for x in as_tuple(vars):
         if x not in expr.atoms():
             return False
+
+        # The vast majority of calls here are incredibly simple tests
+        # like q_affine(x+1, [x]).  Catch these quickly and
+        # explicitly, instead of calling the very slow function `diff`.
+        if expr == x:
+            continue
+        if expr.is_Add and len(expr.args) == 2:
+            if expr.args[0] == x and expr.args[1].is_Number:
+                continue
+            if expr.args[1] == x and expr.args[0].is_Number:
+                continue
+
         try:
             if diff(expr, x) == nan or not Eq(diff(expr, x, x), 0):
                 return False


### PR DESCRIPTION
This is some juicy low-hanging fruit that showed up in profiling.  For me, this speeds up the python component of Operator creation by ~20%.

Happy to pretty it up a bit and/or remove the debug info about the slow path - this is really just to start a discussion.