### PR TITLE
MPI: support for running isotropic acoustic

### DIFF
--- a/devito/__init__.py
+++ b/devito/__init__.py
@@ -8,6 +8,7 @@ from itertools import product
 import cpuinfo
 
 from devito.base import *  # noqa
+from devito.builtins import *  # noqa
 from devito.data.allocators import *  # noqa
 from devito.dimension import *  # noqa
 from devito.equation import *  # noqa

--- a/devito/builtins.py
+++ b/devito/builtins.py
@@ -1,0 +1,48 @@
+"""
+Built-in :class:`Operator`s provided by Devito.
+"""
+
+import devito as dv
+
+
+def assign(f, v=0):
+    """
+    Assign a value to a :class:`Function`.
+
+    Parameters
+    ----------
+    f : Function
+        The left-hand side of the assignment.
+    v : scalar, optional
+        The right-hand side of the assignment.
+    """
+    dv.Operator(dv.Eq(f, v), name='assign')()
+
+
+def smooth(f, g, axis=None):
+    """
+    Smooth a :class:`Function` through simple moving average.
+
+    Parameters
+    ----------
+    f : Function
+        The left-hand side of the smoothing kernel, that is the smoothed Function.
+    g : Function
+        The right-hand side of the smoothing kernel, that is the Function being smoothed.
+    axis : Dimension or list of Dimensions, optional
+        The :class:`Dimension` along which the smoothing operation is performed.
+        Defaults to ``f``'s innermost Dimension.
+
+    Notes
+    -----
+    More info about simple moving average available at: ::
+
+        https://en.wikipedia.org/wiki/Moving_average#Simple_moving_average
+    """
+    if g.is_Constant:
+        # Return a scaled version of the input if it's a Constant
+        f.data[:] = .9 * g.data
+    else:
+        if axis is None:
+            axis = g.dimensions[-1]
+        dv.Operator(dv.Eq(f, g.avg(dims=axis)), name='smoother')()

--- a/devito/builtins.py
+++ b/devito/builtins.py
@@ -2,6 +2,8 @@
 Built-in :class:`Operator`s provided by Devito.
 """
 
+from sympy import Abs, sqrt
+
 import devito as dv
 
 
@@ -46,3 +48,24 @@ def smooth(f, g, axis=None):
         if axis is None:
             axis = g.dimensions[-1]
         dv.Operator(dv.Eq(f, g.avg(dims=axis)), name='smoother')()
+
+
+def norm(f, order=2):
+    """
+    Compute the norm of a :class:`Function`.
+
+    Parameters
+    ----------
+    f : Function
+        The Function for which the norm is computed.
+    order : int, optional
+        The order of the norm. Defaults to 2.
+    """
+    n = dv.Constant(name='n', dtype=f.dtype)
+    if order == 1:
+        dv.Operator(dv.Inc(n, Abs(f)), name='norm1')()
+    elif order == 2:
+        dv.Operator([dv.Eq(n, f*f), dv.Eq(n, sqrt(n))], name='norm2')()
+    else:
+        raise NotImplementedError
+    return n.data

--- a/devito/builtins.py
+++ b/devito/builtins.py
@@ -7,6 +7,8 @@ import numpy as np
 
 import devito as dv
 
+__all__ = ['assign', 'smooth', 'norm', 'sumall', 'inner']
+
 
 def assign(f, v=0):
     """
@@ -51,6 +53,44 @@ def smooth(f, g, axis=None):
         dv.Operator(dv.Eq(f, g.avg(dims=axis)), name='smoother')()
 
 
+# Reduction-inducing builtins
+
+class MPIReduction(object):
+    """
+    A context manager to build MPI-aware reduction Operators.
+    """
+
+    def __init__(self, *functions):
+        grids = {f.grid for f in functions}
+        if len(grids) == 0:
+            self.grid = None
+        elif len(grids) == 1:
+            self.grid = grids.pop()
+        else:
+            raise ValueError("Multiple Grids found")
+        dtype = {f.dtype for f in functions}
+        if len(dtype) == 1:
+            self.dtype = dtype.pop()
+        else:
+            raise ValueError("Illegal mixed data types")
+        self.v = None
+
+    def __enter__(self):
+        i = dv.Dimension(name='i',)
+        self.n = dv.Function(name='n', shape=(1,), dimensions=(i,),
+                             grid=self.grid, dtype=self.dtype)
+        self.n.data[0] = 0
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        if self.grid is None or not dv.configuration['mpi']:
+            assert self.n.data.size == 1
+            self.v = self.n.data[0]
+        else:
+            comm = self.grid.distributor.comm
+            self.v = comm.allreduce(np.asarray(self.n.data))[0]
+
+
 def norm(f, order=2):
     """
     Compute the norm of a :class:`Function`.
@@ -62,10 +102,6 @@ def norm(f, order=2):
     order : int, optional
         The order of the norm. Defaults to 2.
     """
-    i = dv.Dimension(name='i',)
-    n = dv.Function(name='n', shape=(1,), dimensions=(i,), grid=f.grid, dtype=f.dtype)
-    n.data[0] = 0
-
     kwargs = {}
     if f.is_TimeFunction and f._time_buffering:
         kwargs[f.time_dim.max_name] = f._time_size - 1
@@ -74,18 +110,12 @@ def norm(f, order=2):
     # otherwise we would eventually be summing more than expected
     p, eqns = f.guard() if f.is_SparseFunction else (f, [])
 
-    op = dv.Operator(eqns + [dv.Inc(n[0], Abs(Pow(p, order)))], name='norm%d' % order)
-    op.apply(**kwargs)
+    with MPIReduction(f) as mr:
+        op = dv.Operator(eqns + [dv.Inc(mr.n[0], Abs(Pow(p, order)))],
+                         name='norm%d' % order)
+        op.apply(**kwargs)
 
-    # May need a global reduction over MPI
-    if f.grid is None:
-        assert n.data.size == 1
-        v = n.data[0]
-    else:
-        comm = f.grid.distributor.comm
-        v = comm.allreduce(np.asarray(n.data))[0]
-
-    v = Pow(v, 1/order)
+    v = Pow(mr.v, 1/order)
 
     return np.float(v)
 
