### PR TITLE
Fix a typo in tutorials docs

### DIFF
--- a/docs/tutorials.rst
+++ b/docs/tutorials.rst
@@ -58,7 +58,7 @@ inversion problems.
   <http://nbviewer.jupyter.org/github/opesci/devito/blob/master/examples/seismic/tutorials/03_fwi.ipynb>`_
 * `04 - Distributed FWI with Dask
   <http://nbviewer.jupyter.org/github/opesci/devito/blob/master/examples/seismic/tutorials/04_dask.ipynb>`_
-* `05 - FWI with total variation (TV)) minimisation
+* `05 - FWI with total variation (TV) minimisation
   <http://nbviewer.jupyter.org/github/opesci/devito/blob/master/examples/seismic/tutorials/05_skimage_tv.ipynb>`_
 * `06 - Acoustic modeling (2D) on a staggerd grid with the first-order wave equation
   <http://nbviewer.jupyter.org/github/opesci/devito/blob/master/examples/seismic/tutorials/06_staggered_acoustic.ipynb>`_


### PR DESCRIPTION
Fix a typo in tutorials docs (double parenthesis: "))" )