### PR TITLE
force vec norm instead of matrix norm in tests

### DIFF
--- a/tests/test_adjoint.py
+++ b/tests/test_adjoint.py
@@ -85,7 +85,7 @@ class TestAdjoint(object):
 
         # Adjoint test: Verify <Ax,y> matches  <x, A^Ty> closely
         term1 = np.dot(srca.data.reshape(-1), solver.source.data)
-        term2 = linalg.norm(rec.data) ** 2
+        term2 = linalg.norm(rec.data.reshape(-1)) ** 2
         info('<Ax,y>: %f, <x, A^Ty>: %f, difference: %4.4e, ratio: %f'
              % (term1, term2, (term1 - term2)/term1, term1 / term2))
         assert np.isclose((term1 - term2)/term1, 0., rtol=1.e-10)
@@ -148,7 +148,7 @@ class TestAdjoint(object):
 
         # Adjoint test: Verify <Ax,y> matches  <x, A^Ty> closely
         term1 = np.dot(im.data.reshape(-1), dm.reshape(-1))
-        term2 = linalg.norm(du.data)**2
+        term2 = linalg.norm(du.data.reshape(-1))**2
         info('<Jx,y>: %f, <x, J^Ty>: %f, difference: %4.4e, ratio: %f'
              % (term1, term2, (term1 - term2)/term1, term1 / term2))
         assert np.isclose((term1 - term2)/term1, 0., rtol=1.e-10)

--- a/tests/test_gradient.py
+++ b/tests/test_gradient.py
@@ -128,9 +128,10 @@ class TestGradient(object):
             # Data for the new model
             d = wave.forward(m=mloc)[0]
             # First order error Phi(m0+dm) - Phi(m0)
-            error1[i] = np.absolute(.5*linalg.norm(d.data - rec.data)**2 - F0)
+            F_i = .5*linalg.norm((d.data - rec.data).reshape(-1))**2
+            error1[i] = np.absolute(F_i - F0)
             # Second order term r Phi(m0+dm) - Phi(m0) - <J(m0)^T \delta d, dm>
-            error2[i] = np.absolute(.5*linalg.norm(d.data - rec.data)**2 - F0 - H[i] * G)
+            error2[i] = np.absolute(F_i - F0 - H[i] * G)
 
         # Test slope of the  tests
         p1 = np.polyfit(np.log10(H), np.log10(error1), 1)
@@ -187,10 +188,12 @@ class TestGradient(object):
                             initializer=initializer)
             # Data for the new model
             d = wave.forward(m=mloc)[0]
+            delta_d = (d.data - rec.data).reshape(-1)
             # First order error F(m0 + hdm) - F(m0)
-            error1[i] = np.linalg.norm(d.data - rec.data, 1)
+
+            error1[i] = np.linalg.norm(delta_d, 1)
             # Second order term F(m0 + hdm) - F(m0) - J dm
-            error2[i] = np.linalg.norm(d.data - rec.data - H[i] * Jdm.data, 1)
+            error2[i] = np.linalg.norm(delta_d - H[i] * Jdm.data.reshape(-1), 1)
 
         # Test slope of the  tests
         p1 = np.polyfit(np.log10(H), np.log10(error1), 1)

--- a/tests/test_yask.py
+++ b/tests/test_yask.py
@@ -568,7 +568,8 @@ class TestIsotropicAcoustic(object):
         exp_rec = 212.15
 
         assert np.isclose(np.linalg.norm(u.data[:]), exp_u, atol=exp_u*1.e-2)
-        assert np.isclose(np.linalg.norm(rec.data), exp_rec, atol=exp_rec*1.e-2)
+        assert np.isclose(np.linalg.norm(rec.data.reshape(-1)), exp_rec,
+                          atol=exp_rec*1.e-2)
 
     def test_acoustic_adjoint(self, shape, kernel, space_order, nbpml):
         """


### PR DESCRIPTION
Small fix in tests to use vector norm instead of matrix norm.