@@ -99,10 +129,6 @@ def sumall(f):
     f : Function
         Input Function.
     """
-    i = dv.Dimension(name='i',)
-    n = dv.Function(name='n', shape=(1,), dimensions=(i,), grid=f.grid, dtype=f.dtype)
-    n.data[0] = 0
-
     kwargs = {}
     if f.is_TimeFunction and f._time_buffering:
         kwargs[f.time_dim.max_name] = f._time_size - 1
@@ -111,15 +137,57 @@ def sumall(f):
     # otherwise we would eventually be summing more than expected
     p, eqns = f.guard() if f.is_SparseFunction else (f, [])
 
-    op = dv.Operator(eqns + [dv.Inc(n[0], p)], name='sum')
-    op.apply(**kwargs)
+    with MPIReduction(f) as mr:
+        op = dv.Operator(eqns + [dv.Inc(mr.n[0], p)], name='sum')
+        op.apply(**kwargs)
 
-    # May need a global reduction over MPI
-    if f.grid is None:
-        assert n.data.size == 1
-        v = n.data[0]
-    else:
-        comm = f.grid.distributor.comm
-        v = comm.allreduce(np.asarray(n.data))[0]
+    return np.float(mr.v)
 
-    return np.float(v)
+
+def inner(f, g):
+    """
+    Inner product of two :class:`Function`s.
+
+    Parameters
+    ----------
+    f : Function
+        First input operand
+    g : Function
+        Second input operand
+
+    Raises
+    ------
+    ValueError
+        If the two input Functions are defined over different grids, or have
+        different dimensionality, or their dimension-wise sizes don't match.
+        If in input are two SparseFunctions and their coordinates don't match,
+        the exception is raised.
+
+    Notes
+    -----
+    The inner product is the sum of all dimension-wise products. For 1D Functions,
+    the inner product corresponds to the dot product.
+    """
+    # Input check
+    if f.is_TimeFunction and f._time_buffering != g._time_buffering:
+        raise ValueError("Cannot compute `inner` between save/nosave TimeFunctions")
+    if f.shape != g.shape:
+        raise ValueError("`f` and `g` must have same shape")
+    if f._data is None or g._data is None:
+        raise ValueError("Uninitialized input")
+    if f.is_SparseFunction and not np.all(f.coordinates_data == g.coordinates_data):
+        raise ValueError("Non-matching coordinates")
+
+    kwargs = {}
+    if f.is_TimeFunction and f._time_buffering:
+        kwargs[f.time_dim.max_name] = f._time_size - 1
+
+    # Protect SparseFunctions from accessing duplicated (out-of-domain) data,
+    # otherwise we would eventually be summing more than expected
+    rhs, eqns = f.guard(f*g) if f.is_SparseFunction else (f*g, [])
+
+    with MPIReduction(f, g) as mr:
+        op = dv.Operator(eqns + [dv.Inc(mr.n[0], rhs)], name='inner')
+        op.apply(**kwargs)
+
+    return np.float(mr.v)

--- a/devito/data/allocators.py
+++ b/devito/data/allocators.py
@@ -7,15 +7,13 @@ import numpy as np
 import ctypes
 from ctypes.util import find_library
 
-from devito.equation import Eq
 from devito.logger import logger
 from devito.parameters import configuration
 from devito.tools import numpy_to_ctypes
-import devito
 
 __all__ = ['ALLOC_FLAT', 'ALLOC_NUMA_LOCAL', 'ALLOC_NUMA_ANY',
            'ALLOC_KNL_MCDRAM', 'ALLOC_KNL_DRAM', 'ALLOC_GUARD',
-           'default_allocator', 'first_touch']
+           'default_allocator']
 
 
 class MemoryAllocator(object):
@@ -322,11 +320,3 @@ def default_allocator():
             return ALLOC_NUMA_LOCAL
     else:
         return ALLOC_FLAT
-
-
-def first_touch(array):
-    """
-    Uses an Operator to initialize the given array in the same pattern that
-    would later be used to access it.
-    """
-    devito.Operator(Eq(array, 0.))()

--- a/devito/data/data.py
+++ b/devito/data/data.py
@@ -47,14 +47,10 @@ class Data(np.ndarray):
         obj._decomposition = decomposition or (None,)*len(shape)
         obj._modulo = modulo or (False,)*len(shape)
 
-        # By default, the indices used to access array values are interpreted as
-        # local indices
-        obj._glb_indexing = False
-
         # This cannot be a property, as Data objects constructed from this
         # object might not have any `decomposition`, but they would still be
         # distributed. Hence, in `__array_finalize__` we must copy this value
-        obj._is_decomposed = any(i is not None for i in obj._decomposition)
+        obj._is_distributed = any(i is not None for i in obj._decomposition)
 
         # Saves the last index used in `__getitem__`. This allows `__array_finalize__`
         # to reconstruct information about the computed view (e.g., `decomposition`)
@@ -89,14 +85,12 @@ class Data(np.ndarray):
 
         if type(obj) != Data:
             # Definitely from view casting
-            self._glb_indexing = False
-            self._is_decomposed = False
+            self._is_distributed = False
             self._modulo = tuple(False for i in range(self.ndim))
             self._decomposition = (None,)*self.ndim
         elif obj._index_stash is not None:
             # From `__getitem__`
-            self._glb_indexing = obj._glb_indexing
-            self._is_decomposed = obj._is_decomposed
+            self._is_distributed = obj._is_distributed
             glb_idx = obj._normalize_index(obj._index_stash)
             self._modulo = tuple(m for i, m in zip(glb_idx, obj._modulo)
                                  if not is_integer(i))
@@ -110,8 +104,7 @@ class Data(np.ndarray):
                     decomposition.append(dec.reshape(i))
             self._decomposition = tuple(decomposition)
         else:
-            self._glb_indexing = obj._glb_indexing
-            self._is_decomposed = obj._is_decomposed
+            self._is_distributed = obj._is_distributed
             if self.ndim == obj.ndim:
                 # E.g., from a ufunc, such as `np.add`
                 self._modulo = obj._modulo
@@ -125,24 +118,23 @@ class Data(np.ndarray):
     def _local(self):
         """A view of ``self`` with global indexing disabled."""
         ret = self.view()
-        ret._glb_indexing = False
+        ret._is_distributed = False
         return ret
 
     def _global(self, glb_idx, decomposition):
         """A "global" view of ``self`` over a given :class:`Decomposition`."""
-        if self._is_decomposed:
+        if self._is_distributed:
             raise ValueError("Cannot derive a decomposed view from a decomposed Data")
         if len(decomposition) != self.ndim:
             raise ValueError("`decomposition` should have ndim=%d entries" % self.ndim)
         ret = self[glb_idx]
         ret._decomposition = decomposition
-        ret._is_decomposed = any(i is not None for i in decomposition)
-        ret._glb_indexing = True
+        ret._is_distributed = any(i is not None for i in decomposition)
         return ret
 
     @property
     def _is_mpi_distributed(self):
-        return self._is_decomposed and configuration['mpi']
+        return self._is_distributed and configuration['mpi']
 
     def __repr__(self):
         return super(Data, self._local).__repr__()
@@ -166,33 +158,32 @@ class Data(np.ndarray):
             return
         elif np.isscalar(val):
             pass
-        elif isinstance(val, Data) and val._is_decomposed:
-            if self._is_decomposed:
+        elif isinstance(val, Data) and val._is_distributed:
+            if self._is_distributed:
                 # `val` is decomposed, `self` is decomposed -> local set
                 pass
             else:
                 # `val` is decomposed, `self` is replicated -> gatherall-like
                 raise NotImplementedError
         elif isinstance(val, np.ndarray):
-            if self._is_decomposed:
+            if self._is_distributed:
                 # `val` is replicated, `self` is decomposed -> `val` gets decomposed
-                if self._glb_indexing:
-                    val_idx = self._normalize_index(glb_idx)
-                    val_idx = [index_dist_to_repl(i, dec) for i, dec in
-                               zip(val_idx, self._decomposition)]
-                    if NONLOCAL in val_idx:
-                        # no-op
-                        return
-                    val_idx = [i for i in val_idx if i is not PROJECTED]
-                    # NumPy broadcasting note:
-                    # When operating on two arrays, NumPy compares their shapes
-                    # element-wise. It starts with the trailing dimensions, and works
-                    # its way forward. Two dimensions are compatible when
-                    # * they are equal, or
-                    # * one of them is 1
-                    # Conceptually, below we apply the same rule
-                    val_idx = val_idx[len(val_idx)-val.ndim:]
-                    val = val[val_idx]
+                val_idx = self._normalize_index(glb_idx)
+                val_idx = [index_dist_to_repl(i, dec) for i, dec in
+                           zip(val_idx, self._decomposition)]
+                if NONLOCAL in val_idx:
+                    # no-op
+                    return
+                val_idx = [i for i in val_idx if i is not PROJECTED]
+                # NumPy broadcasting note:
+                # When operating on two arrays, NumPy compares their shapes
+                # element-wise. It starts with the trailing dimensions, and works
+                # its way forward. Two dimensions are compatible when
+                # * they are equal, or
+                # * one of them is 1
+                # Conceptually, below we apply the same rule
+                val_idx = val_idx[len(val_idx)-val.ndim:]
+                val = val[val_idx]
             else:
                 # `val` is replicated`, `self` is replicated -> plain ndarray.__setitem__
                 pass
@@ -238,7 +229,7 @@ class Data(np.ndarray):
             if mod is True:
                 # Need to wrap index based on modulo
                 v = index_apply_modulo(i, s)
-            elif self._glb_indexing is True and dec is not None:
+            elif self._is_distributed is True and dec is not None:
                 # Need to convert the user-provided global indices into local indices.
                 # Obviously this will have no effect if MPI is not used
                 try:

--- a/devito/data/data.py
+++ b/devito/data/data.py
@@ -272,7 +272,12 @@ PROJECTED = Index('projected')
 
 
 def index_is_basic(idx):
-    return all(is_integer(i) or (i is NONLOCAL) for i in idx)
+    if is_integer(idx):
+        return True
+    elif isinstance(idx, (slice, np.ndarray)):
+        return False
+    else:
+        return all(is_integer(i) or (i is NONLOCAL) for i in idx)
 
 
 def index_apply_modulo(idx, modulo):

--- a/devito/data/data.py
+++ b/devito/data/data.py
@@ -314,11 +314,8 @@ def index_dist_to_repl(idx, decomposition):
     """
     Convert a distributed array index a replicated array index.
     """
-    if is_integer(idx):
-        return PROJECTED
-
     if decomposition is None:
-        return idx
+        return PROJECTED if is_integer(idx) else idx
 
     # Derive shift value
     value = idx.start if isinstance(idx, slice) else idx
@@ -330,7 +327,9 @@ def index_dist_to_repl(idx, decomposition):
     # Convert into absolute local index
     idx = decomposition.convert_index(idx, rel=False)
 
-    if idx is None:
+    if is_integer(idx):
+        return PROJECTED
+    elif idx is None:
         return NONLOCAL
     elif isinstance(idx, (tuple, list)):
         return [i - value for i in idx]

--- a/devito/data/decomposition.py
+++ b/devito/data/decomposition.py
@@ -315,19 +315,20 @@ class Decomposition(tuple):
         """
 
         if len(args) == 1:
