### PR TITLE
Minor fixes and speedup

### DIFF
--- a/examples/seismic/tti/tti_example.py
+++ b/examples/seismic/tti/tti_example.py
@@ -57,7 +57,7 @@ if __name__ == "__main__":
     parser.add_argument("--nbpml", default=40,
                         type=int, help="Number of PML layers around the domain")
     parser.add_argument("-k", dest="kernel", default='centered',
-                        choices=['centered', 'shifted', 'staggered'],
+                        choices=['centered', 'staggered'],
                         help="Choice of finite-difference kernel")
     parser.add_argument("-dse", default="advanced",
                         choices=["noop", "basic", "advanced",

--- a/examples/seismic/tti/wavesolver.py
+++ b/examples/seismic/tti/wavesolver.py
@@ -29,7 +29,7 @@ class AnisotropicWaveSolver(object):
         self._kwargs = kwargs
 
     @memoized_meth
-    def op_fwd(self, kernel='shifted', save=False):
+    def op_fwd(self, kernel='centered', save=False):
         """Cached operator for forward runs with buffered wavefield"""
         return ForwardOperator(self.model, save=save, geometry=self.geometry,
                                space_order=self.space_order,
@@ -56,11 +56,6 @@ class AnisotropicWaveSolver(object):
 
         :returns: Receiver, wavefield and performance summary
         """
-
-        # Space order needs to be halved in the shifted case to have an
-        # overall space_order discretization
-        self.space_order = self.space_order // 2 if kernel == 'shifted' \
-            else self.space_order
 
         if kernel == 'staggered':
             time_order = 1

--- a/tests/test_adjoint.py
+++ b/tests/test_adjoint.py
@@ -28,17 +28,16 @@ class TestAdjoint(object):
     @pytest.mark.parametrize('mkey, shape, kernel, space_order, nbpml', [
         # 1 tests with varying time and space orders
         ('layers', (60, ), 'OT2', 4, 10), ('layers', (60, ), 'OT2', 8, 10),
-        ('layers', (60, ), 'OT4', 4, 10), ('layers', (60, ), 'OT4', 8, 10),
+        ('layers', (60, ), 'OT4', 4, 10),
         # 2D tests with varying time and space orders
         ('layers', (60, 70), 'OT2', 4, 10), ('layers', (60, 70), 'OT2', 8, 10),
-        ('layers', (60, 70), 'OT2', 12, 10), ('layers', (60, 70), 'OT4', 4, 10),
-        ('layers', (60, 70), 'OT4', 8, 10), ('layers', (60, 70), 'OT4', 12, 10),
+        ('layers', (60, 70), 'OT2', 12, 10), ('layers', (60, 70), 'OT4', 8, 10),
         # 3D tests with varying time and space orders
         ('layers', (60, 70, 80), 'OT2', 4, 10), ('layers', (60, 70, 80), 'OT2', 8, 10),
         ('layers', (60, 70, 80), 'OT2', 12, 10), ('layers', (60, 70, 80), 'OT4', 4, 10),
-        ('layers', (60, 70, 80), 'OT4', 8, 10), ('layers', (60, 70, 80), 'OT4', 12, 10),
         # Constant model in 2D and 3D
         ('constant', (60, 70), 'OT2', 8, 14), ('constant', (60, 70, 80), 'OT2', 8, 14),
+        ('constant', (60, 70), 'OT4', 12, 14), ('constant', (60, 70, 80), 'OT4', 4, 14),
     ])
     def test_adjoint_F(self, mkey, shape, kernel, space_order, nbpml):
         """

--- a/tests/test_dse.py
+++ b/tests/test_dse.py
@@ -150,7 +150,6 @@ def test_tti_rewrite_aggressive(tti_nodse):
 
 @switchconfig(profiling='advanced')
 @pytest.mark.parametrize('kernel,space_order,expected', [
-    ('shifted', 8, 355), ('shifted', 16, 622),
     ('centered', 8, 168), ('centered', 16, 300)
 ])
 def test_tti_rewrite_aggressive_opcounts(kernel, space_order, expected):
@@ -391,3 +390,23 @@ def test_makeit_ssa(exprs, exp_u, exp_v):
 
     assert np.all(u.data == exp_u)
     assert np.all(v.data == exp_v)
+
+
+def test_time_dependent_split():
+    grid = Grid(shape=(4, 4))
+    u = TimeFunction(name='u', grid=grid, time_order=2, space_order=1, save=3)
+    v = TimeFunction(name='v', grid=grid, time_order=2, space_order=0, save=3)
+
+    # The second equation needs a full loop over x/y for u then
+    # a full one over x.y for v
+    eq = [Eq(u.forward, 2 + grid.time_dim),
+          Eq(v.forward, u.forward.dx + u.forward.dy + 1)]
+    op = Operator(eq, dse='advanced', dle='basic')
+
+    trees = retrieve_iteration_tree(op)
+    assert len(trees) == 2
+
+    op()
+
+    assert np.allclose(u.data[1, 2:-2, 2:-2], 3.0)
+    assert np.allclose(v.data[1, :, :], 1.0)

--- a/tests/test_dse.py
+++ b/tests/test_dse.py
@@ -392,21 +392,23 @@ def test_makeit_ssa(exprs, exp_u, exp_v):
     assert np.all(v.data == exp_v)
 
 
-def test_time_dependent_split():
-    grid = Grid(shape=(4, 4))
-    u = TimeFunction(name='u', grid=grid, time_order=2, space_order=1, save=3)
+@pytest.mark.parametrize('dse', ['noop', 'basic', 'advanced', 'aggressive'])
+@pytest.mark.parametrize('dle', ['noop', 'basic', 'advanced', 'speculative'])
+def test_time_dependent_split(dse, dle):
+    grid = Grid(shape=(10, 10))
+    u = TimeFunction(name='u', grid=grid, time_order=2, space_order=2, save=3)
     v = TimeFunction(name='v', grid=grid, time_order=2, space_order=0, save=3)
 
     # The second equation needs a full loop over x/y for u then
     # a full one over x.y for v
     eq = [Eq(u.forward, 2 + grid.time_dim),
           Eq(v.forward, u.forward.dx + u.forward.dy + 1)]
-    op = Operator(eq, dse='advanced', dle='basic')
+    op = Operator(eq, dse=dse, dle=dle)
 
     trees = retrieve_iteration_tree(op)
     assert len(trees) == 2
 
     op()
 
-    assert np.allclose(u.data[1, 2:-2, 2:-2], 3.0)
-    assert np.allclose(v.data[1, :, :], 1.0)
+    assert np.allclose(u.data[2, :, :], 3.0)
+    assert np.allclose(v.data[1, 1:-1, 1:-1], 1.0)


### PR DESCRIPTION

To small main thing:

- fix the `__new__` in sources that was ignoring the cache and therefore failing with time derivative for these sources

- reduces the number of test in test_adjoint to speed up Travis and spread the different space orders over these OT 4 test so that we still test all of it.