### PR TITLE
MPI enhancements 

### DIFF
--- a/devito/core/operator.py
+++ b/devito/core/operator.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 
 from devito.core.autotuning import autotune
-from devito.ir.iet import HaloOp, MetaCall, FindNodes, Transformer
+from devito.ir.iet import HaloSpot, MetaCall, FindNodes, Transformer
 from devito.ir.support import align_accesses
 from devito.parameters import configuration
 from devito.mpi import HaloExchangeBuilder
@@ -25,7 +25,7 @@ class OperatorCore(Operator):
 
         # Build send/recv Callables and Calls
         heb = HaloExchangeBuilder(is_threaded(kwargs.get("dle")), configuration['mpi'])
-        callables, calls = heb.make(FindNodes(HaloOp).visit(iet))
+        callables, calls = heb.make(FindNodes(HaloSpot).visit(iet))
 
         # Update the Operator internal state
         self._includes.append('mpi.h')

--- a/devito/core/operator.py
+++ b/devito/core/operator.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 
 from devito.core.autotuning import autotune
-from devito.ir.iet import List, HaloOp, MetaCall, FindNodes, Transformer
+from devito.ir.iet import HaloOp, MetaCall, FindNodes, Transformer
 from devito.ir.support import align_accesses
 from devito.parameters import configuration
 from devito.mpi import HaloExchangeBuilder
@@ -33,8 +33,7 @@ class OperatorCore(Operator):
                                              for i in callables]))
 
         # Transform the IET by adding in the `haloupdate` Calls
-        mapper = {k: List(body=v) for k, v in calls.items()}
-        iet = Transformer(mapper, nested=True).visit(iet)
+        iet = Transformer(calls, nested=True).visit(iet)
 
         return iet
 

--- a/devito/core/operator.py
+++ b/devito/core/operator.py
@@ -34,7 +34,7 @@ class OperatorCore(Operator):
                                              for i in callables]))
 
         # Transform the IET by adding in the `haloupdate` Calls
-        mapper = {k: List(body=v + list(k.body)) for k, v in calls.items()}
+        mapper = {k: List(body=v) for k, v in calls.items()}
         iet = Transformer(mapper, nested=True).visit(iet)
 
         return iet

--- a/devito/core/operator.py
+++ b/devito/core/operator.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 
 from devito.core.autotuning import autotune
-from devito.ir.iet import List, HaloSpot, MetaCall, FindNodes, Transformer
+from devito.ir.iet import List, HaloOp, MetaCall, FindNodes, Transformer
 from devito.ir.support import align_accesses
 from devito.parameters import configuration
 from devito.mpi import HaloExchangeBuilder
@@ -23,10 +23,9 @@ class OperatorCore(Operator):
         if configuration['mpi'] is False:
             return iet
 
-        # Build halo exchange Callables and Calls
-        halo_spots = FindNodes(HaloSpot).visit(iet)
+        # Build send/recv Callables and Calls
         heb = HaloExchangeBuilder(is_threaded(kwargs.get("dle")), configuration['mpi'])
-        callables, calls = heb.make(halo_spots)
+        callables, calls = heb.make(FindNodes(HaloOp).visit(iet))
 
         # Update the Operator internal state
         self._includes.append('mpi.h')

--- a/devito/dle/backends/advanced.py
+++ b/devito/dle/backends/advanced.py
@@ -68,7 +68,7 @@ class AdvancedRewriter(BasicRewriter):
                 hoistable = [i for i in needed[1:] if i.is_Hoistable]
                 mapper.update({i: None for i in hoistable})
                 hoistable = [i.halo_scheme for i in hoistable]
-                mapper[top] = HaloSpot(top.halo_scheme.union(hoistable))
+                mapper[top] = HaloSpot(top.halo_scheme.union(hoistable), top.key)
 
         iet = Transformer(mapper, nested=True).visit(iet)
 

--- a/devito/ir/iet/properties.py
+++ b/devito/ir/iet/properties.py
@@ -65,10 +65,14 @@ class HaloSpotProperty(Tag):
     pass
 
 
-HOISTABLE = HaloSpotProperty('hoistable')
-"""The HaloSpot can be squashed with a previous HaloSpot as all data dependences
-would still be honored."""
-
 USELESS = HaloSpotProperty('useless')
 """The HaloSpot can be ignored as an halo update at this point would be completely
 useless."""
