### PR TITLE
Lazy MPI initialization and OpenMPI support

### DIFF
--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -22,7 +22,7 @@ __all__ = ['jit_compile', 'load', 'make', 'GNUCompiler']
 
 def sniff_compiler_version(cc):
     """
-    Try to detect the compiler version.
+    Detect the compiler version.
 
     Adapted from: ::
 
@@ -66,6 +66,21 @@ def sniff_compiler_version(cc):
         pass
 
     return ver
+
+
+def sniff_mpi_distro(mpiexec):
+    """
+    Detect the MPI version.
+    """
+    try:
+        ver = check_output([mpiexec, "--version"]).decode("utf-8")
+        if "open-mpi" in ver:
+            return 'OpenMPI'
+        elif "HYDRA" in ver:
+            return 'MPICH'
+    except (CalledProcessError, UnicodeDecodeError):
+        pass
+    return 'unknown'
 
 
 class Compiler(GCCToolchain):

--- a/devito/function.py
+++ b/devito/function.py
@@ -4,7 +4,6 @@ from itertools import product
 import sympy
 import numpy as np
 from psutil import virtual_memory
-from mpi4py import MPI
 from cached_property import cached_property
 
 from devito.cgen_utils import INT, cast_mapper
@@ -13,6 +12,7 @@ from devito.dimension import Dimension, ConditionalDimension, DefaultDimension
 from devito.equation import Eq, Inc
 from devito.exceptions import InvalidArgument
 from devito.logger import debug, warning
+from devito.mpi import MPI
 from devito.parameters import configuration
 from devito.symbolics import indexify, retrieve_functions
 from devito.finite_differences import Differentiable, generate_fd_shortcuts
@@ -454,7 +454,7 @@ class TensorFunction(AbstractCachedFunction, ArgProvider):
 
     def _halo_exchange(self):
         """Perform the halo exchange with the neighboring processes."""
-        if MPI.COMM_WORLD.size == 1:
+        if not MPI.Is_initialized() or MPI.COMM_WORLD.size == 1:
             # Nothing to do
             return
         if MPI.COMM_WORLD.size > 1 and self.grid is None:
@@ -1580,12 +1580,13 @@ class SparseFunction(AbstractSparseFunction, Differentiable):
 
     def _dist_scatter(self, data=None):
         data = data if data is not None else self.data
-        comm = self.grid.distributor.comm
+        distributor = self.grid.distributor
 
         # If not using MPI, don't waste time
-        if comm.size == 1:
+        if distributor.nprocs == 1:
             return {self: data, self.coordinates: self.coordinates.data}
 
+        comm = distributor.comm
         mpitype = MPI._typedict[np.dtype(self.dtype).char]
 
         # Pack (reordered) data values so that they can be sent out via an Alltoallv
@@ -1612,11 +1613,13 @@ class SparseFunction(AbstractSparseFunction, Differentiable):
         return {self: data, self.coordinates: coords}
 
     def _dist_gather(self, data):
-        comm = self.grid.distributor.comm
+        distributor = self.grid.distributor
 
         # If not using MPI, don't waste time
-        if comm.size == 1:
+        if distributor.nprocs == 1:
             return
+
+        comm = distributor.comm
 
         # Send back the sparse point values
         sshape, scount, sdisp, _, rcount, rdisp = self._dist_alltoall
@@ -1881,20 +1884,20 @@ class PrecomputedSparseFunction(AbstractSparseFunction):
 
     def _dist_scatter(self, data=None):
         data = data if data is not None else self.data
-        comm = self.grid.distributor.comm
+        distributor = self.grid.distributor
 
         # If not using MPI, don't waste time
-        if comm.size == 1:
+        if distributor.nprocs == 1:
             return {self: data, self.gridpoints: self.gridpoints.data,
                     self.coefficients: self.coefficients.data}
 
         raise NotImplementedError
 
     def _dist_gather(self, data):
-        comm = self.grid.distributor.comm
+        distributor = self.grid.distributor
 
         # If not using MPI, don't waste time
-        if comm.size == 1:
+        if distributor.nprocs == 1:
             return
 
         raise NotImplementedError

--- a/devito/mpi/distributed.py
+++ b/devito/mpi/distributed.py
@@ -1,17 +1,26 @@
 from collections import namedtuple
 from ctypes import Structure, c_int, c_void_p, sizeof
 from itertools import product
+import atexit
 
 from cached_property import cached_property
 from cgen import Struct, Value
 
 import numpy as np
-from mpi4py import MPI
 
+from devito.parameters import configuration
 from devito.types import LEFT, RIGHT
 from devito.tools import EnrichedTuple, as_tuple
 
-__all__ = ['Distributor']
+
+# Do not prematurely initialize MPI
+# This allows launching a Devito program from within another Python program
+# that has *already* initialized MPI
+import mpi4py
+mpi4py.rc(initialize=False, finalize=False)
+from mpi4py import MPI  # noqa
+
+__all__ = ['Distributor', 'MPI']
 
 
 class Distributor(object):
@@ -27,50 +36,76 @@ class Distributor(object):
     def __init__(self, shape, dimensions, input_comm=None):
         self._glb_shape = shape
         self._dimensions = dimensions
-        self._input_comm = (input_comm or MPI.COMM_WORLD).Clone()
 
-        # `Compute_dims` sets the dimension sizes to be as close to each other
-        # as possible, using an appropriate divisibility algorithm. Thus, in 3D:
-        # * topology[0] >= topology[1] >= topology[2]
-        # * topology[0] * topology[1] * topology[2] == self._input_comm.size
-        topology = MPI.Compute_dims(self._input_comm.size, len(shape))
-        # At this point MPI's dimension 0 corresponds to the rightmost element
-        # in `topology`. This is in reverse to `shape`'s ordering. Hence, we
-        # now restore consistency
-        self._topology = tuple(reversed(topology))
+        if configuration['mpi']:
+            # First time we enter here, we make sure MPI is initialized
+            if not MPI.Is_initialized():
+                MPI.Init()
 
-        if self._input_comm is not input_comm:
-            # By default, Devito arranges processes into a cartesian topology.
-            # MPI works with numbered dimensions and follows the C row-major
-            # numbering of the ranks, i.e. in a 2x3 Cartesian topology (0,0)
-            # maps to rank 0, (0,1) maps to rank 1, (0,2) maps to rank 2, (1,0)
-            # maps to rank 3, and so on.
-            self._comm = self._input_comm.Create_cart(self._topology)
+                # Make sure Finalize will be called upon exit
+                def finalize_mpi():
+                    MPI.Finalize()
+                atexit.register(finalize_mpi)
+
+            self._input_comm = (input_comm or MPI.COMM_WORLD).Clone()
+
+            # `Compute_dims` sets the dimension sizes to be as close to each other
+            # as possible, using an appropriate divisibility algorithm. Thus, in 3D:
+            # * topology[0] >= topology[1] >= topology[2]
+            # * topology[0] * topology[1] * topology[2] == self._input_comm.size
+            topology = MPI.Compute_dims(self._input_comm.size, len(shape))
+            # At this point MPI's dimension 0 corresponds to the rightmost element
+            # in `topology`. This is in reverse to `shape`'s ordering. Hence, we
+            # now restore consistency
+            self._topology = tuple(reversed(topology))
+
+            if self._input_comm is not input_comm:
+                # By default, Devito arranges processes into a cartesian topology.
+                # MPI works with numbered dimensions and follows the C row-major
+                # numbering of the ranks, i.e. in a 2x3 Cartesian topology (0,0)
+                # maps to rank 0, (0,1) maps to rank 1, (0,2) maps to rank 2, (1,0)
+                # maps to rank 3, and so on.
+                self._comm = self._input_comm.Create_cart(self._topology)
+            else:
+                self._comm = input_comm
         else:
-            self._comm = input_comm
+            self._input_comm = None
+            self._comm = None
+            self._topology = tuple(1 for _ in range(len(shape)))
 
-        # Perform domain decomposition
-        glb_numbs = [np.array_split(range(i), j) for i, j in zip(shape, self._topology)]
+        # The domain decomposition
+        glb_numbs = [np.array_split(range(i), j)
+                     for i, j in zip(shape, self._topology)]
         self._glb_numbs = EnrichedTuple(*glb_numbs, getters=self.dimensions)
 
     def __del__(self):
-        self._input_comm.Free()
-
-    @property
-    def myrank(self):
-        return self._comm.rank
-
-    @property
-    def mycoords(self):
-        return tuple(self._comm.coords)
+        if self._input_comm is not None:
+            self._input_comm.Free()
 
     @property
     def comm(self):
         return self._comm
 
     @property
+    def myrank(self):
+        if self.comm is not None:
+            return self.comm.rank
+        else:
+            return 0
+
+    @property
+    def mycoords(self):
+        if self.comm is not None:
+            return tuple(self.comm.coords)
+        else:
+            return tuple(0 for _ in range(self.ndim))
+
+    @property
     def nprocs(self):
-        return self._comm.size
+        if self.comm is not None:
+            return self.comm.size
+        else:
+            return 1
 
     @property
     def ndim(self):
@@ -112,8 +147,8 @@ class Distributor(object):
     @property
     def glb_numb(self):
         """Return the global numbering of this process' domain section."""