-            if isinstance(args[0], slice):
-                if args[0].start is None:
+            arg = args[0]
+            if isinstance(arg, slice):
+                if arg.start is None or self.glb_min is None:
                     nleft = 0
                 else:
-                    nleft = self.glb_min - args[0].start
-                if args[0].stop is None:
+                    nleft = self.glb_min - arg.start
+                if arg.stop is None or self.glb_max is None:
                     nright = 0
-                elif args[0].stop < 0:
-                    nright = args[0].stop
+                elif arg.stop < 0:
+                    nright = arg.stop
                 else:
-                    nright = args[0].stop - self.glb_max - 1
-            elif isinstance(args[0], Iterable):
-                items = [np.array([j for j in i if j in args[0]]) for i in self]
+                    nright = arg.stop - self.glb_max - 1
+            elif isinstance(arg, Iterable):
+                items = [np.array([j for j in i if j in arg]) for i in self]
                 for i, arr in enumerate(list(items)):
                     items[i] = np.arange(arr.size) + sum(j.size for j in items[:i])
                 return Decomposition(items, self.local)

--- a/devito/data/decomposition.py
+++ b/devito/data/decomposition.py
@@ -41,7 +41,7 @@ class Decomposition(tuple):
 
     >>> d = Decomposition([[0, 1, 2], [3, 4], [5, 6, 7]], 1)
     >>> d
