### PR TITLE
fix YASK segfault

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -103,7 +103,7 @@ install:
 before_script:
   - echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> ~/.ssh/config
   - if [[ $DEVITO_BACKEND == 'yask' ]]; then
-      conda install swig; cd ../;
+      conda install -c conda-forge swig; cd ../;
       git clone https://github.com/opesci/yask.git;
       cd yask; make compiler-api; pip install -e .; cd ../devito;
     fi

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -139,7 +139,7 @@ def pipInstallDevito () {
 def installYask () {
     sh "mkdir -p $HOME/.ssh/"
     sh """echo -e "Host github.com\n\tStrictHostKeyChecking no\n" >> $HOME/.ssh/config"""
-    sh "source activate devito ; conda install swig"
+    sh "source activate devito ; conda install -c conda-forge swig"
     sh "mkdir ${WORKSPACE}/scratch"
     dir ("${WORKSPACE}/scratch") { sh 'git clone https://github.com/opesci/yask.git' }
     dir ("${WORKSPACE}/scratch/yask") {


### PR DESCRIPTION
not a bug in our code (neither devito nor yask). We apparently just need to get swig from conda-forge .

This avoids a nasty bug due to importing a fauly Qt-based backend in matplotlib. Apparently the conda-forge install does not downgrade matplotlib/qt to the faulty versions