-        assert len(self._comm.coords) == len(self._glb_numbs)
-        glb_numb = [i[j] for i, j in zip(self._glb_numbs, self._comm.coords)]
+        assert len(self.mycoords) == len(self._glb_numbs)
+        glb_numb = [i[j] for i, j in zip(self._glb_numbs, self.mycoords)]
         return EnrichedTuple(*glb_numb, getters=self.dimensions)
 
     @property

--- a/devito/mpi/distributed.py
+++ b/devito/mpi/distributed.py
@@ -74,7 +74,7 @@ class Distributor(object):
                 self._comm = input_comm
         else:
             self._input_comm = None
-            self._comm = None
+            self._comm = MPI.COMM_NULL
             self._topology = tuple(1 for _ in range(len(shape)))
 
         # The domain decomposition
@@ -92,21 +92,21 @@ class Distributor(object):
 
     @property
     def myrank(self):
-        if self.comm is not None:
+        if self.comm is not MPI.COMM_NULL:
             return self.comm.rank
         else:
             return 0
 
     @property
     def mycoords(self):
-        if self.comm is not None:
+        if self.comm is not MPI.COMM_NULL:
             return tuple(self.comm.coords)
         else:
             return tuple(0 for _ in range(self.ndim))
 
     @property
     def nprocs(self):