-    Decomposition([0 1 2], <<[3 4]>>, [5 6 7])
+    Decomposition([0,2], <<[3,4]>>, [5,7])
     >>> d.loc_abs_min
     3
     >>> d.loc_abs_max
@@ -112,9 +112,14 @@ class Decomposition(tuple):
             all(np.all(i == j) for i, j in zip(self, o))
 
     def __repr__(self):
-        items = ', '.join('<<%s>>' % str(v) if self.local == i else str(v)
-                          for i, v in enumerate(self))
-        return "Decomposition(%s)" % items
+        ret = []
+        for i, v in enumerate(self):
+            bounds = (min(v, default=None), max(v, default=None))
+            item = '[]' if bounds == (None, None) else '[%d,%d]' % bounds
+            if self.local == i:
+                item = "<<%s>>" % item
+            ret.append(item)
+        return 'Decomposition(%s)' % ', '.join(ret)
 
     def __call__(self, *args, rel=True):
         """Alias for ``self.convert_index``."""
@@ -157,7 +162,7 @@ class Decomposition(tuple):
 
         >>> d = Decomposition([[0, 1, 2], [3, 4], [5, 6, 7], [8, 9, 10, 11]], 2)
         >>> d
-        Decomposition([0 1 2], [3 4], <<[5 6 7]>>, [ 8 9 10 11])
+        Decomposition([0,2], [3,4], <<[5,7]>>, [8,11])
 
         A global index as single argument:
 
@@ -292,26 +297,26 @@ class Decomposition(tuple):
         --------
         >>> d = Decomposition([[0, 1, 2], [3, 4], [5, 6, 7], [8, 9, 10, 11]], 2)
         >>> d
-        Decomposition([0 1 2], [3 4], <<[5 6 7]>>, [ 8 9 10 11])
+        Decomposition([0,2], [3,4], <<[5,7]>>, [8,11])
 
         Providing explicit values
 
         >>> d.reshape(1, 1)
-        Decomposition([0 1 2 3], [4 5], <<[6 7 8]>>, [ 9 10 11 12 13])
+        Decomposition([0,3], [4,5], <<[6,8]>>, [9,13])
 
         >>> d.reshape(-2, 2)
-        Decomposition([0], [1 2], <<[3 4 5]>>, [ 6  7  8  9 10 11])
+        Decomposition([0,0], [1,2], <<[3,5]>>, [6,11])
 
         Providing a slice
 
         >>> d.reshape(slice(2, 9))
-        Decomposition([0], [1 2], <<[3 4 5]>>, [6])
+        Decomposition([0,0], [1,2], <<[3,5]>>, [6,6])
 
         >>> d.reshape(slice(2, -2))
-        Decomposition([0], [1 2], <<[3 4 5]>>, [6 7])
+        Decomposition([0,0], [1,2], <<[3,5]>>, [6,7])
 
         >>> d.reshape(slice(4))
-        Decomposition([0 1 2], [3], <<[]>>, [])
+        Decomposition([0,2], [3,3], <<[]>>, [])
         """
 
         if len(args) == 1:

--- a/devito/function.py
+++ b/devito/function.py
@@ -46,7 +46,7 @@ class Constant(AbstractCachedSymbol, ArgProvider):
 
     def __init__(self, *args, **kwargs):
         if not self._cached():
-            self._value = kwargs.get('value')
+            self._value = kwargs.get('value', 0)
 
     @classmethod
     def __dtype_setup__(cls, **kwargs):

--- a/devito/function.py
+++ b/devito/function.py
@@ -1794,7 +1794,8 @@ class SparseFunction(AbstractSparseFunction, Differentiable):
         if expr is None:
             out = self.indexify().xreplace({self._sparse_dim: cd})
         else:
-            functions = {f for f in retrieve_functions(expr) if f.is_SparseFunction}
+            functions = {f for f in retrieve_function_carriers(expr)
+                         if f.is_SparseFunction}
             out = indexify(expr).xreplace({f._sparse_dim: cd for f in functions})
 
         # Equations for the indirection dimensions

--- a/devito/function.py
+++ b/devito/function.py
@@ -6,8 +6,9 @@ import numpy as np
 from psutil import virtual_memory
 from cached_property import cached_property
 
+from devito.builtins import assign
 from devito.cgen_utils import INT, cast_mapper
-from devito.data import Data, default_allocator, first_touch
+from devito.data import Data, default_allocator
 from devito.dimension import Dimension, ConditionalDimension, DefaultDimension
 from devito.equation import Eq, Inc
 from devito.exceptions import InvalidArgument
@@ -173,7 +174,7 @@ class TensorFunction(AbstractCachedFunction, ArgProvider):
                 self._data = Data(self.shape_allocated, self.indices, self.dtype,
                                   self._decomposition, self._allocator)
                 if self._first_touch:
-                    first_touch(self)
+                    assign(self, 0)
                 if callable(self._initializer):
                     if self._first_touch:
                         warning("`first touch` together with `initializer` causing "

--- a/devito/function.py
+++ b/devito/function.py
@@ -1573,7 +1573,7 @@ class SparseFunction(AbstractSparseFunction, Differentiable):
 
     @property
     def coordinates_data(self):
-        return self.coordinates.data
+        return self.coordinates.data.view(np.ndarray)
 
     @property
     def _coefficients(self):

--- a/devito/function.py
+++ b/devito/function.py
@@ -578,7 +578,7 @@ class TensorFunction(AbstractCachedFunction, ArgProvider):
     @property
     def initializer(self):
         if self._data is not None:
-            return self._data.view(np.ndarray)
+            return self.data_with_halo.view(np.ndarray)
         else:
             return self._initializer
 

--- a/devito/function.py
+++ b/devito/function.py
@@ -1206,10 +1206,10 @@ class AbstractSparseFunction(TensorFunction):
         """
         The *reference* grid point corresponding to each sparse point.
 
