### PR TITLE
YASK: misc fixes

### DIFF
--- a/devito/dle/backends/basic.py
+++ b/devito/dle/backends/basic.py
@@ -56,8 +56,8 @@ class BasicRewriter(AbstractRewriter):
             for i in target:
                 name, bounds = i.dim.name, i.symbolic_bounds
                 # Iteration bounds
-                _min = Scalar(name='%sf_m' % name, dtype=np.int32)
-                _max = Scalar(name='%sf_M' % name, dtype=np.int32)
+                _min = Scalar(name='%sf_m' % name, dtype=np.int32, is_const=True)
+                _max = Scalar(name='%sf_M' % name, dtype=np.int32, is_const=True)
                 defined_args[_min.name] = bounds[0]
                 defined_args[_max.name] = bounds[1]
 
@@ -66,11 +66,10 @@ class BasicRewriter(AbstractRewriter):
                          for j in range(len(i.uindices))]
                 defined_args.update({uf.name: j.symbolic_min
                                      for uf, j in zip(ufunc, i.uindices)})
-                limits = [Scalar(name=_min.name, dtype=np.int32),
-                          Scalar(name=_max.name, dtype=np.int32), 1]
                 uindices = [IncrDimension(j.parent, i.dim + as_symbol(k), 1, j.name)
                             for j, k in zip(i.uindices, ufunc)]
-                free.append(i._rebuild(limits=limits, offsets=None, uindices=uindices))
+                free.append(i._rebuild(limits=(_min, _max, 1), offsets=None,
+                                       uindices=uindices))
 
             # Construct elemental function body
             free = Transformer(dict((zip(target, free))), nested=True).visit(root)

--- a/devito/ir/stree/algorithms.py
+++ b/devito/ir/stree/algorithms.py
@@ -14,7 +14,7 @@ __all__ = ['st_build']
 
 def st_build(clusters):
     """
-    Create a :class:`ScheduleTree` from a :class:`ClusterGroup`.
+    Create a ScheduleTree from a ClusterGroup.
     """
     # ClusterGroup -> Schedule tree
     stree = st_schedule(clusters)
@@ -30,7 +30,7 @@ def st_build(clusters):
 
 def st_schedule(clusters):
     """
-    Arrange an iterable of :class:`Cluster`s into a :class:`ScheduleTree`.
+    Arrange an iterable of Clusters into a ScheduleTree.
     """
     stree = ScheduleTree()
 
@@ -77,9 +77,9 @@ def st_schedule(clusters):
 
 def st_make_halo(stree):
     """
-    Add :class:`NodeHalo`s to a :class:`ScheduleTree`. A HaloNode captures
-    the halo exchanges that should take place before executing the sub-tree;
-    these are described by means of a :class:`HaloScheme`.
+    Add NodeHalos to a ScheduleTree. A NodeHalo captures the halo exchanges
+    that should take place before executing the sub-tree; these are described
+    by means of a HaloScheme.
     """
     # Build a HaloScheme for each expression bundle
     halo_schemes = {}
@@ -111,17 +111,15 @@ def st_make_halo(stree):
 
 def st_section(stree):
     """
-    Add :class:`NodeSection` to a :class:`ScheduleTree`. A section defines a
-    sub-tree with the following properties: ::
+    Add NodeSections to a ScheduleTree. A NodeSection, or simply "section",
+    defines a sub-tree with the following properties:
 
-        * The root is a node of type :class:`NodeSection`;
-        * The immediate children of the root are nodes of type :class:`NodeIteration`
-          and have same parent.
-        * The :class:`Dimension` of the immediate children are either: ::
+        * The root is a node of type NodeSection;
+        * The immediate children of the root are nodes of type NodeIteration;
+        * The Dimensions of the immediate children are either:
             * identical, OR
-            * different, but all of type :class:`SubDimension`;
-        * The :class:`Dimension` of the immediate children cannot be a
-          :class:`TimeDimension`.
+            * different, but all of type SubDimension;
+        * The Dimension of the immediate children cannot be a TimeDimension.
     """
 
     class Section(object):
@@ -131,8 +129,7 @@ def st_section(stree):
             self.nodes = [node]
 
         def is_compatible(self, node):
-            return (self.parent == node.parent
-                    and (self.dim == node.dim or node.dim.is_Sub))
+            return self.parent == node.parent and self.dim.root == node.dim.root
 
     # Search candidate sections
     sections = []

