### PR TITLE
Fix constant bug

### DIFF
--- a/devito/types/constant.py
+++ b/devito/types/constant.py
@@ -2,7 +2,7 @@ import numpy as np
 
 from devito.exceptions import InvalidArgument
 from devito.logger import warning
-from devito.tools import ArgProvider, memoized_meth
+from devito.tools import ArgProvider
 from devito.types.basic import AbstractCachedSymbol
 
 __all__ = ['Constant']

--- a/devito/types/constant.py
+++ b/devito/types/constant.py
@@ -70,7 +70,6 @@ class Constant(AbstractCachedSymbol, ArgProvider):
         """Tuple of argument names introduced by this symbol."""
         return (self.name,)
 
-    @memoized_meth
     def _arg_defaults(self, alias=None):
         """A map of default argument values defined by this symbol."""
         key = alias or self

--- a/tests/test_constant.py
+++ b/tests/test_constant.py
@@ -1,10 +1,10 @@
 import numpy as np
-import pytest
 
 from conftest import skipif
 from devito import Grid, Constant, Function, TimeFunction, Eq, solve, Operator
 
 pytestmark = skipif(['yask', 'ops'])
+
 
 class TestConst(object):
     """
@@ -16,35 +16,25 @@ class TestConst(object):
         Test that the default replacement rules return the same
         as standard FD.
         """
-        
-        from IPython import embed, os
 
         n = 5
         t = Constant(name='t', dtype=np.int32)
 
         grid = Grid(shape=(2, 2))
         x, y = grid.dimensions
-        
+
         f = TimeFunction(name='f', grid=grid, save=n+1)
-        #check = Function(name='check', grid=grid)
-
-        #f.data[:] = 0
+        f.data[:] = 0
         eq = Eq(f.dt-1)
-        #eq_test = Eq(check,f[t,x,y])
-
-        stencil = solve(eq, f.forward)
-        #print(stencil)
-        embed()
+        stencil = Eq(f.forward, solve(eq, f.forward))
         op = Operator([stencil])
-        
-        #op_test = Operator([eq_test])
+        op.apply(time_m=0, time_M=n-1, dt=1)
 
-        #
-        #for j in range(0,n):
-            ##if j>0:
-                ##t.data = j-1
-                ##op_check.apply()
-                ##assert(np.amax(check.data[:], axis=None) == j-1)
-                ##assert(np.amin(check.data[:], axis=None) == j-1)
-            #op.apply(time_m=j, time_M=j, dt=1)
-            #embed()
+        check = Function(name='check', grid=grid)
+        eq_test = Eq(check, f[t, x, y])
+        op_test = Operator([eq_test])
+        for j in range(0, n+1):
+                t.data = j  # Ensure constant is being updated correctly
+                op_test.apply(t=t)
+                assert(np.amax(check.data[:], axis=None) == j)
+                assert(np.amin(check.data[:], axis=None) == j)

--- a/tests/test_constant.py
+++ b/tests/test_constant.py
@@ -34,7 +34,7 @@ class TestConst(object):
         eq_test = Eq(check, f[t, x, y])
         op_test = Operator([eq_test])
         for j in range(0, n+1):
-                t.data = j  # Ensure constant is being updated correctly
-                op_test.apply(t=t)
-                assert(np.amax(check.data[:], axis=None) == j)
-                assert(np.amin(check.data[:], axis=None) == j)
+            t.data = j  # Ensure constant is being updated correctly
+            op_test.apply(t=t)
+            assert(np.amax(check.data[:], axis=None) == j)
+            assert(np.amin(check.data[:], axis=None) == j)

--- a/tests/test_constant.py
+++ b/tests/test_constant.py
@@ -1,0 +1,50 @@
+import numpy as np
+import pytest
+
+from conftest import skipif
+from devito import Grid, Constant, Function, TimeFunction, Eq, solve, Operator
+
+pytestmark = skipif(['yask', 'ops'])
+
+class TestConst(object):
+    """
+    Class for testing symbolic coefficients functionality
+    """
+
+    def test_const_change(self):
+        """
+        Test that the default replacement rules return the same
+        as standard FD.
+        """
+        
+        from IPython import embed, os
+
+        n = 5
+        t = Constant(name='t', dtype=np.int32)
+
+        grid = Grid(shape=(2, 2))
+        x, y = grid.dimensions
+        
+        f = TimeFunction(name='f', grid=grid, save=n+1)
+        #check = Function(name='check', grid=grid)
+
+        #f.data[:] = 0
+        eq = Eq(f.dt-1)
+        #eq_test = Eq(check,f[t,x,y])
+
+        stencil = solve(eq, f.forward)
+        #print(stencil)
+        embed()
+        op = Operator([stencil])
+        
+        #op_test = Operator([eq_test])
+
+        #
+        #for j in range(0,n):
+            ##if j>0:
+                ##t.data = j-1
+                ##op_check.apply()
+                ##assert(np.amax(check.data[:], axis=None) == j-1)
+                ##assert(np.amin(check.data[:], axis=None) == j-1)
+            #op.apply(time_m=j, time_M=j, dt=1)
+            #embed()


### PR DESCRIPTION
Setting `_arg_defaults` to be a `memoized_meth` of course resulted in things such as `const.data=j` not working. This fixes that and adds a little test ensuing that constant can be set as the user desires.