-        .. note::
-
-            When using MPI, this property refers to the *physically* owned
-            sparse points.
+        Notes
+        -----
+        When using MPI, this property refers to the *physically* owned
+        sparse points.
         """
         raise NotImplementedError
 
@@ -1708,14 +1708,16 @@ class SparseFunction(AbstractSparseFunction, Differentiable):
         return ret
 
     def interpolate(self, expr, offset=0, increment=False, self_subs={}):
-        """Creates a :class:`sympy.Eq` equation for the interpolation
-        of an expression onto this sparse point collection.
+        """Generate equations interpolating an arbitrary expression into ``self``.
 
-        :param expr: The expression to interpolate.
-        :param offset: Additional offset from the boundary for
-                       absorbing boundary conditions.
-        :param increment: (Optional) if True, perform an increment rather
-                          than an assignment. Defaults to False.
+        Parameters
+        ----------
+        expr : sympy.Expr
+            Input expression to interpolate.
+        offset : int, optional
+            Additional offset from the boundary.
+        increment: bool, optional
+            If True, generate increments (Inc) rather than assignments (Eq).
         """
         variables = list(retrieve_function_carriers(expr))
 
@@ -1737,12 +1739,16 @@ class SparseFunction(AbstractSparseFunction, Differentiable):
         return eqns + summands + last
 
     def inject(self, field, expr, offset=0):
-        """Symbol for injection of an expression onto a grid
+        """Generate equations injecting an arbitrary expression into a field.
 
-        :param field: The grid field into which we inject.
-        :param expr: The expression to inject.
-        :param offset: Additional offset from the boundary for
-                       absorbing boundary conditions.
+        Parameters
+        ----------
+        field : Function
+            Input field into which the injection is performed.
+        expr : sympy.Expr
+            Injected expression.
+        offset : int, optional
+            Additional offset from the boundary.
         """
 
         variables = list(retrieve_function_carriers(expr)) + [field]
@@ -1819,7 +1825,7 @@ class SparseFunction(AbstractSparseFunction, Differentiable):
         coords = scattered
 
         # Translate global coordinates into local coordinates
-        coords = coords - np.array(self.grid.origin_domain, dtype=self.dtype)
+        coords = coords - np.array(self.grid.origin_offset, dtype=self.dtype)
 
         return {self: data, self.coordinates: coords}
 

--- a/devito/grid.py
+++ b/devito/grid.py
@@ -241,6 +241,9 @@ class Grid(ArgProvider):
         """
         args = ReducerMap()
 
+        for k, v in self.dimension_map.items():
+            args.update(k._arg_defaults(start=0, size=v.loc))
+
         if configuration['mpi']:
             distributor = self.distributor
             args[distributor._C_comm.name] = distributor._C_comm.value

--- a/devito/grid.py
+++ b/devito/grid.py
@@ -187,9 +187,9 @@ class Grid(ArgProvider):
         return dict(zip(self.spacing_symbols, self.spacing))
 
     @property
-    def origin_domain(self):
+    def origin_offset(self):
         """
-        Origin of the local (per-process) physical domain.
+        Offset of the local (per-process) origin from the domain origin.
         """
         grid_origin = [min(i) for i in self.distributor.glb_numb]
         assert len(grid_origin) == len(self.spacing)

--- a/devito/yask/function.py
+++ b/devito/yask/function.py
@@ -155,7 +155,7 @@ class Function(function.Function, Signer):
 
     @cached_property
     @_allocate_memory
-    def data_allocated(self):
+    def _data_allocated(self):
         return Data(self._data.grid, self.shape_allocated, self.indices, self.dtype)
 
     def _arg_defaults(self, alias=None):

--- a/examples/seismic/acoustic/acoustic_example.py
+++ b/examples/seismic/acoustic/acoustic_example.py
@@ -2,10 +2,9 @@ import numpy as np
 from argparse import ArgumentParser
 
 from devito.logger import info
-from devito import Constant, Function
+from devito import Constant, Function, smooth
 from examples.seismic.acoustic import AcousticWaveSolver
 from examples.seismic import demo_model, TimeAxis, RickerSource, Receiver
