### PR TITLE
Caching some properties for efficiency. See issue #657.

### DIFF
--- a/devito/dimension.py
+++ b/devito/dimension.py
@@ -77,15 +77,15 @@ class Dimension(AbstractSymbol, ArgProvider):
     def limits(self):
         return (self.symbolic_start, self.symbolic_end, 1)
 
-    @property
+    @cached_property
     def size_name(self):
         return "%s_size" % self.name
 
-    @property
+    @cached_property
     def min_name(self):
         return "%s_m" % self.name
 
-    @property
+    @cached_property
     def max_name(self):
         return "%s_M" % self.name
 

--- a/devito/function.py
+++ b/devito/function.py
@@ -65,6 +65,7 @@ class Constant(AbstractCachedSymbol, ArgProvider):
         """Return a tuple of argument names introduced by this symbol."""
         return (self.name,)
 
+    @memoized_meth
     def _arg_defaults(self, alias=None):
         """
         Returns a map of default argument values defined by this symbol.
@@ -579,6 +580,7 @@ class TensorFunction(AbstractCachedFunction, ArgProvider):
         """Return a tuple of argument names introduced by this function."""
         return (self.name,)
 
+    @memoized_meth
     def _arg_defaults(self, alias=None):
         """
         Returns a map of default argument values defined by this symbol.
@@ -1288,6 +1290,7 @@ class AbstractSparseFunction(TensorFunction):
         """
         raise NotImplementedError
 
+    @memoized_meth
     def _arg_defaults(self, alias=None):
         key = alias or self
         mapper = {self: key}

--- a/devito/grid.py
+++ b/devito/grid.py
@@ -7,8 +7,6 @@ from devito.mpi import Distributor
 from devito.parameters import configuration
 from devito.tools import ArgProvider, ReducerMap, as_tuple
 
-from cached_property import cached_property
-
 from sympy import prod
 import numpy as np
 

--- a/devito/grid.py
+++ b/devito/grid.py
@@ -7,6 +7,8 @@ from devito.mpi import Distributor
 from devito.parameters import configuration
 from devito.tools import ArgProvider, ReducerMap, as_tuple
 
+from cached_property import cached_property
+
 from sympy import prod
 import numpy as np
 
@@ -227,7 +229,7 @@ class Grid(ArgProvider):
     def is_distributed(self, dim):
         """Return True if ``dim`` is a distributed :class:`Dimension`,
         False otherwise."""
-        return dim in self.distributor.dimensions
+        return any(dim is d for d in self.distributor.dimensions)
 
     def _make_stepping_dim(self, time_dim, name=None):
         """Create a stepping dimension for this Grid."""

--- a/devito/ir/support/space.py
+++ b/devito/ir/support/space.py
@@ -2,7 +2,6 @@ import abc
 from collections import OrderedDict
 from functools import reduce
 from operator import mul
-
 from cached_property import cached_property
 
 from frozendict import frozendict

--- a/devito/ir/support/space.py
+++ b/devito/ir/support/space.py
@@ -3,6 +3,8 @@ from collections import OrderedDict
 from functools import reduce
 from operator import mul
 
+from cached_property import cached_property
+
 from frozendict import frozendict
 
 from devito.tools import PartialOrderTuple, as_tuple, filter_ordered, toposort
@@ -212,7 +214,7 @@ class IntervalGroup(PartialOrderTuple):
     def __repr__(self):
         return "IntervalGroup[%s]" % (', '.join([repr(i) for i in self]))
 
-    @property
+    @cached_property
     def dimensions(self):
         return filter_ordered([i.dim for i in self])
 
@@ -224,7 +226,7 @@ class IntervalGroup(PartialOrderTuple):
     def shape(self):
         return tuple(i.extent for i in self)
 
-    @property
+    @cached_property
     def is_well_defined(self):
         """
         Return True if all :class:`Interval`s are over different :class:`Dimension`s,
@@ -294,7 +296,7 @@ class IntervalGroup(PartialOrderTuple):
         if not self.is_well_defined:
             raise ValueError("Cannot fetch Interval from ill defined Space")
         for i in self:
-            if i.dim == key:
+            if i.dim is key:
                 return i
         return NullInterval(key)
 

--- a/devito/mpi/distributed.py
+++ b/devito/mpi/distributed.py
@@ -30,7 +30,9 @@ class AbstractDistributor(ABC):
 
     """
     Decompose a set of :class:`Dimension`s over a set of MPI processes.
+
     .. note::
+
         This is an abstract class, which simply defines the interface that
         all subclasses are expected to implement.
     """
@@ -99,6 +101,7 @@ class AbstractDistributor(ABC):
     def glb_to_loc(self, dim, *args, strict=True):
         """
         Convert a global index into a relative (default) or absolute local index.
+
         Parameters
         ----------
         dim : :class:`Dimension`
@@ -122,6 +125,7 @@ class Distributor(AbstractDistributor):
 
     """
     Decompose a set of :class:`Dimension`s over a set of MPI processes.
+
     :param shape: The global shape of the domain to be decomposed.
     :param dimensions: The decomposed :class:`Dimension`s.
     :param comm: An MPI communicator.