--- a/devito/ir/support/basic.py
+++ b/devito/ir/support/basic.py
@@ -2,7 +2,7 @@ from cached_property import cached_property
 from sympy import Basic, S
 
 from devito.ir.support.space import Any, Backward
-from devito.symbolics import retrieve_terminals, q_affine, q_constant, q_inc
+from devito.symbolics import retrieve_terminals, q_monoaffine, q_inc
 from devito.tools import (Tag, as_tuple, is_integer, filter_sorted,
                           flatten, memoized_meth)
 from devito.types import Dimension
@@ -162,10 +162,7 @@ class Vector(tuple):
 class IndexMode(Tag):
     """Tag for access functions."""
     pass
-
-
-CONSTANT = IndexMode('constant')
-AFFINE = IndexMode('affine')
+AFFINE = IndexMode('affine')  # noqa
 IRREGULAR = IndexMode('irregular')
 
 
@@ -239,16 +236,14 @@ class IterationInstance(Vector):
     def index_mode(self):
         index_mode = []
         for i, fi in zip(self, self.findices):
-            if q_constant(i):
-                index_mode.append(CONSTANT)
-            elif q_affine(i, fi):
+            if q_monoaffine(i, fi, self.findices):
                 index_mode.append(AFFINE)
             else:
                 dims = {i for i in i.free_symbols if isinstance(i, Dimension)}
                 try:
                     # There's still hope it's regular if a DerivedDimension is used
                     candidate = dims.pop()
-                    if candidate.parent == fi and q_affine(i, candidate):
+                    if candidate.root == fi and q_monoaffine(i, candidate, self.findices):
                         index_mode.append(AFFINE)
                         continue
                 except (KeyError, AttributeError):
@@ -260,9 +255,7 @@ class IterationInstance(Vector):
     def aindices(self):
         aindices = []
         for i, fi in zip(self, self.findices):
-            if q_constant(i):
-                aindices.append(None)
-            elif q_affine(i, fi):
+            if q_monoaffine(i, fi, self.findices):
                 aindices.append(fi)
             else:
                 dims = {i for i in i.free_symbols if isinstance(i, Dimension)}
@@ -319,7 +312,7 @@ class IterationInstance(Vector):
 
     @property
     def is_regular(self):
-        return all(i in (CONSTANT, AFFINE) for i in self.index_mode)
+        return all(i is AFFINE for i in self.index_mode)
 
     @property
     def is_irregular(self):

--- a/devito/ir/support/basic.py
+++ b/devito/ir/support/basic.py
@@ -2,7 +2,7 @@ from cached_property import cached_property
 from sympy import Basic, S
 
 from devito.ir.support.space import Any, Backward
-from devito.symbolics import retrieve_terminals, q_affine, q_inc
+from devito.symbolics import retrieve_terminals, q_affine, q_constant, q_inc
 from devito.tools import (Tag, as_tuple, is_integer, filter_sorted,
                           flatten, memoized_meth)
 from devito.types import Dimension
@@ -239,7 +239,7 @@ class IterationInstance(Vector):
     def index_mode(self):
         index_mode = []
         for i, fi in zip(self, self.findices):
-            if is_integer(i):
+            if q_constant(i):
                 index_mode.append(CONSTANT)
             elif q_affine(i, fi):
                 index_mode.append(AFFINE)
@@ -260,7 +260,7 @@ class IterationInstance(Vector):
     def aindices(self):
         aindices = []
         for i, fi in zip(self, self.findices):
-            if is_integer(i):
+            if q_constant(i):
                 aindices.append(None)
             elif q_affine(i, fi):
                 aindices.append(fi)

--- a/devito/mpi/halo_scheme.py
+++ b/devito/mpi/halo_scheme.py
@@ -54,26 +54,25 @@ class HaloScheme(object):
         ({loc_indices}, ((Dimension, DataSide, amount), ...))
 
     The tuples (Dimension, DataSide, amount) tell the amount of data that
-    a :class:`DiscreteFunction` should communicate along (a subset of) its
-    :class:`Dimension`s.
+    a DiscreteFunction should communicate along its Dimensions.
 
     The dict ``loc_indices`` tells how to access/insert the halo along the
