### PR TITLE
Revamp autotuning

### DIFF
--- a/devito/__init__.py
+++ b/devito/__init__.py
@@ -62,11 +62,7 @@ def _at_callback(val):  # noqa
         level, mode = val
     if level == 'off':
         level = False
-    if configuration['backend'] == 'core' and mode == 'runtime':
-        warning("Unsupported auto-tuning mode `runtime` with backend `core`")
-        return at_setup(level, 'preemptive')
-    else:
-        return at_setup(level, mode)
+    return at_setup(level, mode)
 configuration.add('autotuning', 'off', at_accepted, callback=_at_callback,  # noqa
                   impacts_jit=False)
 

--- a/devito/core/autotuning.py
+++ b/devito/core/autotuning.py
@@ -70,7 +70,7 @@ def autotune(operator, args, level, mode):
         return args
 
     # Attempted block sizes ...
-    mapper = OrderedDict([(i.argument.symbolic_size.name, i) for i in tunable])
+    mapper = OrderedDict([(i.tunable.name, i) for i in tunable])
     # ... Defaults (basic mode)
     blocksizes = [OrderedDict([(i, v) for i in mapper]) for v in options['at_blocksize']]
     # ... Always try the entire iteration space (degenerate block)

--- a/devito/core/operator.py
+++ b/devito/core/operator.py
@@ -70,11 +70,23 @@ class OperatorCore(OperatorRunnable):
 
         return iet
 
-    def _autotune(self, args):
-        if self._dle_flags.get('blocking', False):
-            return autotune(self, args, self.parameters, self._dle_args)
-        else:
+    def _autotune(self, args, setup):
+        if setup is False or not self._dle_flags.get('blocking'):
             return args
+        elif setup is True:
+            level = configuration['autotuning'].level or 'basic'
+            return autotune(self, args, level, configuration['autotuning'].mode)
+        elif isinstance(setup, str):
+            return autotune(self, args, setup, configuration['autotuning'].mode)
+        elif isinstance(setup, tuple) and len(setup) == 2:
+            level, mode = setup
+            if level is False:
+                return args
+            else:
+                return autotune(self, args, level, mode)
+        else:
+            raise ValueError("Expected bool, str, or 2-tuple, got `%s` instead"
+                             % type(setup))
 
 
 class OperatorDebug(OperatorCore):

--- a/devito/core/operator.py
+++ b/devito/core/operator.py
@@ -75,18 +75,25 @@ class OperatorCore(OperatorRunnable):
             return args
         elif setup is True:
             level = configuration['autotuning'].level or 'basic'
-            return autotune(self, args, level, configuration['autotuning'].mode)
+            args = autotune(self, args, level, configuration['autotuning'].mode)
         elif isinstance(setup, str):
-            return autotune(self, args, setup, configuration['autotuning'].mode)
+            args = autotune(self, args, setup, configuration['autotuning'].mode)
         elif isinstance(setup, tuple) and len(setup) == 2:
             level, mode = setup
             if level is False:
                 return args
             else:
-                return autotune(self, args, level, mode)
+                args = autotune(self, args, level, mode)
         else:
             raise ValueError("Expected bool, str, or 2-tuple, got `%s` instead"
                              % type(setup))
+
+        # Record the tuned values
+        mapper = self._state.setdefault('tuned', {})
+        mapper.update({k: v for k, v in args.items()
+                       if k in [i.tunable.name for i in self._dle_args]})
+
+        return args
 
 
 class OperatorDebug(OperatorCore):

--- a/devito/dle/backends/common.py
+++ b/devito/dle/backends/common.py
@@ -81,6 +81,10 @@ class BlockingArg(Arg):
     def original_dim(self):
         return self.iteration.dim
 
+    @property
+    def tunable(self):
+        return self.argument.symbolic_size
+
 
 class AbstractRewriter(object):
     """

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -167,8 +167,7 @@ class Operator(Callable):
         args.update(kwargs.pop('backend', {}))
 
         # Execute autotuning and adjust arguments accordingly
-        if kwargs.pop('autotune', configuration['autotuning'].level):
-            args = self._autotune(args)
+        args = self._autotune(args, kwargs.pop('autotune', configuration['autotuning']))
 
         # Check all user-provided keywords are known to the Operator
         if not configuration['ignore-unknowns']:
@@ -254,7 +253,7 @@ class Operator(Callable):
         """Introduce C-level profiling nodes within the Iteration/Expression tree."""
         return List(body=iet), None
 
-    def _autotune(self, args):
+    def _autotune(self, args, setup):
         """Use auto-tuning on this Operator to determine empirically the
         best block sizes when loop blocking is in use."""
         return args

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -70,6 +70,10 @@ class Operator(Callable):
         # References to local or external routines
         self._func_table = OrderedDict()
 
+        # Internal state. May be used to store information about previous runs,
+        # autotuning reports, etc
+        self._state = {}
+
         # Expression lowering: indexification, substitution rules, specialization
         expressions = [indexify(i) for i in expressions]
         expressions = self._apply_substitutions(expressions, subs)

--- a/devito/yask/wrappers.py
+++ b/devito/yask/wrappers.py
@@ -199,9 +199,9 @@ class YaskKernel(object):
         self.soln.prepare_solution()
 
         # Set up auto-tuning
-        if configuration['autotuning'] is False:
+        if configuration['autotuning'].level is False:
             self.soln.reset_auto_tuner(False)
-        elif configuration['autotuning'] == 'preemptive':
+        elif configuration['autotuning'].mode == 'preemptive':
             self.soln.run_auto_tuner_now()
 
     def post_apply(self):

--- a/tests/test_autotuner.py
+++ b/tests/test_autotuner.py
@@ -129,7 +129,6 @@ def test_timesteps_per_at_run():
     buffer.close()
 
 
-@skipif_yask
 def test_nondestructive_forward():
     """Test autotuning in non-destructive mode."""
     grid = Grid(shape=(64, 64, 64))
@@ -143,7 +142,6 @@ def test_nondestructive_forward():
     assert np.all(f.data[1] == 101)
 
 
-@skipif_yask
 def test_nondestructive_backward():
     """Test autotuning in non-destructive mode."""
     grid = Grid(shape=(64, 64, 64))

--- a/tests/test_autotuner.py
+++ b/tests/test_autotuner.py
@@ -19,8 +19,8 @@ pytestmark = pytest.mark.skipif(configuration['backend'] == 'yask' or
 
 @silencio(log_level='DEBUG')
 @pytest.mark.parametrize("shape,expected", [
-    ((30, 30), 17),
-    ((30, 30, 30), 21)
+    ((30, 30), 13),
+    ((30, 30, 30), 17)
 ])
 def test_at_is_actually_working(shape, expected):
     """