-from examples.seismic.utils import smooth
 
 
 def acoustic_setup(shape=(50, 50, 50), spacing=(15.0, 15.0, 15.0),

--- a/examples/seismic/acoustic/acoustic_example.py
+++ b/examples/seismic/acoustic/acoustic_example.py
@@ -29,7 +29,8 @@ def acoustic_setup(shape=(50, 50, 50), spacing=(15.0, 15.0, 15.0),
     rec = Receiver(name='rec', grid=model.grid, time_range=time_range, npoint=nrec)
     rec.coordinates.data[:, 0] = np.linspace(0., model.domain_size[0], num=nrec)
     if len(shape) > 1:
-        rec.coordinates.data[:, 1:] = src.coordinates.data[0, 1:]
+        rec.coordinates.data[:, 1] = np.array(model.domain_size)[1] * .5
+        rec.coordinates.data[:, -1] = model.origin[-1] + 2 * spacing[-1]
 
     # Create solver object to provide relevant operators
     solver = AcousticWaveSolver(model, source=src, receiver=rec, kernel=kernel,

--- a/examples/seismic/source.py
+++ b/examples/seismic/source.py
@@ -117,10 +117,6 @@ class PointSource(SparseTimeFunction):
 
         return obj
 
-    def __init__(self, *args, **kwargs):
-        if not self._cached():
-            super(PointSource, self).__init__(*args, **kwargs)
-
     @cached_property
     def time_values(self):
         return self._time_range.time_values

--- a/examples/seismic/utils.py
+++ b/examples/seismic/utils.py
@@ -1,20 +1,6 @@
 from scipy import ndimage
 
-from devito import Operator, Eq
-__all__ = ['smooth', 'scipy_smooth']
-
-
-# Velocity models
-def smooth(dest, f):
-    """
-    Run an n-point moving average kernel over ``f`` and store the result
-    into ``dest``. The average is computed along the innermost ``f`` dimension.
-    """
-    if f.is_Constant:
-        # Return a scaled version of the input if it's a Constant
-        dest.data[:] = .9 * f.data
-    else:
-        Operator(Eq(dest, f.avg(dims=f.dimensions[-1])), name='smoother').apply()
+__all__ = ['scipy_smooth']
 
 
 def scipy_smooth(img, sigma=5):

--- a/tests/test_checkpointing.py
+++ b/tests/test_checkpointing.py
@@ -95,20 +95,20 @@ def test_segmented_averaging():
     # We add the average to the point itself, so the grid "interior"
     # (domain) is updated only.
     f_ref = TimeFunction(name='f', grid=grid)
-    f_ref.data_allocated[:] = 1.
+    f_ref.data_with_halo[:] = 1.
     op(f=f_ref, time=1)
     assert (f_ref.data[1, :] == 2.).all()
-    assert (f_ref.data_allocated[1, 0] == 1.).all()
-    assert (f_ref.data_allocated[1, -1] == 1.).all()
+    assert (f_ref.data_with_halo[1, 0] == 1.).all()
+    assert (f_ref.data_with_halo[1, -1] == 1.).all()
 
     # Now we sweep the x direction in 4 segmented steps of 5 iterations each
     nsteps = 5
-    f.data_allocated[:] = 1.
+    f.data_with_halo[:] = 1.
     for i in range(4):
         op(f=f, time=1, x_m=i*nsteps, x_M=(i+1)*nsteps-1)
     assert (f_ref.data[1, :] == 2.).all()
-    assert (f_ref.data_allocated[1, 0] == 1.).all()
-    assert (f_ref.data_allocated[1, -1] == 1.).all()
+    assert (f_ref.data_with_halo[1, 0] == 1.).all()
+    assert (f_ref.data_with_halo[1, -1] == 1.).all()
 
 
 @silencio(log_level='WARNING')

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -355,14 +355,12 @@ class TestDataDistributed(object):
         u.data[:] = 1.
         assert np.all(u.data == 1.)
         assert np.all(u.data._local == 1.)
-        assert np.all(u.data._global == 1.)
 
         v.data_with_halo[:] = 1.
         assert v.data_with_halo[:].shape == (3, 3)
         assert np.all(v.data_with_halo == 1.)
         assert np.all(v.data_with_halo[:] == 1.)
         assert np.all(v.data_with_halo._local == 1.)
-        assert np.all(v.data_with_halo._global == 1.)
 
     @pytest.mark.parallel(nprocs=4)
     def test_indexing(self):
@@ -409,7 +407,6 @@ class TestDataDistributed(object):
         # to the local rank domain, so it must be == myrank
         assert np.all(u.data == myrank)
         assert np.all(u.data._local == myrank)
-        assert np.all(u.data._global == myrank)
         if LEFT in glb_pos_map[x] and LEFT in glb_pos_map[y]:
             assert np.all(u.data[:2, :2] == myrank)
             assert u.data[:2, 2:].size == u.data[2:, :2].size == u.data[2:, 2:].size == 0

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -76,7 +76,8 @@ class TestDataBasic(object):
         u = Function(name='yu3D', grid=grid, space_order=2)
 
         assert u.shape == u.data.shape == domain_shape
-        assert u.shape_with_halo == u.data_with_halo.shape == (20, 20, 20)
+        assert u._shape_with_inhalo == u.data_with_halo.shape == (20, 20, 20)
+        assert u.shape_with_halo == u._shape_with_inhalo  # W/o MPI, these two coincide
 
         # Test simple insertion and extraction
         u.data_with_halo[0, 0, 0] = 1.
@@ -167,7 +168,8 @@ class TestDataBasic(object):
         u0 = Function(name='u0', grid=grid, space_order=0)
         u2 = Function(name='u2', grid=grid, space_order=2)
 
-        assert u0.shape == u0.shape_with_halo == u0.shape_allocated
+        assert u0.shape == u0._shape_with_inhalo == u0.shape_allocated
+        assert u0.shape_with_halo == u0._shape_with_inhalo  # W/o MPI, these two coincide
         assert len(u2.shape) == len(u2._extent_halo.left)
         assert tuple(i + j*2 for i, j in zip(u2.shape, u2._extent_halo.left)) ==\
             u2.shape_with_halo

--- a/tests/test_derivatives.py
+++ b/tests/test_derivatives.py
@@ -237,8 +237,8 @@ def test_subsampled_fd():
     grid2 = Grid((6, 6), dimensions=dims)
     u2 = TimeFunction(name='u2', grid=grid2, save=nt, space_order=1)
     for i in range(nt):
-        for j in range(u2.data_allocated.shape[2]):
-            u2.data_allocated[i, :, j] = np.arange(u2.data_allocated.shape[2])
+        for j in range(u2.data_with_halo.shape[2]):
+            u2.data_with_halo[i, :, j] = np.arange(u2.data_with_halo.shape[2])
 
     eqns = [Eq(u.forward, u + 1.), Eq(u2.forward, u2.dx)]
     op = Operator(eqns, dse="advanced")

--- a/tests/test_gradient.py
+++ b/tests/test_gradient.py
@@ -3,8 +3,8 @@ import pytest
 from numpy import linalg
 from conftest import skipif_yask
 
-from devito import Function, info, clear_cache
-from examples.seismic.acoustic.acoustic_example import smooth, acoustic_setup as setup
+from devito import Function, info, clear_cache, smooth
+from examples.seismic.acoustic.acoustic_example import acoustic_setup as setup
 from examples.seismic import Receiver
 
 

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -1084,7 +1084,7 @@ class TestIsotropicAcoustic(object):
         ((60, 70), 'OT2', 8, 10, False, 351.217, 867.420, 405805.482, 239444.952),
         ((60, 70, 80), 'OT2', 12, 10, False, 153.122, 205.902, 27484.635, 11736.917)
     ])
-    @pytest.mark.parallel(nprocs=[4, 16])
+    @pytest.mark.parallel(nprocs=[4, 8])
     def test_adjoint_F(self, shape, kernel, space_order, nbpml, save,
                        Eu, Erec, Ev, Esrca):
         """

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -131,13 +131,13 @@ class TestFunction(object):
 
         glb_pos_map = grid.distributor.glb_pos_map
         if LEFT in glb_pos_map[y]:
-            assert np.all(f._data_ro_with_inhalo._local[1:-1, -1] == 2.)
-            assert np.all(f._data_ro_with_inhalo._local[:, 0] == 0.)
+            assert np.all(f._data_ro_with_inhalo[1:-1, -1] == 2.)
+            assert np.all(f._data_ro_with_inhalo[:, 0] == 0.)
         else:
-            assert np.all(f._data_ro_with_inhalo._local[1:-1, 0] == 1.)
-            assert np.all(f._data_ro_with_inhalo._local[:, -1] == 0.)
-        assert np.all(f._data_ro_with_inhalo._local[0] == 0.)
-        assert np.all(f._data_ro_with_inhalo._local[-1] == 0.)
+            assert np.all(f._data_ro_with_inhalo[1:-1, 0] == 1.)
+            assert np.all(f._data_ro_with_inhalo[:, -1] == 0.)
+        assert np.all(f._data_ro_with_inhalo[0] == 0.)
+        assert np.all(f._data_ro_with_inhalo[-1] == 0.)
 
     @pytest.mark.parallel(nprocs=2)
     def test_halo_exchange_bilateral_asymmetric(self):
@@ -179,13 +179,13 @@ class TestFunction(object):
 
         glb_pos_map = grid.distributor.glb_pos_map
         if LEFT in glb_pos_map[y]:
-            assert np.all(f._data_ro_with_inhalo._local[2:-1, -1] == 2.)
-            assert np.all(f._data_ro_with_inhalo._local[:, 0:2] == 0.)
+            assert np.all(f._data_ro_with_inhalo[2:-1, -1] == 2.)
+            assert np.all(f._data_ro_with_inhalo[:, 0:2] == 0.)
         else:
-            assert np.all(f._data_ro_with_inhalo._local[2:-1, 0:2] == 1.)
-            assert np.all(f._data_ro_with_inhalo._local[:, -1] == 0.)
-        assert np.all(f._data_ro_with_inhalo._local[0:2] == 0.)
-        assert np.all(f._data_ro_with_inhalo._local[-1] == 0.)
+            assert np.all(f._data_ro_with_inhalo[2:-1, 0:2] == 1.)
+            assert np.all(f._data_ro_with_inhalo[:, -1] == 0.)
+        assert np.all(f._data_ro_with_inhalo[0:2] == 0.)
+        assert np.all(f._data_ro_with_inhalo[-1] == 0.)
 
     @pytest.mark.parallel(nprocs=4)
     def test_halo_exchange_quadrilateral(self):
@@ -239,29 +239,29 @@ class TestFunction(object):
 
         glb_pos_map = grid.distributor.glb_pos_map
         if LEFT in glb_pos_map[x] and LEFT in glb_pos_map[y]:
-            assert np.all(f._data_ro_with_inhalo._local[0] == 0.)
-            assert np.all(f._data_ro_with_inhalo._local[:, 0] == 0.)
-            assert np.all(f._data_ro_with_inhalo._local[1:-1, -1] == 2.)
-            assert np.all(f._data_ro_with_inhalo._local[-1, 1:-1] == 3.)
-            assert f._data_ro_with_inhalo._local[-1, -1] == 4.
+            assert np.all(f._data_ro_with_inhalo[0] == 0.)
+            assert np.all(f._data_ro_with_inhalo[:, 0] == 0.)
+            assert np.all(f._data_ro_with_inhalo[1:-1, -1] == 2.)
+            assert np.all(f._data_ro_with_inhalo[-1, 1:-1] == 3.)
+            assert f._data_ro_with_inhalo[-1, -1] == 4.
         elif LEFT in glb_pos_map[x] and RIGHT in glb_pos_map[y]:
-            assert np.all(f._data_ro_with_inhalo._local[0] == 0.)
-            assert np.all(f._data_ro_with_inhalo._local[:, -1] == 0.)
-            assert np.all(f._data_ro_with_inhalo._local[1:-1, 0] == 1.)
-            assert np.all(f._data_ro_with_inhalo._local[-1, 1:-1] == 4.)
-            assert f._data_ro_with_inhalo._local[-1, 0] == 3.
+            assert np.all(f._data_ro_with_inhalo[0] == 0.)
+            assert np.all(f._data_ro_with_inhalo[:, -1] == 0.)
+            assert np.all(f._data_ro_with_inhalo[1:-1, 0] == 1.)
+            assert np.all(f._data_ro_with_inhalo[-1, 1:-1] == 4.)
+            assert f._data_ro_with_inhalo[-1, 0] == 3.
         elif RIGHT in glb_pos_map[x] and LEFT in glb_pos_map[y]:
-            assert np.all(f._data_ro_with_inhalo._local[-1] == 0.)
-            assert np.all(f._data_ro_with_inhalo._local[:, 0] == 0.)
-            assert np.all(f._data_ro_with_inhalo._local[1:-1, -1] == 4.)
-            assert np.all(f._data_ro_with_inhalo._local[0, 1:-1] == 1.)
-            assert f._data_ro_with_inhalo._local[0, -1] == 2.
+            assert np.all(f._data_ro_with_inhalo[-1] == 0.)
+            assert np.all(f._data_ro_with_inhalo[:, 0] == 0.)
+            assert np.all(f._data_ro_with_inhalo[1:-1, -1] == 4.)
+            assert np.all(f._data_ro_with_inhalo[0, 1:-1] == 1.)
+            assert f._data_ro_with_inhalo[0, -1] == 2.
         else:
-            assert np.all(f._data_ro_with_inhalo._local[-1] == 0.)
-            assert np.all(f._data_ro_with_inhalo._local[:, -1] == 0.)
-            assert np.all(f._data_ro_with_inhalo._local[1:-1, 0] == 3.)
-            assert np.all(f._data_ro_with_inhalo._local[0, 1:-1] == 2.)
-            assert f._data_ro_with_inhalo._local[0, 0] == 1.
+            assert np.all(f._data_ro_with_inhalo[-1] == 0.)
+            assert np.all(f._data_ro_with_inhalo[:, -1] == 0.)
+            assert np.all(f._data_ro_with_inhalo[1:-1, 0] == 3.)
+            assert np.all(f._data_ro_with_inhalo[0, 1:-1] == 2.)
+            assert f._data_ro_with_inhalo[0, 0] == 1.
 
     @skipif_yask
     @pytest.mark.parallel(nprocs=4)

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -25,7 +25,7 @@ def symbol(name, dimensions, value=0., shape=(3, 5), mode='function'):
     and "indexed" API."""
     assert(mode in ['function', 'indexed'])
     s = Function(name=name, dimensions=dimensions, shape=shape)
-    s.data_allocated[:] = value
+    s.data_with_halo[:] = value
     return s.indexify() if mode == 'indexed' else s
 
 
@@ -421,7 +421,7 @@ class TestArguments(object):
             'x_size': 5, 'x_m': 0, 'x_M': 4,
             'y_size': 6, 'y_m': 0, 'y_M': 5,
             'z_size': 7, 'z_m': 0, 'z_M': 6,
-            'f': f.data_allocated, 'g': g.data_allocated,
+            'f': f.data_with_halo, 'g': g.data_with_halo,
         }
         self.verify_arguments(op.arguments(time=4), expected)
         exp_parameters = ['f', 'g', 'x_m', 'x_M', 'x_size', 'y_m',
@@ -473,7 +473,7 @@ class TestArguments(object):
             'x_size': 5, 'x_m': 0, 'x_M': 3,
             'y_size': 6, 'y_m': 0, 'y_M': 4,
             'z_size': 7, 'z_m': 0, 'z_M': 5,
-            'g': g.data_allocated
+            'g': g.data_with_halo
         }
         self.verify_arguments(arguments, expected)
         # Verify execution