+
+
+def hoistable(i):
+    """
+    The HaloSpot can be squashed with a previous HaloSpot as all data dependences
+    would still be honored.
+    """
+    return HaloSpotProperty('hoistable', i)

--- a/devito/ir/iet/scheduler.py
+++ b/devito/ir/iet/scheduler.py
@@ -14,7 +14,8 @@ __all__ = ['iet_build', 'iet_insert_C_decls']
 
 def iet_build(stree):
     """
-    Create an Iteration/Expression tree (IET) from a :class:`ScheduleTree`.
+    Create an Iteration/Expression tree (IET) from a ScheduleTree.
+
     The nodes in the returned IET are decorated with properties deriving from
     data dependence analysis.
     """
@@ -31,7 +32,7 @@ def iet_build(stree):
 
 
 def iet_make(stree):
-    """Create an IET from a :class:`ScheduleTree`."""
+    """Create an IET from a ScheduleTree."""
     nsections = 0
     queues = OrderedDict()
     for i in stree.visit():
@@ -67,13 +68,12 @@ def iet_make(stree):
 
 def iet_lower_dimensions(iet):
     """
-    Replace all :class:`DerivedDimension`s within the ``iet``'s expressions with
-    lower-level symbolic objects (other :class:`Dimension`s, or :class:`sympy.Symbol`).
+    Replace all DerivedDimensions within the ``iet``'s expressions with
+    lower-level symbolic objects (other Dimensions or Symbols).
 
-        * Array indices involving :class:`SteppingDimension`s are turned into
-          :class:`ModuloDimension`s.
+        * Array indices involving SteppingDimensions are turned into ModuloDimensions.
           Example: ``u[t+1, x] = u[t, x] + 1 >>> u[t1, x] = u[t0, x] + 1``
-        * Array indices involving :class:`ConditionalDimension`s used are turned into
+        * Array indices involving ConditionalDimensions used are turned into
           integer-division expressions.
           Example: ``u[t_sub, x] = u[time, x] >>> u[time / 4, x] = u[time, x]``
     """

--- a/devito/ir/iet/visitors.py
+++ b/devito/ir/iet/visitors.py
@@ -118,7 +118,7 @@ class PrintAST(Visitor):
         else:
             return self.indent + str(o)
 
-    def visit_HaloOp(self, o):
+    def visit_HaloSpot(self, o):
         self._depth += 1
         body = self._visit(o.children)
         self._depth -= 1
@@ -283,7 +283,7 @@ class CGen(Visitor):
         signature = c.FunctionDeclaration(c.Value(o.retval, o.name), decls)
         return c.FunctionBody(signature, c.Block(body))
 
-    def visit_HaloOp(self, o):
+    def visit_HaloSpot(self, o):
         body = flatten(self._visit(i) for i in o.children)
         return c.Collection(body)
 

--- a/devito/ir/iet/visitors.py
+++ b/devito/ir/iet/visitors.py
@@ -118,6 +118,9 @@ class PrintAST(Visitor):
         else:
             return self.indent + str(o)
 
+    def visit_HaloOp(self, o):
+        return self.indent + o.__repr__()
+
     def visit_Conditional(self, o):
         self._depth += 1
         then_body = self._visit(o.then_body)

--- a/devito/ir/iet/visitors.py
+++ b/devito/ir/iet/visitors.py
@@ -119,7 +119,10 @@ class PrintAST(Visitor):
             return self.indent + str(o)
 
     def visit_HaloOp(self, o):
-        return self.indent + o.__repr__()
+        self._depth += 1
+        body = self._visit(o.children)
+        self._depth -= 1
+        return self.indent + "%s\n%s" % (o.__repr__(), body)
 
     def visit_Conditional(self, o):
         self._depth += 1
@@ -279,6 +282,10 @@ class CGen(Visitor):
         decls = self._args_decl(params)
         signature = c.FunctionDeclaration(c.Value(o.retval, o.name), decls)
         return c.FunctionBody(signature, c.Block(body))
+
+    def visit_HaloOp(self, o):
+        body = flatten(self._visit(i) for i in o.children)
+        return c.Collection(body)
 
     def visit_Operator(self, o):
         # Kernel signature and body