-    keyed Function's non-halo indices. For example, consider the
-    :class:`Function` ``u(t, x, y)``. Assume ``x`` and ``y`` require a halo
-    exchange. The question is: once the halo exchange is performed, at what
-    offset in ``t`` should it be placed? should it be at ``u(0, ...)`` or
-    ``u(1, ...)`` or even ``u(t-1, ...)``? ``loc_indices`` has as many entries
-    as non-halo dimensions, and each entry provides symbolic information about
-    how to access the corresponding non-halo dimension. Thus, in this example
+    keyed Function's non-halo indices. For example, consider the Function
+    ``u(t, x, y)``. Assume ``x`` and ``y`` require a halo exchange. The
+    question is: once the halo exchange is performed, at what offset in ``t``
+    should it be placed? should it be at ``u(0, ...)`` or ``u(1, ...)`` or even
+    ``u(t-1, ...)``? ``loc_indices`` has as many entries as non-halo
+    dimensions, and each entry provides symbolic information about how to
+    access the corresponding non-halo dimension. Thus, in this example
     ``loc_indices`` could be, for instance, ``{t: 0}`` or ``{t: t-1}``.
 
     Parameters
     ----------
-    exprs : tuple of :class:`IREq`
+    exprs : tuple of IREq
         The expressions for which the HaloScheme is built
-    ispace : :class:`IterationSpace`
+    ispace : IterationSpace
         Description of iteration directions and sub-iterators used in ``exprs``.
-    dspace : :class:`DataSpace`
+    dspace : DataSpace
         Description of the data access pattern in ``exprs``.
     fmapper : dict, optional
         The format is the same as ``M``. When provided, ``exprs``, ``ispace`` and
@@ -142,8 +141,7 @@ class HaloScheme(object):
 def hs_classify(scope):
     """
     A mapper ``Function -> (Dimension -> [HaloLabel]`` describing what type of
-    halo exchange is expected by the various :class:`DiscreteFunction`s in a
-    :class:`Scope`.
+    halo exchange is expected by the DiscreteFunctions in a given Scope.
     """
     mapper = {}
     for f, r in scope.reads.items():
@@ -216,7 +214,7 @@ def hs_comp_halos(f, dims, dspace=None):
     """
     An iterable of 3-tuples ``[(Dimension, DataSide, amount), ...]`` describing
     the amount of halo that should be exchange along the two sides of a set of
-    :class:`Dimension`s.
+    Dimensions.
     """
     halos = []
     for d in dims:
