### PR TITLE
Performance optimisation improvements

### DIFF
--- a/devito/__init__.py
+++ b/devito/__init__.py
@@ -130,13 +130,15 @@ def infer_cpu():
 # - Some optimizations may not be applied to the generated code.
 # - The compiler performs more type and value checking
 def _switch_cpu(develop_mode):
-    if bool(develop_mode) is False:
-        isa, platform = infer_cpu()
-        configuration['isa'] = os.environ.get('DEVITO_ISA', isa)
-        configuration['platform'] = os.environ.get('DEVITO_PLATFORM', platform)
+    isa = os.environ.get('DEVITO_ISA')
+    platform = os.environ.get('DEVITO_PLATFORM')
+    if bool(develop_mode) is True:
+        configuration['isa'] = isa or 'cpp'
+        configuration['platform'] = platform or 'intel64'
     else:
-        configuration['isa'] = 'cpp'
-        configuration['platform'] = 'intel64'
+        default_isa, default_platform = infer_cpu()
+        configuration['isa'] = isa or default_isa
+        configuration['platform'] = platform or default_platform
 configuration.add('develop-mode', True, [False, True], _switch_cpu)  # noqa
 
 # Initialize the configuration, either from the environment or

--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -225,20 +225,6 @@ class GNUCompiler(Compiler):
         self.MPICXX = 'mpicxx'
 
 
-class GNUCompilerNoAVX(GNUCompiler):
-
-    """
-    GNU JIT compiler with AVX suppressed.
-
-    This may be used on MAC OS to work around a known gcc bug when compiling with
-    AVX enabled.
-    """
-
-    def __init__(self, *args, **kwargs):
-        super(GNUCompilerNoAVX, self).__init__(*args, **kwargs)
-        self.cflags += ['-mno-avx']
-
-
 class ClangCompiler(Compiler):
 
     def __init__(self, *args, **kwargs):