@@ -497,7 +497,7 @@ class TestArguments(object):
             'x_size': 5, 'x_m': 1, 'x_M': 3,
             'y_size': 6, 'y_m': 2, 'y_M': 4,
             'z_size': 7, 'z_m': 3, 'z_M': 5,
-            'g': g.data_allocated
+            'g': g.data_with_halo
         }
         self.verify_arguments(arguments, expected)
         # Verify execution
@@ -528,7 +528,7 @@ class TestArguments(object):
             'y_size': 6, 'y_m': 2, 'y_M': 4,
             'z_size': 7, 'z_m': 3, 'z_M': 5,
             'time_m': 1, 'time_M': 4,
-            'f': f.data_allocated
+            'f': f.data_with_halo
         }
         self.verify_arguments(arguments, expected)
         # Verify execution
@@ -564,7 +564,7 @@ class TestArguments(object):
         assert (a2.data[:] == 6.).all()
 
         # Override with user-allocated numpy data
-        a3 = np.zeros_like(a.data_allocated)
+        a3 = np.zeros_like(a.data_with_halo)
         a3[:] = 4.
         op(a=a3)
         assert (a3[[slice(i.left, -i.right) for i in a._offset_domain]] == 7.).all()
@@ -597,7 +597,7 @@ class TestArguments(object):
         assert (a2.data[:] == 6.).all()
 
         # Override with user-allocated numpy data
