### PR TITLE
Restrict testing on pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,9 @@
+trigger:
+- master
+
+pr:
+- master  
+
 jobs:
 
 - job: build_and_test


### PR DESCRIPTION
Add yaml configuration to restrict pipelines runs to master branch and PRs which target master branch

Documentation for this is found at:

https://docs.microsoft.com/en-us/azure/devops/pipelines/build/triggers?view=vsts&tabs=yaml