@@ -39,17 +39,33 @@ def test_at_is_actually_working(shape, expected):
     stencil = Eq(outfield.indexify(), outfield.indexify() + infield.indexify()*3.0)
     op = Operator(stencil, dle=('blocking', {'blockinner': True, 'blockalways': True}))
 
-    # Expected 3 AT attempts for the given shape
+    # Run with whatever `configuration` says (by default, basic+preemptive)
     op(infield=infield, outfield=outfield, autotune=True)
     out = [i for i in buffer.getvalue().split('\n') if 'took' in i]
     assert len(out) == 4
 
-    # Now try the same with aggressive autotuning, which tries 9 more cases
+    buffer.truncate(0)
+
+    # Now try `aggressive` autotuning
     configuration['autotuning'] = 'aggressive'
     op(infield=infield, outfield=outfield, autotune=True)
     out = [i for i in buffer.getvalue().split('\n') if 'took' in i]
     assert len(out) == expected
     configuration['autotuning'] = configuration._defaults['autotuning']
+
+    buffer.truncate(0)
+
+    # Try again, but using the Operator API directly
+    op(infield=infield, outfield=outfield, autotune='aggressive')
+    out = [i for i in buffer.getvalue().split('\n') if 'took' in i]
+    assert len(out) == expected
+
+    buffer.truncate(0)
+
+    # Similar to above
+    op(infield=infield, outfield=outfield, autotune=('aggressive', 'preemptive'))
+    out = [i for i in buffer.getvalue().split('\n') if 'took' in i]
+    assert len(out) == expected
 
     logger.removeHandler(temporary_handler)
 
@@ -99,10 +115,10 @@ def test_timesteps_per_at_run():
         stencil = Eq(outfield[t + to, x, y, z],
                      outfield.indexify() + infield.indexify()*3.0)
         op = Operator(stencil, dle=('blocking', {'blockalways': True}))
-        op(infield=infield, outfield=outfield, t=2, autotune=True)
+        op(infield=infield, outfield=outfield, time=20, autotune=True)
         out = [i for i in buffer.getvalue().split('\n') if 'took' in i]
         assert len(out) == 4
-        assert all('in %d timesteps' % options['at_squeezer'] in i for i in out)
+        assert all('in %d timesteps' % (options['at_squeezer'] + 1) in i for i in out)
         buffer.truncate(0)
 
     logger.removeHandler(temporary_handler)
@@ -111,3 +127,31 @@ def test_timesteps_per_at_run():
     temporary_handler.close()
     buffer.flush()
     buffer.close()
+
+
+@skipif_yask
+def test_nondestructive_forward():
+    """Test autotuning in non-destructive mode."""
+    grid = Grid(shape=(64, 64, 64))
+    f = TimeFunction(name='f', grid=grid)
+
+    op = Operator(Eq(f.forward, f + 1))
+    op.apply(time=100, autotune=('basic', 'runtime'))
+
+    # AT is expected to have executed 35 timesteps
+    assert np.all(f.data[0] == 100)
+    assert np.all(f.data[1] == 101)
+
+
+@skipif_yask
+def test_nondestructive_backward():
+    """Test autotuning in non-destructive mode."""
+    grid = Grid(shape=(64, 64, 64))
+    f = TimeFunction(name='f', grid=grid)
+
+    op = Operator(Eq(f.backward, f + 1))
+    op.apply(time=101, autotune=('basic', 'runtime'))
+
+    # AT is expected to have executed 35 timesteps
+    assert np.all(f.data[0] == 101)
+    assert np.all(f.data[1] == 100)


### PR DESCRIPTION
* 'runtime' mode for 'core' so that we don't waste time
* more tests
* enhanced ``op.apply`` interface (now can pass basic/aggressive/... directly as ``op.apply(autotune=aggressive)`` instead of setting them globally via ``configuration``)

see tests for more info