-        a3 = np.zeros_like(a.data_allocated)
+        a3 = np.zeros_like(a.data_with_halo)
         a3[:] = 4.
         op(time_m=0, time=1, a=a3)
         assert (a3[[slice(i.left, -i.right) for i in a._offset_domain]] == 7.).all()
@@ -1141,10 +1141,10 @@ class TestLoopScheduler(object):
         p_aux = Dimension(name='p_aux')
         b = Function(name='b', shape=shape + (10,), dimensions=dimensions + (p_aux,),
                      space_order=2)
-        b.data_allocated[:] = 1.0
+        b.data_with_halo[:] = 1.0
         b2 = Function(name='b2', shape=(10,) + shape, dimensions=(p_aux,) + dimensions,
                       space_order=2)
-        b2.data_allocated[:] = 1.0
+        b2.data_with_halo[:] = 1.0
         eqns = [Eq(a.forward, a.laplace + 1.),
                 Eq(b, time*b*a + b)]
         eqns2 = [Eq(a.forward, a.laplace + 1.),
@@ -1161,7 +1161,7 @@ class TestLoopScheduler(object):
 
         # Verify both operators produce the same result
         op(time=10)
-        a.data_allocated[:] = 0.
+        a.data_with_halo[:] = 0.
         op2(time=10)
 
         for i in range(10):

--- a/tests/test_pickle.py
+++ b/tests/test_pickle.py
@@ -11,6 +11,19 @@ from devito.symbolics import IntDiv, ListInitializer, FunctionFromPointer
 import cloudpickle as pickle
 
 
+def test_constant():
+    c = Constant(name='c')
+    assert c.data == 0.
+    c.data = 1.
+
+    pkl_c = pickle.dumps(c)
+    new_c = pickle.loads(pkl_c)
+
+    # .data is initialized, so it should have been pickled too
+    assert np.all(c.data == 1.)
+    assert np.all(new_c.data == 1.)
+
+
 def test_function():
     grid = Grid(shape=(3, 3, 3))
     f = Function(name='f', grid=grid)


### PR DESCRIPTION
This PR adds:

* some built-in Operators to compute norms/inner products/... of Functions when over MPI. These are meant to be used in place of NumPy linalg functions when MPI is used.
* bunch of tweaks to Data indexing and manipulation over MPI
* cleanup and minor fixes
* lots of new MPI-related tests