--- a/devito/ir/iet/visitors.py
+++ b/devito/ir/iet/visitors.py
@@ -414,7 +414,7 @@ class MapNodes(Visitor):
         super(MapNodes, self).__init__()
         if parent_type is None:
             self.parent_type = Iteration
-        elif parent_type is 'any':
+        elif parent_type == 'any':
             self.parent_type = Node
         else:
             assert issubclass(parent_type, Node)

--- a/devito/ir/support/basic.py
+++ b/devito/ir/support/basic.py
@@ -823,8 +823,9 @@ class Scope(object):
                         is_flow = (r < w) or (r == w and r.lex_ge(w))
                     except TypeError:
                         # Non-integer vectors are not comparable.
-                        # Conservatively, we assume it is a dependence
-                        is_flow = True
+                        # Conservatively, we assume it is a dependence, unless
+                        # it's a read-for-increment
+                        is_flow = not r.is_read_increment
                     if is_flow:
                         found.append(Dependence(w, r))
         return found
@@ -840,8 +841,9 @@ class Scope(object):
                         is_anti = (r > w) or (r == w and r.lex_lt(w))
                     except TypeError:
                         # Non-integer vectors are not comparable.
-                        # Conservatively, we assume it is a dependence
-                        is_anti = True
+                        # Conservatively, we assume it is a dependence, unless
+                        # it's a read-for-increment
+                        is_anti = not r.is_read_increment
                     if is_anti:
                         found.append(Dependence(r, w))
         return found

--- a/devito/mpi/halo_scheme.py
+++ b/devito/mpi/halo_scheme.py
@@ -101,10 +101,6 @@ class HaloScheme(object):
         return self._mapper.__hash__()
 
     @cached_property
-    def components(self):
-        return tuple(HaloScheme(fmapper={k: v}) for k, v in self.fmapper.items())
-
-    @cached_property
     def fmapper(self):
         return OrderedDict([(i, self._mapper[i]) for i in
                             sorted(self._mapper, key=attrgetter('name'))])

--- a/devito/mpi/halo_scheme.py
+++ b/devito/mpi/halo_scheme.py
@@ -114,7 +114,9 @@ class HaloScheme(object):
         return {f: v.halos for f, v in self.fmapper.items()}
 
     def union(self, others):
-        """Create a HaloScheme from the union of ``self`` with ``others``."""
+        """
+        Create a new HaloScheme representing the union of ``self`` with other HaloSchemes.
+        """
         fmapper = dict(self.fmapper)
         for i in as_tuple(others):
             for k, v in i.fmapper.items():
@@ -126,6 +128,22 @@ class HaloScheme(object):
                 halos = tuple(filter_ordered(hse.halos + v.halos))
                 fmapper[k] = HaloSchemeEntry(hse.loc_indices, halos)
 
+        return HaloScheme(fmapper=fmapper)
+
+    def project(self, functions):
+        """
+        Create a new HaloScheme which only retains the HaloSchemeEntries corresponding
+        to the provided ``functions``.
+        """
+        fmapper = {k: v for k, v in self.fmapper.items() if k in as_tuple(functions)}
+        return HaloScheme(fmapper=fmapper)
+
+    def drop(self, functions):
+        """
+        Create a new HaloScheme which contains all entries in ``self`` except those
+        corresponding to the provided ``functions``.
+        """
+        fmapper = {k: v for k, v in self.fmapper.items() if k not in as_tuple(functions)}
         return HaloScheme(fmapper=fmapper)
 
 

--- a/devito/mpi/routines.py
+++ b/devito/mpi/routines.py
@@ -183,9 +183,9 @@ class BasicHaloExchangeBuilder(HaloExchangeBuilder):
                 # generated once for each (`ndim`, `halos`)
                 if (f.ndim, v) not in generated:
                     uniquekey = len([i for i in generated if isinstance(i, tuple)])
-                    generated[(f.ndim, v)] = [self._make_haloupdate(df, v.loc_indices,
-                                                                    hs.halos[f], extra,
-                                                                    uniquekey)]
+                    haloupdate = self._make_haloupdate(df, v.loc_indices, v.halos, extra,
+                                                       uniquekey)
+                    generated[(f.ndim, v)] = [haloupdate]
 
                 # `haloupdate` Call construction
                 comm = f.grid.distributor._obj_comm