@@ -241,7 +239,7 @@ def hs_comp_halos(f, dims, dspace=None):
 
 def hs_comp_locindices(f, dims, ispace, dspace, scope):
     """
-    Map the :class:`Dimension`s in ``dims`` to the local indices necessary
+    Map the Dimensions in ``dims`` to the local indices necessary
     to perform a halo exchange, as described in HaloScheme.__doc__.
 
     Examples

--- a/devito/mpi/halo_scheme.py
+++ b/devito/mpi/halo_scheme.py
@@ -95,14 +95,17 @@ class HaloScheme(object):
 
         for f, v in classification.items():
             # *How much* halo do we have to exchange?
-            halos = hs_comp_halos(f, [d for d, hl in v.items() if hl is STENCIL], dspace)
-            halos.extend(hs_comp_halos(f, [d for d, hl in v.items() if hl is FULL]))
-
-            # *What* are the local (i.e., non-halo) indices?
-            loc_indices = hs_comp_locindices(f, [d for d, hl in v.items() if hl is NONE],
-                                             ispace, dspace, scope)
+            dims = [d for d, hl in v.items() if hl is STENCIL]
+            halos = hs_comp_halos(f, dims, dspace)
+            dims = [d for d, hl in v.items() if hl is FULL]
+            halos.extend(hs_comp_halos(f, dims))
 
             if halos:
+                # There is some halo to be exchanged; *what* are the local
+                # (i.e., non-halo) indices?
+                dims = [d for d, hl in v.items() if hl is NONE]
+                loc_indices = hs_comp_locindices(f, dims, ispace, dspace, scope)
+
                 self._mapper[f] = HaloSchemeEntry(frozendict(loc_indices), tuple(halos))
 
         self._mapper = frozendict(self._mapper)

--- a/devito/symbolics/queries.py
+++ b/devito/symbolics/queries.py
@@ -5,7 +5,7 @@ from devito.tools import as_tuple
 
 __all__ = ['q_leaf', 'q_indexed', 'q_terminal', 'q_trigonometry', 'q_op',
            'q_terminalop', 'q_sum_of_product', 'q_indirect', 'q_timedimension',
-           'q_affine', 'q_linear', 'q_identity', 'q_inc', 'q_scalar',
+           'q_constant', 'q_affine', 'q_linear', 'q_identity', 'q_inc', 'q_scalar',
            'iq_timeinvariant', 'iq_timevarying']
 
 
@@ -93,6 +93,20 @@ def q_inc(expr):
         return expr.is_Increment
     except AttributeError:
         return False
+
+
+def q_constant(expr):
+    """
+    Return True if ``expr`` is a constant, possibly symbolic, value, False otherwise.
+    Examples of non-constants are expressions containing Dimensions.
+    """
+    for i in expr.free_symbols:
+        try:
+            if not (i.is_Scalar or i.is_Constant):
+                return False
+        except AttributeError:
+            return False
+    return True
 
 
 def q_affine(expr, vars):

--- a/devito/symbolics/queries.py
+++ b/devito/symbolics/queries.py
@@ -1,12 +1,12 @@
 from sympy import Eq, diff, cos, sin, nan
 
-from devito.tools import as_tuple
+from devito.tools import as_tuple, is_integer
 
 
 __all__ = ['q_leaf', 'q_indexed', 'q_terminal', 'q_trigonometry', 'q_op',
            'q_terminalop', 'q_sum_of_product', 'q_indirect', 'q_timedimension',
            'q_constant', 'q_affine', 'q_linear', 'q_identity', 'q_inc', 'q_scalar',
-           'iq_timeinvariant', 'iq_timevarying']
+           'q_multivar', 'q_monoaffine', 'iq_timeinvariant', 'iq_timevarying']
 
 
 """
@@ -95,11 +95,25 @@ def q_inc(expr):
         return False
 
 
+def q_multivar(expr, vars):
+    """
+    Return True if at least two variables in ``vars`` appear in ``expr``,
+    False otherwise.
+    """
+    # The vast majority of calls here provide incredibly simple single variable
+    # functions, so if there are < 2 free symbols we return immediately
+    if not len(expr.free_symbols) > 1:
+        return False
+    return len(set(as_tuple(vars)) & expr.free_symbols) >= 2
+
+
 def q_constant(expr):
     """
     Return True if ``expr`` is a constant, possibly symbolic, value, False otherwise.
     Examples of non-constants are expressions containing Dimensions.
     """
+    if is_integer(expr):
+        return True
     for i in expr.free_symbols:
         try:
             if not (i.is_Scalar or i.is_Constant):
@@ -117,12 +131,14 @@ def q_affine(expr, vars):
     Readapted from: https://stackoverflow.com/questions/36283548\
         /check-if-an-equation-is-linear-for-a-specific-set-of-variables/
     """
-    # A function is (separately) affine in a given set of variables if all
-    # non-mixed second order derivatives are identically zero.
-    for x in as_tuple(vars):
-        if x not in expr.atoms():
-            return False
-
+    vars = as_tuple(vars)
+    # If any `vars` does not appear in `expr`, the only possibility
+    # for `expr` to be affine is that it's a constant function
+    if any(x not in expr.atoms() for x in vars):
+        return q_constant(expr)
+    # At this point, `expr` is (separately) affine in the `vars` variables
+    # if all non-mixed second order derivatives are identically zero.
+    for x in vars:
         # The vast majority of calls here are incredibly simple tests
         # like q_affine(x+1, [x]).  Catch these quickly and
         # explicitly, instead of calling the very slow function `diff`.
@@ -140,6 +156,16 @@ def q_affine(expr, vars):
         except TypeError:
             return False
     return True
+
+
+def q_monoaffine(expr, x, vars):
+    """
+    Return True if ``expr`` is a single variable function which is affine in ``x`` ,
+    False otherwise.
+    """
+    if q_multivar(expr, vars):
+        return False
+    return q_affine(expr, x)
 
 
 def q_linear(expr, vars):

--- a/devito/symbolics/queries.py
+++ b/devito/symbolics/queries.py
@@ -116,7 +116,7 @@ def q_constant(expr):
         return True
     for i in expr.free_symbols:
         try:
-            if not (i.is_Scalar or i.is_Constant):
+            if not i._is_const:
                 return False
         except AttributeError:
             return False

--- a/devito/types/basic.py
+++ b/devito/types/basic.py
@@ -731,8 +731,8 @@ class Array(AbstractCachedFunction):
     """
     Tensor symbol representing an array in symbolic equations.
 