@@ -248,6 +252,7 @@ class Distributor(AbstractDistributor):
     def glb_to_rank(self, index):
         """
         Return the rank owning a given global index.
+
         :param index: A single domain index, or a list of domain indices. In
                       the latter case, a list of corresponding ranks is returned.
         """
@@ -290,7 +295,9 @@ class Distributor(AbstractDistributor):
     def _C_comm(self):
         """
         A :class:`Object` wrapping an MPI communicator.
+
         Extracted from: ::
+
             https://github.com/mpi4py/mpi4py/blob/master/demo/wrap-ctypes/helloworld.py
         """
         from devito.types import Object
@@ -321,6 +328,7 @@ class SparseDistributor(AbstractDistributor):
     """
     Decompose a :class:`Dimension` representing a set of data values
     arbitrarily spread over a cartesian grid.
+
     :param npoint: The number of sparse data values.
     :param dimension: The decomposed :class:`Dimension`.
     :param distributor: The :class:`Distributor` the SparseDistributor depends on.
@@ -397,4 +405,4 @@ def compute_dims(nprocs, ndim):
             return MPI.Compute_dims(nprocs, ndim)
     else:
         v = int(v)
-return tuple(v for _ in range(ndim))
+    return tuple(v for _ in range(ndim))

--- a/devito/mpi/distributed.py
+++ b/devito/mpi/distributed.py
@@ -76,7 +76,6 @@ class AbstractDistributor(ABC):
         """Shape of the decomposed domain."""
         return EnrichedTuple(*self._glb_shape, getters=self.dimensions)
 
->>>>>>> Resolve conflict.
     @property
     def shape(self):
         """The calling MPI rank's local shape."""

--- a/devito/mpi/distributed.py
+++ b/devito/mpi/distributed.py
@@ -30,9 +30,7 @@ class AbstractDistributor(ABC):
 
     """
     Decompose a set of :class:`Dimension`s over a set of MPI processes.
-
     .. note::
-
         This is an abstract class, which simply defines the interface that
         all subclasses are expected to implement.
     """
@@ -78,6 +76,7 @@ class AbstractDistributor(ABC):
         """Shape of the decomposed domain."""
         return EnrichedTuple(*self._glb_shape, getters=self.dimensions)
 
+>>>>>>> Resolve conflict.
     @property
     def shape(self):
         """The calling MPI rank's local shape."""
@@ -101,7 +100,6 @@ class AbstractDistributor(ABC):
     def glb_to_loc(self, dim, *args, strict=True):
         """
         Convert a global index into a relative (default) or absolute local index.
-
         Parameters
         ----------
         dim : :class:`Dimension`
@@ -125,7 +123,6 @@ class Distributor(AbstractDistributor):
 
     """
     Decompose a set of :class:`Dimension`s over a set of MPI processes.
-
     :param shape: The global shape of the domain to be decomposed.
     :param dimensions: The decomposed :class:`Dimension`s.
     :param comm: An MPI communicator.
@@ -252,7 +249,6 @@ class Distributor(AbstractDistributor):
     def glb_to_rank(self, index):
         """
         Return the rank owning a given global index.
-
         :param index: A single domain index, or a list of domain indices. In
                       the latter case, a list of corresponding ranks is returned.
         """
@@ -295,9 +291,7 @@ class Distributor(AbstractDistributor):
     def _C_comm(self):
         """
         A :class:`Object` wrapping an MPI communicator.
-
         Extracted from: ::
-
             https://github.com/mpi4py/mpi4py/blob/master/demo/wrap-ctypes/helloworld.py
         """
         from devito.types import Object
@@ -328,7 +322,6 @@ class SparseDistributor(AbstractDistributor):
     """
     Decompose a :class:`Dimension` representing a set of data values
     arbitrarily spread over a cartesian grid.
-
     :param npoint: The number of sparse data values.
     :param dimension: The decomposed :class:`Dimension`.
     :param distributor: The :class:`Distributor` the SparseDistributor depends on.
@@ -405,4 +398,4 @@ def compute_dims(nprocs, ndim):
             return MPI.Compute_dims(nprocs, ndim)
     else:
         v = int(v)
-    return tuple(v for _ in range(ndim))
+return tuple(v for _ in range(ndim))

--- a/devito/yask/function.py
+++ b/devito/yask/function.py
@@ -6,7 +6,7 @@ import numpy as np
 import devito.function as function
 from devito.exceptions import InvalidArgument
 from devito.logger import yask as log
-from devito.tools import Signer, numpy_to_ctypes
+from devito.tools import Signer, numpy_to_ctypes, memoized_meth
 from devito.types import _SymbolCache
 
 from devito.yask.data import Data, DataScalar
@@ -184,6 +184,7 @@ class TimeFunction(function.TimeFunction, Function):
             indices[cls._time_position] = indices[cls._time_position].root
         return tuple(indices)
 
+    @memoized_meth
     def _arg_defaults(self, alias=None):
         args = super(TimeFunction, self)._arg_defaults(alias=alias)
         # This is a little hack: a TimeFunction originally meant to be accessed


### PR DESCRIPTION
Currently `_prepare_arguments` (located in `operator.py`) is fairly time consuming. Upon repeated calls to `op.apply()` many arguments are being 're-prepared' when there is no need. This begins to address this problem by caching certain properties e.t.c.

Note that this is a first step and more work is required to further reduce the overheads of repeated operator calls. 