@@ -197,7 +197,7 @@ class BasicHaloExchangeBuilder(HaloExchangeBuilder):
 
         # Polish retval
         callables = flatten(generated.values())
-        calls = {k: List(body=v) for k, v in calls.items()}
+        calls = {k: List(body=v + [k.body]) for k, v in calls.items()}
 
         return callables, calls
 

--- a/devito/mpi/routines.py
+++ b/devito/mpi/routines.py
@@ -195,7 +195,11 @@ class BasicHaloExchangeBuilder(HaloExchangeBuilder):
                 call = Call(generated[(f.ndim, v)][0].name, args)
                 calls.setdefault(hs, []).append(call)
 
-        return flatten(generated.values()), calls
+        # Polish retval
+        callables = flatten(generated.values())
+        calls = {k: List(body=v) for k, v in calls.items()}
+
+        return callables, calls
 
     def _handle_halowaitany(self, halo_wait_anys):
         return [], {i: None for i in halo_wait_anys}

--- a/devito/mpi/routines.py
+++ b/devito/mpi/routines.py
@@ -36,12 +36,12 @@ class HaloExchangeBuilder(object):
         self._threaded = threaded
 
     @abc.abstractmethod
-    def make(self, halo_ops):
+    def make(self, halo_spots):
         """
         Construct Callables and Calls implementing a halo exchange for the
-        provided HaloOps.
+        provided HaloSpots.
 
-        There are three types of HaloOp:
+        There are three types of HaloSpots:
 
             * ``HaloSpot``, representing send/recv operations;
             * ``HaloWaitAny``, representing wait operations;
@@ -64,9 +64,9 @@ class HaloExchangeBuilder(object):
         communication, then both ``HaloWaitAny`` and ``HaloCompAny`` will be
         trivial no-op (hence the "Any" suffix).
         """
-        ret = [self._handle_halospot([i for i in halo_ops if i.is_HaloSpot])]
-        ret.append(self._handle_halowaitany([i for i in halo_ops if i.is_HaloWaitAny]))
-        ret.append(self._handle_halocompany([i for i in halo_ops if i.is_HaloCompAny]))
+        ret = [self._handle_halospot(halo_spots)]
+        ret.append(self._handle_halowaitany([]))
+        ret.append(self._handle_halocompany([]))
 
         callables = []
         calls = {}

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -352,16 +352,14 @@ posix_memalign((void**)&bufs, 64, sizeof(float[buf_x_size][buf_y_size]));
 posix_memalign((void**)&bufg, 64, sizeof(float[buf_x_size][buf_y_size]));
 MPI_Request rrecv;
 MPI_Request rsend;
-MPI_Status ssend;
-MPI_Status srecv;
 MPI_Irecv((float *)bufs,buf_x_size*buf_y_size,MPI_FLOAT,fromrank,13,comm,&rrecv);
 if (torank != MPI_PROC_NULL)
 {
   gather3d((float *)bufg,buf_x_size,buf_y_size,f_vec,ogtime,ogx,ogy);
 }
 MPI_Isend((float *)bufg,buf_x_size*buf_y_size,MPI_FLOAT,torank,13,comm,&rsend);
-MPI_Wait(&rsend,&ssend);
-MPI_Wait(&rrecv,&srecv);
+MPI_Wait(&rsend,MPI_STATUS_IGNORE);
+MPI_Wait(&rrecv,MPI_STATUS_IGNORE);
 if (fromrank != MPI_PROC_NULL)
 {
   scatter3d((float *)bufs,buf_x_size,buf_y_size,f_vec,ostime,osx,osy);


### PR DESCRIPTION
This is based on #754 , which explains the diff

The main thing this PR does is changing the way the HaloSpots are scheduled and analysed within an IET.

Previously, HaloSpots were flatten out, so we could have:

```
HaloSpot(u)
HaloSpot(v)
Iteration
  Iteration
    Iteration
      Expression involving u and v
```

Now, a HaloSpot embeds the Iteration nest it "refers to" -- meaning, the Iteration nest requiring the halo exchange described by the HaloSpot itself. 

```
HaloSpot(u,v)
  Iteration
    Iteration
      Iteration
        Expression involving u and v
```

This has no immediate effect, but it will simplify implementation of computation/communication overlap (2 PRs far from this one)