-    Arrays are created and managed directly by Devito (IOW, they are not
-    expected to be used directly in user code).
+    An Array is very similar to a sympy.Indexed, though it also carries
+    metadata essential for code generation.
 
     Parameters
     ----------
@@ -750,6 +750,11 @@ class Array(AbstractCachedFunction):
     scope : str, optional
         Control memory allocation. Allowed values: 'heap', 'stack'. Defaults
         to 'heap'.
+
+    Warnings
+    --------
+    Arrays are created and managed directly by Devito (IOW, they are not
+    expected to be used directly in user code).
     """
 
     is_Array = True

--- a/devito/types/constant.py
+++ b/devito/types/constant.py
@@ -53,6 +53,10 @@ class Constant(AbstractCachedSymbol, ArgProvider):
         return kwargs.get('dtype', np.float32)
 
     @property
+    def _is_const(self):
+        return True
+
+    @property
     def data(self):
         """The value of the data object, as a scalar (int, float, ...)."""
         return self.dtype(self._value)

--- a/devito/types/dimension.py
+++ b/devito/types/dimension.py
@@ -94,7 +94,7 @@ class Dimension(AbstractSymbol, ArgProvider):
 
     def __new_stage2__(cls, name, spacing=None):
         newobj = sympy.Symbol.__xnew__(cls, name)
-        newobj._spacing = spacing or Scalar(name='h_%s' % name)
+        newobj._spacing = spacing or Scalar(name='h_%s' % name, is_const=True)
         return newobj
 
     __xnew__ = staticmethod(__new_stage2__)
@@ -111,17 +111,17 @@ class Dimension(AbstractSymbol, ArgProvider):
     @cached_property
     def symbolic_size(self):
         """Symbolic size of the Dimension."""
-        return Scalar(name=self.size_name, dtype=np.int32)
+        return Scalar(name=self.size_name, dtype=np.int32, is_const=True)
 
     @cached_property
     def symbolic_min(self):
         """Symbol defining the minimum point of the Dimension."""
-        return Scalar(name=self.min_name, dtype=np.int32)
+        return Scalar(name=self.min_name, dtype=np.int32, is_const=True)
 
     @cached_property
     def symbolic_max(self):
         """Symbol defining the maximum point of the Dimension."""
-        return Scalar(name=self.max_name, dtype=np.int32)
+        return Scalar(name=self.max_name, dtype=np.int32, is_const=True)
 
     @cached_property
     def size_name(self):
@@ -515,8 +515,8 @@ class SubDimension(DerivedDimension):
 
     @classmethod
     def _symbolic_thickness(cls, name):
-        return (Scalar(name="%s_ltkn" % name, dtype=np.int32),
-                Scalar(name="%s_rtkn" % name, dtype=np.int32))
+        return (Scalar(name="%s_ltkn" % name, dtype=np.int32, is_const=True),
+                Scalar(name="%s_rtkn" % name, dtype=np.int32, is_const=True))
 
     @cached_property
     def _thickness_map(self):

--- a/devito/yask/operator.py
+++ b/devito/yask/operator.py
@@ -75,8 +75,7 @@ class OperatorYASK(Operator):
 
             try:
                 # Generate YASK grids and populate `yc_soln` with equations
-                gridmap = yaskit(trees, yc_soln)
-                local_grids = [i for i in gridmap if i.is_Array]
+                local_grids = yaskit(trees, yc_soln)
 
                 # Build the new IET nodes
                 yk_soln_obj = YaskSolnObject(namespace['code-soln-name'](n))

--- a/devito/yask/transformer.py
+++ b/devito/yask/transformer.py
@@ -72,7 +72,7 @@ def yaskit(trees, yc_soln):
                 # For sequential Iterations, the extent *must* be statically known,
                 # otherwise we don't know how to handle this
                 try:
-                    int(i.size())
+                    int(i.dim._thickness_map.get(i.size()))
                 except TypeError:
                     raise NotImplementedError("Found sequential Iteration with "
                                               "statically unknown extent")

--- a/devito/yask/transformer.py
+++ b/devito/yask/transformer.py
@@ -152,7 +152,7 @@ def make_yask_ast(expr, yc_soln, mapper):
             else:
                 return nfac.new_misc_index(expr.name)
         else:
-            # A DSE-generated temporary, which must have already been
+            # E.g., A DSE-generated temporary, which must have already been
             # encountered as a LHS of a previous expression
             assert function in mapper
             return mapper[function]
@@ -165,6 +165,13 @@ def make_yask_ast(expr, yc_soln, mapper):
             mapper[function] = yc_soln.new_grid(function.name, dimensions)
             # Allow number of time-steps to be set in YASK kernel.
             mapper[function].set_dynamic_step_alloc(True)
+            # We also get to know some relevant Dimension-related symbols
+            # For example, the min point of the `x` Dimension, `x_m`, should
+            # be mapped to YASK's `FIRST(x)`
+            for d in function.indices:
+                node = nfac.new_domain_index(d.name)
+                mapper[d.symbolic_min] = nfac.new_first_domain_index(node)
+                mapper[d.symbolic_max] = nfac.new_last_domain_index(node)
         indices = [make_yask_ast(i, yc_soln, mapper) for i in expr.indices]
         return mapper[function].new_grid_point(indices)
     elif expr.is_Add:

--- a/devito/yask/wrappers.py
+++ b/devito/yask/wrappers.py
@@ -300,9 +300,9 @@ class YaskContext(Signer):
             # different set of dimensions (e.g., a strict subset and/or some misc
             # dimensions). In such a case, an extra dummy grid is attached
             # `obj` examples: u(x, d), u(x, y, z)
-            dimensions = [make_yask_ast(i, yc_hook, {}) for i in self.dimensions]
+            dimensions = [make_yask_ast(i, yc_hook) for i in self.dimensions]
             yc_hook.new_grid('dummy_grid_full', dimensions)
-        dimensions = [make_yask_ast(i.root, yc_hook, {}) for i in obj.indices]
+        dimensions = [make_yask_ast(i.root, yc_hook) for i in obj.indices]
         yc_hook.new_grid('dummy_grid_true', dimensions)
 
         # Create 'hook' kernel solution
@@ -353,7 +353,7 @@ class YaskContext(Signer):
 
         # Apply compile-time optimizations
         if configuration['isa'] != 'cpp':
-            dimensions = [make_yask_ast(i, yc_soln, {}) for i in self.space_dimensions]
+            dimensions = [make_yask_ast(i, yc_soln) for i in self.space_dimensions]
             # Vector folding
             for i, j in zip(dimensions, configuration.yask['folding']):
                 yc_soln.set_fold_len(i, j)

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -12,9 +12,7 @@ pytestmark = skipif('ops')
 class TestDataBasic(object):
 
     def test_simple_indexing(self):
-        """
-        Tests packing/unpacking data in :class:`Function` objects.
-        """
+        """Test data packing/unpacking via basic indexing."""
         grid = Grid(shape=(16, 16, 16))
         u = Function(name='yu3D', grid=grid, space_order=0)
 
@@ -51,10 +49,7 @@ class TestDataBasic(object):
         assert np.all(u.data[4, :, 4] == block)
 
     def test_advanced_indexing(self):
-        """
-        Tests packing/unpacking data in :class:`Function` objects with more advanced
-        access functions.
-        """
+        """Test data packing/unpacking via advanced indexing."""
         grid = Grid(shape=(4, 4, 4))
         u = TimeFunction(name='yu4D', grid=grid, space_order=0, time_order=1)
         u.data[:] = 0.
@@ -69,10 +64,7 @@ class TestDataBasic(object):
         assert np.all(u.data[1, :, :, -1] == 0.)
 
     def test_halo_indexing(self):
-        """
-        Tests packing/unpacking data in :class:`Function` objects when some halo
-        region is present.
-        """
+        """Test data packing/unpacking in presence of a halo region."""
         domain_shape = (16, 16, 16)
         grid = Grid(shape=domain_shape)
         u = Function(name='yu3D', grid=grid, space_order=2)
@@ -93,10 +85,40 @@ class TestDataBasic(object):
         assert u.data[-1, -1, -1] == 0.
         assert u.data_with_halo[-1, -1, -1] == 3.
 
+    def test_broadcasting(self):
+        """
+        Test Data broadcasting, expected to behave as NumPy broadcasting.
+
+        Notes
+        -----
+        Refer to https://docs.scipy.org/doc/numpy-1.15.0/user/basics.broadcasting.html
+        for more info about NumPy broadcasting rules.
+        """
+        grid = Grid(shape=(4, 4, 4))
+        u = Function(name='yu3D', grid=grid)
+        u.data[:] = 2.
+
+        # Assign from array with lower-dimensional shape
+        v = np.ones(shape=(4, 4), dtype=u.dtype)
+        u.data[:] = v
+        assert np.all(u.data == 1.)
+
+        # Assign from array with higher-dimensional shape causes a ValueError exception
+        v = np.zeros(shape=(4, 4, 4, 4), dtype=u.dtype)
+        try:
+            u.data[:] = v
+        except ValueError:
+            assert True
+        except:
+            assert False
+
+        # Assign from array having shape with some 1-valued entries
+        v = np.zeros(shape=(4, 1, 4), dtype=u.dtype)
+        u.data[:] = v
+        assert np.all(u.data == 0.)
+
     def test_arithmetic(self):
-        """
-        Tests arithmetic operations between :class:`Data` objects and values.
-        """
+        """Test arithmetic operations involving Data objects."""
         grid = Grid(shape=(16, 16, 16))
         u = Function(name='yu3D', grid=grid, space_order=0)
         u.data[:] = 1
@@ -124,9 +146,7 @@ class TestDataBasic(object):
 
     @skipif('yask')
     def test_illegal_indexing(self):
-        """
-        Tests that indexing into illegal entries throws an exception.
-        """
+        """Tests that indexing into illegal entries throws an exception."""
         nt = 5
         grid = Grid(shape=(4, 4, 4))
         u = Function(name='u', grid=grid)
@@ -144,9 +164,7 @@ class TestDataBasic(object):
             pass
 
     def test_logic_indexing(self):
-        """
-        Tests logic indexing for stepping dimensions.
-        """
+        """Test logic indexing along stepping dimensions."""
         grid = Grid(shape=(4, 4, 4))
         v_mod = TimeFunction(name='v_mod', grid=grid)
 
@@ -233,9 +251,10 @@ class TestDataBasic(object):
 class TestDecomposition(object):
 
     """