-        if self.comm is not None:
+        if self.comm is not MPI.COMM_NULL:
             return self.comm.size
         else:
             return 1

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -1,5 +1,4 @@
 import numpy as np
-from mpi4py import MPI
 
 import pytest
 from conftest import skipif_yask
@@ -8,17 +7,9 @@ from devito import (Grid, Constant, Function, TimeFunction, SparseFunction,
                     SparseTimeFunction, Dimension, ConditionalDimension,
                     SubDimension, Eq, Inc, Operator)
 from devito.ir.iet import Call, Conditional, FindNodes
-from devito.mpi import copy, sendrecv, update_halo
+from devito.mpi import MPI, copy, sendrecv, update_halo
 from devito.parameters import configuration
 from devito.types import LEFT, RIGHT
-
-
-def setup_module(module):
-    configuration['mpi'] = True
-
-
-def teardown_module(module):
-    configuration['mpi'] = False
 
 
 @skipif_yask
@@ -318,6 +309,7 @@ if (fromrank != MPI_PROC_NULL)
 dat_y_size,ostime,osx,osy);
 }"""
 
+    @pytest.mark.parallel(nprocs=1)
     def test_iet_update_halo(self):
         grid = Grid(shape=(4, 4))
         t = grid.stepping_dim
@@ -547,6 +539,7 @@ class TestOperatorSimple(object):
         calls = FindNodes(Call).visit(op)
         assert len(calls) == 0
 
+    @pytest.mark.parallel(nprocs=1)
     def test_stencil_nowrite_implies_haloupdate(self):
         grid = Grid(shape=(12,))
         x = grid.dimensions[0]
@@ -560,6 +553,7 @@ class TestOperatorSimple(object):
         calls = FindNodes(Call).visit(op)
         assert len(calls) == 1
 
+    @pytest.mark.parallel(nprocs=1)
     def test_avoid_redundant_haloupdate(self):
         grid = Grid(shape=(12,))
         x = grid.dimensions[0]


### PR DESCRIPTION
Two things shipped by this PR:
* MPI is not automatically initialized when importing a module from devito. This means that from a different Python session we can exec ``mpirun python my_devito_program.py``  and this will work. I needed it for our testing framework, but I suspect it's gonna be useful in general in other situations, especially if MPI_Spawn is unsuitable or if we are going through a third-party library and we don't have direct control . However, when running with ``DEVITO_MPI=1``, MPI is initialized (unless already initialized) as soon as the first ``Grid`` is created. 
* Generalize the testing framework so that it can be run with OpenMPI (previously only MPICH was working)
