### PR TITLE
Update requirements

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -26,7 +26,6 @@ dependencies:
   - pytest-cov
   - multidict
   - frozendict
-  - gcc
   - pip:
     - "git+https://github.com/inducer/codepy"
     - pyrevolve==1.0.2

--- a/environment.yml
+++ b/environment.yml
@@ -26,8 +26,9 @@ dependencies:
   - pytest-cov
   - multidict
   - frozendict
+  - gcc
   - pip:
     - "git+https://github.com/inducer/codepy"
-    - "git+https://github.com/opesci/pyrevolve"
+    - pyrevolve==1.0.2
     - py-cpuinfo
     - anytree>=2.4.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -17,5 +17,5 @@ pytest-cov
 multidict
 frozendict
 anytree>=2.4.3
-git+https://github.com/opesci/pyrevolve
+pyrevolve==1.0.2
 distributed>=1.21.8


### PR DESCRIPTION
This short PR makes the following changes in the requirements/environment.yml setup:
- ~~Add gcc as a dependency in environment.yml so people following the conda procedure get a C compiler without having to explicitly install one. The last two installation issues could have been avoided with this.~~
- Fix the pyrevolve dependency to a specific version. This is so that we can issue a new release of pyrevolve for the new API - which would enable #771 to be tested on travis without breaking compatibility for people until it is merged. 