-    .. note::
-
-        If these tests don't work, definitely TestDataDistributed won't behave
+    Notes
+    -----
+    If these tests don't work, there is no chance that the tests in TestDataDistributed
+    will pass.
     """
 
     def test_convert_index(self):

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -312,8 +312,9 @@ class TestDependenceAnalysis(object):
         ('u[x+1,y,z-1]', (AFFINE, AFFINE, AFFINE)),
         ('u[x+1,3,z-1]', (AFFINE, AFFINE, AFFINE)),
         ('u[sx+1,y,z-1]', (AFFINE, AFFINE, AFFINE)),
-        ('u[x+1,c,s]', (AFFINE, AFFINE, AFFINE)),
-        ('u[x+1,c+1,s*s]', (AFFINE, AFFINE, AFFINE)),
+        ('u[x+1,c,s]', (AFFINE, AFFINE, IRREGULAR)),
+        ('u[x+1,c,sc]', (AFFINE, AFFINE, AFFINE)),
+        ('u[x+1,c+1,sc*sc]', (AFFINE, AFFINE, AFFINE)),
         ('u[x*x+1,y,z]', (IRREGULAR, AFFINE, AFFINE)),
         ('u[x*y,y,z]', (IRREGULAR, AFFINE, AFFINE)),
         ('u[x + z,x + y,z*z]', (IRREGULAR, IRREGULAR, IRREGULAR)),
@@ -334,6 +335,7 @@ class TestDependenceAnalysis(object):
 
         u = Function(name='u', grid=grid)  # noqa
         c = Constant(name='c')  # noqa
+        sc = Scalar(name='sc', is_const=True)  # noqa
         s = Scalar(name='s')  # noqa
 
         ii = IterationInstance(eval(indexed))


### PR DESCRIPTION
the AFFINE property detection is now much smarter than it used to be , hence YASK can now offload more IETs (in particular, higdon-like boundary condition loops)