@@ -480,8 +466,6 @@ compiler_registry = {
     'custom': CustomCompiler,
     'gnu': GNUCompiler,
     'gcc': GNUCompiler,
-    'gcc-noavx': GNUCompilerNoAVX,
-    'gnu-noavx': GNUCompilerNoAVX,
     'clang': ClangCompiler,
     'osx': ClangCompiler,
     'intel': IntelCompiler,

--- a/devito/core/autotuning.py
+++ b/devito/core/autotuning.py
@@ -254,6 +254,9 @@ def make_calculate_parblocks(trees, blockable, nthreads):
 
 
 def generate_block_shapes(blockable, args, level):
+    if not blockable:
+        return []
+
     # Max attemptable block shape
     max_bs = tuple((d.step.name, d.max_step.subs(args)) for d in blockable)
 

--- a/devito/core/operator.py
+++ b/devito/core/operator.py
@@ -1,4 +1,5 @@
 from devito.core.autotuning import autotune
+from devito.dle import NThreads
 from devito.ir.support import align_accesses
 from devito.parameters import configuration
 from devito.operator import Operator
@@ -36,3 +37,12 @@ class OperatorCore(Operator):
         self._state.setdefault('autotuning', []).append(summary)
 
         return args
+
+    @property
+    def nthreads(self):
+        nthreads = [i for i in self.input if isinstance(i, NThreads)]
+        if len(nthreads) == 0:
+            return 1
+        else:
+            assert len(nthreads) == 1
+            return nthreads.pop()

--- a/devito/data/allocators.py
+++ b/devito/data/allocators.py
@@ -2,6 +2,7 @@ import abc
 from functools import reduce
 from operator import mul
 import mmap
+import os
 
 import numpy as np
 import ctypes
@@ -307,6 +308,11 @@ ALLOC_NUMA_ANY = NumaAllocator('any')
 ALLOC_NUMA_LOCAL = NumaAllocator('local')
 
 
+def infer_knl_mode():
+    path = os.path.join('sys', 'bus', 'node', 'devices', 'node1')
+    return 'flat' if os.path.exists(path) else 'cache'
+
+
 def default_allocator():
     """
     Return a suitable MemoryAllocator for the architecture on which the process
@@ -336,7 +342,7 @@ def default_allocator():
     if configuration['develop-mode']:
         return ALLOC_GUARD
     elif NumaAllocator.available():
-        if configuration['platform'] == 'knl':
+        if configuration['platform'] == 'knl' and infer_knl_mode() == 'flat':
             return ALLOC_KNL_MCDRAM
         else:
             return ALLOC_NUMA_LOCAL

--- a/devito/dle/parallelizer.py
+++ b/devito/dle/parallelizer.py
@@ -6,13 +6,15 @@ import cgen as c
 import psutil
 from sympy import Function, Or
 
-from devito.ir.iet import (Call, Conditional, Block, Expression, List, Prodder,
-                           FindSymbols, FindNodes, Return, COLLAPSED, Transformer,
-                           IsPerfectIteration, retrieve_iteration_tree, filter_iterations)
+from devito.ir import (DummyEq, Call, Conditional, Block, Expression, List, Prodder,
+                       FindSymbols, FindNodes, Return, COLLAPSED, Transformer,
+                       IsPerfectIteration, retrieve_iteration_tree, filter_iterations,
+                       compose_nodes)
+from devito.logger import dle_warning
 from devito.symbolics import CondEq
 from devito.parameters import configuration
-from devito.tools import memoized_func
-from devito.types import Constant, Symbol
+from devito.tools import is_integer, memoized_func
+from devito.types import Constant, Dimension, Symbol
 
 
 @memoized_func
@@ -78,6 +80,12 @@ class SingleThreadProdder(Conditional, Prodder):
 
 class Ompizer(object):
 
+    NESTED = 2
+    """
+    Use nested parallelism if the number of hyperthreads per core is greater
+    than this threshold.
+    """
+
     COLLAPSE = 32
     """
     Use a collapse clause if the number of available physical cores is greater
@@ -86,6 +94,8 @@ class Ompizer(object):
 
     lang = {
         'for': lambda i: c.Pragma('omp for collapse(%d) schedule(static)' % i),
+        'par-for': lambda i: c.Pragma('omp parallel for collapse(%d) schedule(static)'
+                                      % i),
         'simd-for': c.Pragma('omp simd'),
         'simd-for-aligned': lambda i, j: c.Pragma('omp simd aligned(%s:%d)' % (i, j)),
         'atomic': c.Pragma('omp atomic update')
@@ -107,91 +117,158 @@ class Ompizer(object):
             self.key = lambda i: i.is_ParallelRelaxed and not i.is_Vectorizable
         self.nthreads = NThreads(name='nthreads')
 
-    def _find_collapsable(self, root, candidates):
-        # Apply heuristic
-        if ncores() < Ompizer.COLLAPSE:
-            return [root]
+    def _make_atomic_incs(self, partree):
+        if not partree.is_ParallelAtomic:
+            return partree
+        # Introduce one `omp atomic` pragma for each increment
+        exprs = FindNodes(Expression).visit(partree)
+        exprs = [i for i in exprs if i.is_Increment and not i.is_ForeignExpression]
+        mapper = {i: List(header=self.lang['atomic'], body=i) for i in exprs}
+        partree = Transformer(mapper).visit(partree)
+        return partree
 
-        # To be collapsable, two Iterations must be perfectly nested
-        if not IsPerfectIteration().visit(root):
-            return [root]
-
-        # The OpenMP specification forbids collapsed loops to use iteration variables
-        # in initializer expressions. For example, the following is forbidden:
-        #
-        # #pragma omp ... collapse(2)
-        # for (int i = ... )
-        #   for (int j = i ...)
-        #     ...
-        #
-        # Below, we make sure this won't happen
-        collapsable = []
-        for n, i in enumerate(candidates):
-            if any(j.dim in i.symbolic_min.free_symbols for j in candidates[:n]):
-                break
-            collapsable.append(i)
-        return collapsable
-
-    def _make_parallel_tree(self, root, collapsable):
-        """Parallelize the IET rooted in `root`."""
-        ncollapse = len(collapsable)
-        parallel = self.lang['for'](ncollapse)
-
-        pragmas = root.pragmas + (parallel,)
-        properties = root.properties + (COLLAPSED(ncollapse),)
-
-        # Introduce the `omp for` pragma
-        mapper = OrderedDict()
-        if root.is_ParallelAtomic:
-            # Introduce the `omp atomic` pragmas
-            exprs = FindNodes(Expression).visit(root)
-            exprs = [i for i in exprs if i.is_Increment and not i.is_ForeignExpression]
-            subs = {i: List(header=self.lang['atomic'], body=i) for i in exprs}
-            handle = Transformer(subs).visit(root)
-            mapper[root] = handle._rebuild(pragmas=pragmas, properties=properties)
-        else:
-            mapper[root] = root._rebuild(pragmas=pragmas, properties=properties)
-        root = Transformer(mapper).visit(root)
-
+    def _make_atomic_prodders(self, partree):
         # Atomic-ize any single-thread Prodders in the parallel tree
-        mapper = {i: SingleThreadProdder(i) for i in FindNodes(Prodder).visit(root)}
-        root = Transformer(mapper).visit(root)
+        mapper = {i: SingleThreadProdder(i) for i in FindNodes(Prodder).visit(partree)}
+        partree = Transformer(mapper).visit(partree)
+        return partree
 
-        return root
+    def _make_partree(self, candidates, omp_pragma):
+        """Parallelize `root` attaching a suitable OpenMP pragma."""
+        assert candidates
+        root = candidates[0]
+
+        # Get the collapsable Iterations
+        collapsable = []
+        if ncores() >= Ompizer.COLLAPSE and IsPerfectIteration().visit(root):
+            # The OpenMP specification forbids collapsed loops to use iteration variables
+            # in initializer expressions. For example, the following is forbidden:
+            #
+            # #pragma omp ... collapse(2)
+            # for (i = ... )
+            #   for (j = i ...)
+            #     ...
+            #
+            # Below, we make sure this won't happen
+            for n, i in enumerate(candidates[1:], 1):
+                if any(j.dim in i.symbolic_min.free_symbols for j in candidates[:n]):
+                    break
+                collapsable.append(i)
+
+        # Attach an OpenMP pragma-for with a collapse clause
+        ncollapse = 1 + len(collapsable)
+        partree = root._rebuild(pragmas=root.pragmas + (omp_pragma(ncollapse),),
+                                properties=root.properties + (COLLAPSED(ncollapse),))
+
+        collapsed = [partree] + collapsable
+
+        return root, partree, collapsed
+
+    def _make_parregion(self, partree):
+        # Build the `omp-parallel` region
+        private = [i for i in FindSymbols().visit(partree)
+                   if i.is_Array and i._mem_stack]
+        private = sorted(set([i.name for i in private]))
+        return ParallelRegion(partree, self.nthreads, private)
+
+    def _make_guard(self, partree, collapsed):
+        # Do not enter the parallel region if the step increment is 0; this
+        # would raise a `Floating point exception (core dumped)` in some OpenMP
+        # implementations. Note that using an OpenMP `if` clause won't work
+        cond = [CondEq(i.step, 0) for i in collapsed if isinstance(i.step, Symbol)]
+        cond = Or(*cond)
+        if cond != False:  # noqa: `cond` may be a sympy.False which would be == False
+            partree = List(body=[Conditional(cond, Return()), partree])
+        return partree
+
+    def _make_nested_partree(self, partree):
+        # Apply heuristic
+        if nhyperthreads() <= Ompizer.NESTED:
+            return partree
+
+        # Note: there might be multiple sub-trees amenable to nested parallelism,
+        # hence we loop over all of them
+        #
+        # for (i = ... )  // outer parallelism
+        #   for (j0 = ...)  // first source of nested parallelism
+        #     ...
+        #   for (j1 = ...)  // second source of nested parallelism
+        #     ...
+        mapper = {}
+        for tree in retrieve_iteration_tree(partree):
+            index = tree.index(partree)
+            outer = tree[index:index + partree.ncollapsed]
+            inner = tree[index + partree.ncollapsed:]
+
+            # Heuristic: nested parallelism is applied only if the top nested
+            # parallel Iteration iterates *within* the top outer parallel Iteration
+            # (i.e., the outer is a loop over blocks, while the nested is a loop
+            # within a block)
+            candidates = []
+            for i in inner:
+                if any(is_integer(j.step - i.symbolic_size) for j in outer):
+                    candidates.append(i)
+                elif candidates:
+                    # If there's at least one candidate but `i` doesn't honor the
+                    # heuristic above, then we break, as the candidates must be
+                    # perfectly nested
+                    break
+            if not candidates:
+                continue
+
+            # Introduce nested parallelism
+            subroot, _, collapsed = self._make_partree(candidates, self.lang['par-for'])
+
+            # The OpenMP specification forbids that nested parallel loops' iteration
+            # variables depend on any of the outer parallel loops' iteration variables.
+            # Therefore, we here apply the following transformation:
+            #
+            # for (i = ...)  // outer parallelism              for (i = ...)
+            #   for (j = i ...)  // nested parallelism  ---->    for (j = 0 ...)
+            #     ...                                              j' = i + j
+            #                                                      ...
+            rebuilt = [i._rebuild(dimension=Dimension(name='n%s' % i.dim.name),
+                                  limits=(0, i.symbolic_size - 1, 1), offsets=(0, 0))
+                       for i in collapsed]
+            exprs = [Expression(DummyEq(i.dim, i.symbolic_min + j.dim))
+                     for i, j in zip(collapsed, rebuilt)]
+            subpartree = compose_nodes(rebuilt + [exprs + list(rebuilt[-1].nodes)])
+
+            mapper[subroot] = subpartree
+
+        partree = Transformer(mapper).visit(partree)
+
+        return partree
 
     def make_parallel(self, iet):
         """Transform ``iet`` by introducing shared-memory parallelism."""
         mapper = OrderedDict()
         for tree in retrieve_iteration_tree(iet):
-            # Get the first omp-parallelizable Iteration in `tree`
+            # Get the omp-parallelizable Iterations in `tree`
             candidates = filter_iterations(tree, key=self.key)
             if not candidates:
                 continue
-            root = candidates[0]
 
-            # Determine the number of collapsable Iterations
-            collapsable = self._find_collapsable(root, candidates)
+            # Outer parallelism
+            root, partree, collapsed = self._make_partree(candidates, self.lang['for'])
 
-            # Build the `omp-for` tree
-            partree = self._make_parallel_tree(root, collapsable)
+            # Nested parallelism
+            partree = self._make_nested_partree(partree)
 
-            # Find out the thread-private and thread-shared variables
-            private = [i for i in FindSymbols().visit(partree)
-                       if i.is_Array and i._mem_stack]
+            # Ensure increments are atomic
+            partree = self._make_atomic_incs(partree)
 
-            # Build the `omp-parallel` region
-            private = sorted(set([i.name for i in private]))
-            partree = ParallelRegion(partree, self.nthreads, private)
+            # Ensure single-thread prodders are atomic
+            partree = self._make_atomic_prodders(partree)
 
-            # Do not enter the parallel region if the step increment is 0; this
-            # would raise a `Floating point exception (core dumped)` in some OpenMP
-            # implementations. Note that using an OpenMP `if` clause won't work
-            cond = [CondEq(i.step, 0) for i in collapsable if isinstance(i.step, Symbol)]
-            cond = Or(*cond)
-            if cond != False:  # noqa: `cond` may be a sympy.False which would be == False
-                partree = List(body=[Conditional(cond, Return()), partree])
+            # Wrap within a parallel region, declaring private and shared variables
+            parregion = self._make_parregion(partree)
 
-            mapper[root] = partree
+            # Protect the parallel region in case of 0-valued step increments
+            parregion = self._make_guard(parregion, collapsed)
+
+            mapper[root] = parregion
+
         iet = Transformer(mapper).visit(iet)
 
         return iet, {'args': [self.nthreads] if mapper else [],

--- a/devito/dse/backends/common.py
+++ b/devito/dse/backends/common.py
@@ -55,15 +55,6 @@ class AbstractRewriter(object):
     """
     tempname = 'r'
 
-    """
-    Bag of thresholds, used to trigger or prevent certain transformations.
-    """
-    thresholds = {
-        'min-cost-alias': 10,
-        'min-cost-factorize': 100,
-        'max-operands': 40,
-    }
-
     def __init__(self, profile=True, template=None):
         self.profile = profile
 

--- a/devito/ir/iet/nodes.py
+++ b/devito/ir/iet/nodes.py
@@ -23,7 +23,7 @@ from devito.types.basic import AbstractFunction
 __all__ = ['Node', 'Block', 'Expression', 'Element', 'Callable', 'Call', 'Conditional',
            'Iteration', 'List', 'LocalExpression', 'Section', 'TimedList', 'Prodder',
            'MetaCall', 'ArrayCast', 'ForeignExpression', 'HaloSpot', 'IterationTree',
-           'ExpressionBundle', 'Increment']
+           'ExpressionBundle', 'Increment', 'Return']
 
 # First-class IET nodes
 
@@ -806,6 +806,9 @@ class Prodder(Call):
     @property
     def periodic(self):
         return self._periodic
+
+
+Return = lambda i='': Element(c.Statement('return%s' % ((' %s' % i) if i else i)))
 
 
 # Nodes required for distributed-memory halo exchange

--- a/devito/profiling.py
+++ b/devito/profiling.py
@@ -191,9 +191,13 @@ class Timer(CompositeObject):
         super(Timer, self).__init__(name, 'profiler', [(i, c_double) for i in sections])
 
     def reset(self):
-        for i, _ in self.pfields:
+        for i in self.fields:
             setattr(self.value._obj, i, 0.0)
         return self.value
+
+    @property
+    def total(self):
+        return sum(getattr(self.value._obj, i) for i in self.fields)
 
     @property
     def sections(self):

--- a/devito/types/basic.py
+++ b/devito/types/basic.py
@@ -885,13 +885,13 @@ class Object(AbstractObject, ArgProvider):
         else:
             return {self.name: self.value}
 
-    def _arg_values(self, args, **kwargs):
+    def _arg_values(self, args=None, **kwargs):
         """
         Produce runtime values for this Object after evaluating user input.
 
         Parameters
         ----------
-        args : dict
+        args : dict, optional
             Known argument values.
         **kwargs
             Dictionary of user-provided argument overrides.
@@ -899,7 +899,7 @@ class Object(AbstractObject, ArgProvider):
         if self.name in kwargs:
             return {self.name: kwargs.pop(self.name)}
         else:
-            return {}
+            return self._arg_defaults()
 
 
 class CompositeObject(Object):

--- a/devito/yask/types.py
+++ b/devito/yask/types.py
@@ -259,6 +259,10 @@ class YaskGridObject(basic.Object):
         self.mapped_function_name = mapped_function_name
         self.name = namespace['code-grid-name'](mapped_function_name)
 
+    def _arg_values(self, args=None, **kwargs):
+        # The C-pointer to a YASK grid is provided directly by Function/TimeFunction
+        return {}
+
     # Pickling support
     _pickle_args = ['mapped_function_name']
     _pickle_kwargs = []

--- a/examples/seismic/acoustic/acoustic_example.py
+++ b/examples/seismic/acoustic/acoustic_example.py
@@ -42,11 +42,6 @@ def run(shape=(50, 50, 50), spacing=(20.0, 20.0, 20.0), tn=1000.0,
                             space_order=space_order, kernel=kernel,
                             preset=preset, **kwargs)
 
-    # Smooth velocity
-    initial_vp = Function(name='v0', grid=solver.model.grid, space_order=space_order)
-    smooth(initial_vp, solver.model.m)
-    dm = np.float32(initial_vp.data**2 - solver.model.m.data)
-
     info("Applying Forward")
     # Whether or not we save the whole time history. We only need the full wavefield
     # with 'save=True' if we compute the gradient without checkpointing, if we use
@@ -64,6 +59,11 @@ def run(shape=(50, 50, 50), spacing=(20.0, 20.0, 20.0), tn=1000.0,
 
     if not full_run:
         return summary.gflopss, summary.oi, summary.timings, [rec, u.data]
+
+    # Smooth velocity
+    initial_vp = Function(name='v0', grid=solver.model.grid, space_order=space_order)
+    smooth(initial_vp, solver.model.m)
+    dm = np.float32(initial_vp.data**2 - solver.model.m.data)
 
     info("Applying Adjoint")
     solver.adjoint(rec, autotune=autotune)

--- a/scripts/set_omp_pinning.sh
+++ b/scripts/set_omp_pinning.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+
+
+#function to display commands
+exe() { echo "$@" ; "$@" ; }
+
+help() {
+    echo "Usage: source set_omp_pinning [PLATFORM | reset | man]"
+    echo "Possible values for PLATFORM are: [$platforms]"
+    echo "With reset, delete any pre-existing pinning configuration and exit"
+    echo "With man, display useful information about pinning-related env vars and exit"
+}
+
+platforms="snb ivb hsw bdw skx knl"
+
+if [[ -z $1 || $1 == "--help" ]]; then
+    help
+elif [[ $1 == "reset" ]]; then
+    exe unset OMP_DISPLAY_AFFINITY
+    exe unset OMP_NESTED
+    exe unset OMP_MAX_ACTIVE_LEVELS
+    exe unset OMP_PLACES
+    exe unset OMP_PROC_BIND
+    exe unset KMP_HOT_TEAMS
+    exe unset KMP_HOT_TEAMS_MAX_LEVELS
+elif [[ $1 == "man" ]]; then
+    cat << EOF
+OpenMP standard environment variables
+-------------------------------------
+OMP_PLACES:
+  a list of places that threads can be pinned on:
+  – threads: Each place corresponds to a single hardware thread
+             on the target machine
+  – cores: Each	place corresponds to a single core (having one or more
+           hardware threads) on the target machine
+  – sockets: Each place corresponds to a single socket (consisting of one or
+             more cores) on the target machine
+  – A list with explicit place values, such as:
+      "{0,1,2,3},{4,5,6,7},{8,9,10,11},{12,13,14,15}"
+      "{0:4},{4:4},{8:4},{12:4}"
+
+OMP_PROC_BIND:
+  the thread affinity policy to be used for parallel regions
+  at the corresponding nested level:
+  – spread: Bind threads as evenly distributed (spread) as possible
+  – close: Bind threads close to the master thread while still distributing
+           threads for load balancing, wrap around once each place receives
+           one thread
+  – master: Bind threads the same place as the master thread
+
+OMP_NESTED:
+  enable/disable nested parallelism. Possible values are true|false. Most
+  compilers keep it disabled by default
+
+Intel-specific environment variables
+------------------------------------
+KMP_HOT_TEAMS:
+  enable/disable hot teams. Disabled by default.
+
+KMP_HOT_TEAMS_MAX_LEVEL:
+  The value set will be the maximum depth for which hot teams will be
+  maintained. By default, only the outermost parallel region is treated
+  as a hot team.
+EOF
+elif [[ $1 == @(snb|ivb|hsw|bdw|skx) ]]; then
+    exe export OMP_DISPLAY_AFFINITY=true
+    exe unset OMP_NESTED
+    exe export OMP_PLACES=cores
+    exe export OMP_PROC_BIND=close
+elif [[ $1 == "knl" ]]; then
+    echo "Setting for nested parallelism"
+    exe export OMP_DISPLAY_AFFINITY=true
+    exe export OMP_NESTED=true
+    exe export OMP_MAX_ACTIVE_LEVELS=2
+    exe export OMP_PLACES=threads
+    exe export OMP_PROC_BIND=spread,close
+    exe export KMP_HOT_TEAMS=1
+    exe export KMP_HOT_TEAMS_MAX_LEVELS=2
+    echo "Note: the KMP_ evn vars are Intel-compiler specific"
+else
+    help
+fi

--- a/tests/test_autotuner.py
+++ b/tests/test_autotuner.py
@@ -204,7 +204,7 @@ def test_discarding_runs():
 
 
 @skipif('nompi')
-@pytest.mark.parallel(mode=2)
+@pytest.mark.parallel(mode=[(2, 'diag'), (2, 'full')])
 def test_at_w_mpi():
     """Make sure autotuning works in presence of MPI. MPI ranks work
     in isolation to determine the best block size, locally."""
@@ -235,3 +235,15 @@ def test_at_w_mpi():
         assert np.all(f._data_ro_with_inhalo[:, :, -1] == 1)
     else:
         assert np.all(f._data_ro_with_inhalo[:, :, 0] == 1)
+
+    # Finally, try running w/o AT, just to be sure nothing was broken
+    f.data_with_halo[:] = 1.
+    op.apply(time=2)
+    if LEFT in glb_pos_map[y]:
+        assert np.all(f.data_ro_domain[1, :, 0] == 5.)
+        assert np.all(f.data_ro_domain[1, :, 1] == 7.)
+        assert np.all(f.data_ro_domain[1, :, 2:4] == 8.)
+    else:
+        assert np.all(f.data_ro_domain[1, :, 4:6] == 8)
+        assert np.all(f.data_ro_domain[1, :, 6] == 7)
+        assert np.all(f.data_ro_domain[1, :, 7] == 5)


### PR DESCRIPTION
This PR adds:

* A first version of nested shared-memory parallelism, still based on OpenMP
* The capability of autotuning in presence of MPI (the MPI ranks tune themselves autonomously in preemptive/destructive mode)

Also it fixes/tweaks:

* Autotuning when there are multiple blocked loop nests in the same operator (now it doesn't tune over the cartesian product of all possible block shapes, but rather it tunes each loop nest individually)
* The use of OpenMP collapsing in some nasty cases

Finally, it ships (as usual) a number of small tweaks throughout the codebase

PR equipped with new tests oc

fixes #143 