### PR TITLE
Rework Platform-related machinery

### DIFF
--- a/benchmarks/user/benchmark.py
+++ b/benchmarks/user/benchmark.py
@@ -56,12 +56,11 @@ def option_performance(f):
 
     _preset = {
         # Fixed
-        'O1': {'dse': 'basic', 'dle': 'basic'},
+        'O1': {'dse': 'basic', 'dle': 'advanced'},
         'O2': {'dse': 'advanced', 'dle': 'advanced'},
         'O3': {'dse': 'aggressive', 'dle': 'advanced'},
         # Parametric
         'dse': {'dse': ['basic', 'advanced', 'aggressive'], 'dle': 'advanced'},
-        'dle': {'dse': 'advanced', 'dle': ['basic', 'advanced']}
     }
 
     def from_preset(ctx, param, value):
@@ -76,7 +75,7 @@ def option_performance(f):
     options = [
         click.option('-bm', '--bench-mode', is_eager=True,
                      callback=from_preset, expose_value=False, default='O2',
-                     type=click.Choice(['O1', 'O2', 'O3', 'dse', 'dle']),
+                     type=click.Choice(['O1', 'O2', 'O3', 'dse']),
                      help='Choose what to benchmark; ignored if execmode=run'),
         click.option('--arch', default='unknown',
                      help='Architecture on which the simulation is/was run'),

--- a/devito/__init__.py
+++ b/devito/__init__.py
@@ -1,7 +1,7 @@
 from collections import namedtuple
 from itertools import product
 
-from devito.archinfo import known_isas, known_platforms, get_isa, get_platform
+from devito.archinfo import platform_registry
 from devito.base import *  # noqa
 from devito.builtins import *  # noqa
 from devito.data.allocators import *  # noqa
@@ -40,9 +40,6 @@ configuration.add('ignore-unknowns', 0, [0, 1], lambda i: bool(i), False)
 # and will instead use the custom kernel
 configuration.add('jit-backdoor', 0, [0, 1], lambda i: bool(i), False)
 
-# (Undocumented) escape hatch for cross-compilation
-configuration.add('cross-compile', None)
-
 # Execution mode setup
 def _reinit_compiler(val):  # noqa
     # Force re-build the compiler
@@ -73,11 +70,9 @@ configuration.add('autotuning', 'off', at_accepted, callback=_at_callback,  # no
 # Should Devito emit the JIT compilation commands?
 configuration.add('debug-compiler', 0, [0, 1], lambda i: bool(i), False)
 
-# Instruction Set Architecture (ISA)
-configuration.add('isa', get_isa(), known_isas)
-
-# Codename of the underlying architecture
-configuration.add('platform', get_platform(), known_platforms)
+# JIT-compilation target platform
+configuration.add('platform', 'cpu64', list(platform_registry),
+                  callback=lambda i: platform_registry[i]())
 
 # In develop-mode:
 # - Some optimizations may not be applied to the generated code.

--- a/devito/__init__.py
+++ b/devito/__init__.py
@@ -62,8 +62,8 @@ configuration.add('mpi', 0, [0, 1, 'basic', 'diag', 'overlap', 'overlap2', 'full
                   callback=_reinit_compiler)
 
 # Autotuning setup
-AT_LEVELs = ['off', 'basic', 'aggressive', 'max']
-AT_MODEs = ['preemptive', 'destructive', 'runtime']
+at_levels = ['off', 'basic', 'aggressive', 'max']
+at_modes = ['preemptive', 'destructive', 'runtime']
 at_default_mode = {'core': 'preemptive', 'yask': 'runtime', 'ops': 'runtime'}
 at_setup = namedtuple('at_setup', 'level mode')
 at_accepted = at_levels + [list(i) for i in product(at_levels, at_modes)]

--- a/devito/__init__.py
+++ b/devito/__init__.py
@@ -20,7 +20,9 @@ from ._version import get_versions  # noqa
 __version__ = get_versions()['version']
 del get_versions
 
-# Setup compiler and backend
+# Setup target platform, compiler, and backend
+configuration.add('platform', 'cpu64', list(platform_registry),
+                  callback=lambda i: platform_registry[i]())
 configuration.add('compiler', 'custom', list(compiler_registry),
                   callback=lambda i: compiler_registry[i]())
 configuration.add('backend', 'core', list(backends_registry), callback=init_backend)
@@ -70,14 +72,14 @@ configuration.add('autotuning', 'off', at_accepted, callback=_at_callback,  # no
 # Should Devito emit the JIT compilation commands?
 configuration.add('debug-compiler', 0, [0, 1], lambda i: bool(i), False)
 
-# JIT-compilation target platform
-configuration.add('platform', 'cpu64', list(platform_registry),
-                  callback=lambda i: platform_registry[i]())
-
 # In develop-mode:
 # - Some optimizations may not be applied to the generated code.
 # - The compiler performs more type and value checking
 configuration.add('develop-mode', True, [False, True])
+
+# DLE configuration
+configuration.add('dle', 'advanced', ['advanced', 'speculative'])
+configuration.add('dle-options', {})
 
 # Initialize the configuration, either from the environment or
 # defaults. This will also trigger the backend initialization

--- a/devito/__init__.py
+++ b/devito/__init__.py
@@ -96,8 +96,7 @@ configuration.add('dle-options', {})
 # Setup Operator profiling
 configuration.add('profiling', 'basic', list(profiler_registry), impacts_jit=False)
 
-# Initialize the configuration, either from the environment or
-# defaults. This will also trigger the backend initialization
+# Initialize `configuration`. This will also trigger the backend initialization
 init_configuration()
 
 # Expose a mechanism to clean up the symbol caches (SymPy's, Devito's)

--- a/devito/__init__.py
+++ b/devito/__init__.py
@@ -1,19 +1,24 @@
 from collections import namedtuple
 from itertools import product
 
-from devito.archinfo import platform_registry
+# API imports
 from devito.base import *  # noqa
 from devito.builtins import *  # noqa
 from devito.data.allocators import *  # noqa
 from devito.equation import *  # noqa
 from devito.finite_differences import *  # noqa
-from devito.logger import error, warning, info, set_log_level  # noqa
-from devito.parameters import *  # noqa
 from devito.types import NODE, CELL, Buffer, SubDomain  # noqa
 from devito.types.dimension import *  # noqa
 
-from devito.compiler import compiler_registry
+# Imports required to initialize Devito
+from devito.archinfo import platform_registry
 from devito.backends import backends_registry, init_backend
+from devito.compiler import compiler_registry
+from devito.dle import dle_registry
+from devito.dse import dse_registry
+from devito.logger import error, warning, info, logger_registry, set_log_level  # noqa
+from devito.parameters import *  # noqa
+from devito.profiling import profiler_registry
 
 
 from ._version import get_versions  # noqa
@@ -33,6 +38,10 @@ configuration.add('first-touch', 0, [0, 1], lambda i: bool(i), False)
 # Should Devito ignore any unknown runtime arguments supplied to Operator.apply(),
 # or rather raise an exception (the default behaviour)?
 configuration.add('ignore-unknowns', 0, [0, 1], lambda i: bool(i), False)
+
+# Setup log level
+configuration.add('log-level', 'INFO', list(logger_registry),
+                  lambda i: set_log_level(i), False)
 
 # Escape hatch for custom kernels. The typical use case is as follows: one lets
 # Devito generate code for an Operator; then, once the session is over, the
@@ -57,7 +66,7 @@ AT_LEVELs = ['off', 'basic', 'aggressive', 'max']
 AT_MODEs = ['preemptive', 'destructive', 'runtime']
 at_default_mode = {'core': 'preemptive', 'yask': 'runtime', 'ops': 'runtime'}
 at_setup = namedtuple('at_setup', 'level mode')
-at_accepted = AT_LEVELs + [list(i) for i in product(AT_LEVELs, AT_MODEs)]
+at_accepted = at_levels + [list(i) for i in product(at_levels, at_modes)]
 def _at_callback(val):  # noqa
     if isinstance(val, str):
         level, mode = val, at_default_mode[configuration['backend']]
@@ -77,9 +86,15 @@ configuration.add('debug-compiler', 0, [0, 1], lambda i: bool(i), False)
 # - The compiler performs more type and value checking
 configuration.add('develop-mode', True, [False, True])
 
-# DLE configuration
-configuration.add('dle', 'advanced', ['advanced', 'speculative'])
+# Setup DSE
+configuration.add('dse', 'advanced', list(dse_registry))
+
+# Setup DLE
+configuration.add('dle', 'advanced', list(dle_registry))
 configuration.add('dle-options', {})
+
+# Setup Operator profiling
+configuration.add('profiling', 'basic', list(profiler_registry), impacts_jit=False)
 
 # Initialize the configuration, either from the environment or
 # defaults. This will also trigger the backend initialization

--- a/devito/archinfo.py
+++ b/devito/archinfo.py
@@ -14,7 +14,9 @@ __all__ = ['known_isas', 'known_platforms', 'get_cpu_info', 'get_isa',
 known_isas = ['cpp', 'sse', 'avx', 'avx2', 'avx512']
 """All known Instruction Set Architectures."""
 
-known_platforms = ['intel64', 'snb', 'ivb', 'hsw', 'bdw', 'skx', 'knl']
+known_platforms = ['intel64', 'snb', 'ivb', 'hsw', 'bdw', 'skx', 'knl',
+                   'arm',
+                   'power8', 'power9']
 """All known platforms."""
 
 
@@ -56,6 +58,8 @@ def get_platform():
     """
     Retrieve the target architecture's codename.
     """
+    # TODO: cannot autodetect the following platforms yet:
+    # ['arm', 'power8', 'power9']
     try:
         # First, try leveraging `gcc`
         p1 = Popen(['gcc', '-march=native', '-Q', '--help=target'],

--- a/devito/archinfo.py
+++ b/devito/archinfo.py
@@ -183,6 +183,17 @@ class Power(Cpu64):
         return 'altivec'
 
 
+class Device(Platform):
+
+    def __init__(self, name, cores_logical=1, cores_physical=1, isa='cpp'):
+        self.name = name
+
+        self.cores_logical = cores_logical
+        self.cores_physical = cores_physical
+        self.isa = isa
+
+
+# CPUs
 CPU64 = Cpu64('cpu64')
 INTEL64 = Intel64('intel64')
 SNB = Intel64('snb')
@@ -196,6 +207,9 @@ ARM = Arm('arm')
 POWER8 = Power('power8')
 POWER9 = Power('power9')
 
+# Devices
+NVIDIAX = Device('nvidiax')
+
 
 platform_registry = {
     'intel64': INTEL64,
@@ -208,7 +222,8 @@ platform_registry = {
     'knl7210': KNL7210,
     'arm': ARM,
     'power8': POWER8,
-    'power9': POWER9
+    'power9': POWER9,
+    'nvidiaX': NVIDIAX
 }
 """
 Registry dict for deriving Platform classes according to the environment variable

--- a/devito/archinfo.py
+++ b/devito/archinfo.py
@@ -1,23 +1,16 @@
 """Collection of utilities to detect properties of the underlying architecture."""
 
+from functools import partial
 from subprocess import PIPE, Popen
 
 import numpy as np
 import cpuinfo
+import psutil
 
+from devito.logger import warning
 from devito.tools.memoization import memoized_func
 
-__all__ = ['known_isas', 'known_platforms', 'get_cpu_info', 'get_isa',
-           'get_platform', 'get_simd_reg_size', 'get_simd_items_per_reg']
-
-
-known_isas = ['cpp', 'sse', 'avx', 'avx2', 'avx512']
-"""All known Instruction Set Architectures."""
-
-known_platforms = ['intel64', 'snb', 'ivb', 'hsw', 'bdw', 'skx', 'knl',
-                   'arm',
-                   'power8', 'power9']
-"""All known platforms."""
+__all__ = ['platform_registry']
 
 
 @memoized_func
@@ -27,39 +20,45 @@ def get_cpu_info():
         cpu_info = {}
         with open('/proc/cpuinfo', 'r') as f:
             lines = f.readlines()
-        get = lambda key: [i for i in lines if i.startswith(key)][0].split(':')[1].strip()
+        get = lambda k: [i for i in lines if i.startswith(k)][0].split(':')[1].strip()
         cpu_info['flags'] = get('flags').split()
         cpu_info['brand'] = get('model name')
         # TODO: Other info omitted as currently unused
-        return cpu_info
     except:
         # Fallback: rely on the slower `cpuinfo`
-        return cpuinfo.get_cpu_info()
+        cpu_info = cpuinfo.get_cpu_info()
 
+    # Distinguish between *physical* and *logical* cores
+    logical = psutil.cpu_count(logical=True)
+    if logical:
+        cpu_info['logical'] = logical
+        cpu_info['physical'] = psutil.cpu_count(logical=False)
+    else:
+        # Fallback: we might end up here on more exotic platforms such a Power8
+        # We attempt to use `lscpu` -- it's a bit sad because we have to spawn
+        # a new process, or simply `lscpu` won't be available
+        p1 = Popen(['lscpu'], stdout=PIPE, stderr=PIPE)
+        output, _ = p1.communicate()
+        if output:
+            lines = output.decode("utf-8").split('\n')
+            get = lambda k: [i for i in lines if i.startswith(k)][0].split(':')[1].strip()
+            cpu_info['logical'] = int(get('CPU(s)'))
+            cpu_info['physical'] = int(get('Core(s)')) * int(get('Socket(s)'))
+        else:
+            warning("Physical/logical core count autodetection failed")
+            cpu_info['logical'] = 1
+            cpu_info['physical'] = 1
 
-@memoized_func
-def get_isa():
-    """
-    Retrieve the target architecture's highest SIMD instruction set architecture.
-    """
-    cpu_info = get_cpu_info()
-    isa = 'cpp'
-    for i in reversed(known_isas):
-        if any(j.startswith(i) for j in cpu_info['flags']):
-            # Using `startswith`, rather than `==`, as a flag such as 'avx512'
-            # appears as 'avx512f, avx512cd, ...'
-            isa = i
-            break
-    return isa
+    return cpu_info
 
 
 @memoized_func
 def get_platform():
-    """
-    Retrieve the target architecture's codename.
-    """
+    """Attempt Platform autodetection."""
+
     # TODO: cannot autodetect the following platforms yet:
     # ['arm', 'power8', 'power9']
+
     try:
         # First, try leveraging `gcc`
         p1 = Popen(['gcc', '-march=native', '-Q', '--help=target'],
@@ -68,39 +67,130 @@ def get_platform():
         p1.stdout.close()  # Allow p1 to receive a SIGPIPE if p2 exits.
         output, _ = p2.communicate()
         platform = output.decode("utf-8").split()[1]
-        # Full list of possible /platform/ values at this point at:
+        # Full list of possible `platform` values at this point at:
         # https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html
         platform = {'sandybridge': 'snb', 'ivybridge': 'ivb', 'haswell': 'hsw',
                     'broadwell': 'bdw', 'skylake': 'skx', 'knl': 'knl'}[platform]
+        return platform_registry[platform]()
     except:
-        # Then, try infer from the brand name, otherwise fallback to default
-        try:
-            cpu_info = get_cpu_info()
-            platform = cpu_info['brand'].split()[4]
-            platform = {'v2': 'ivb', 'v3': 'hsw', 'v4': 'bdw', 'v5': 'skx'}[platform]
-        except:
-            platform = None
-    # Is it a known platform?
-    if platform not in known_platforms:
-        platform = 'intel64'
-    return platform
+        pass
+
+    # No luck so far; try instead from the brand name
+    try:
+        cpu_info = get_cpu_info()
+        platform = cpu_info['brand'].split()[4]
+        platform = {'v2': 'ivb', 'v3': 'hsw', 'v4': 'bdw', 'v5': 'skx'}[platform]
+        return platform_registry[platform]()
+    except:
+        pass
+
+    # Stick to default
+    return CPU64('cpu64')
 
 
-@memoized_func
-def get_simd_reg_size(isa):
-    """
-    Retrieve the size in bytes of a SIMD register of the target architecture.
-    """
-    assert isa in known_isas
-    return {'cpp': 16, 'sse': 16, 'avx': 32, 'avx2': 32, 'avx512': 64}[isa]
+class Platform(object):
+
+    def __init__(self, name):
+        self.name = name
+
+        self.cores_logical = 1
+        self.cores_physical = 1
+
+        self.isa = 'cpp'
+
+    def __str__(self):
+        return self.name
+
+    def __repr__(self):
+        return "DevitoTargetPlatform[%s]" % self.name
+
+    @property
+    def threads_per_core(self):
+        return self.cores_logical // self.cores_physical
 
 
-@memoized_func
-def get_simd_items_per_reg(isa, dtype):
-    """
-    Retrieve the number of items of type ``dtype`` that can fit in a SIMD register
-    of the target architecture.
-    """
-    simd_size = get_simd_reg_size(isa)
-    assert simd_size % np.dtype(dtype).itemsize == 0
-    return int(simd_size / np.dtype(dtype).itemsize)
+class CPU64(Platform):
+
+    def __init__(self, name):
+        self.name = name
+
+        cpu_info = get_cpu_info()
+        self.cores_logical = cpu_info['logical']
+        self.cores_physical = cpu_info['physical']
+
+        self.isa = self._detect_isa()
+
+    def _detect_isa(self):
+        return 'cpp'
+
+    @property
+    def simd_reg_size(self):
+        """Size in bytes of a SIMD register."""
+        return isa_registry[self.isa]
+
+    def simd_items_per_reg(self, dtype):
+        """Number of items of type ``dtype`` that can fit in a SIMD register."""
+        assert self.simd_reg_size % np.dtype(dtype).itemsize == 0
+        return int(self.simd_reg_size / np.dtype(dtype).itemsize)
+
+
+class Intel64(CPU64):
+
+    def _detect_isa(self):
+        known_isas = ['cpp', 'sse', 'avx', 'avx2', 'avx512']
+        for i in reversed(known_isas):
+            if any(j.startswith(i) for j in get_cpu_info()['flags']):
+                # Using `startswith`, rather than `==`, as a flag such as 'avx512'
+                # appears as 'avx512f, avx512cd, ...'
+                return i
+        return 'cpp'
+
+
+class KNL7210(Intel64):
+
+    def __init__(self, name):
+        self.name = name
+        self.cores_logical = 256
+        self.cores_physical = 64
+        self.isa = 'avx512'
+
+
+class Arm(CPU64):
+    pass
+
+
+class Power(CPU64):
+
+    def _detect_isa(self):
+        return 'altivec'
+
+
+isa_registry = {
+    'cpp': 16,
+    'sse': 16,
+    'avx': 32,
+    'avx2': 32,
+    'avx512': 64,
+    'altivec': 16
+}
+"""Size in bytes of a SIMD register in known ISAs."""
+
+
+platform_registry = {
+    'cpu64': get_platform,  # Trigger autodetection
+    'intel64': partial(Intel64, 'intel64'),
+    'snb': partial(Intel64, 'snb'),
+    'ivb': partial(Intel64, 'ivb'),
+    'hsw': partial(Intel64, 'hsw'),
+    'bdw': partial(Intel64, 'bdw'),
+    'skx': partial(Intel64, 'skx'),
+    'knl': partial(Intel64, 'knl'),
+    'knl7210': partial(KNL7210, name='knl'),
+    'arm': partial(Arm, name='arm'),
+    'power8': partial(Power, name='power'),
+    'power9': partial(Power, name='power')
+}
+"""
+Registry dict for deriving Platform classes according to the environment variable
+DEVITO_PLATFORM. Developers should add new platform classes here.
+"""

--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -236,6 +236,8 @@ class ClangCompiler(Compiler):
             self.cflags += ['-mcpu=native']
         else:
             self.cflags += ['-march=native']
+        if configuration['openmp']:
+            self.ldflags += ['-fopenmp']
 
     def __lookup_cmds__(self):
         self.CC = 'clang'

--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -230,7 +230,7 @@ class ClangCompiler(Compiler):
     def __init__(self, *args, **kwargs):
         super(ClangCompiler, self).__init__(*args, **kwargs)
         self.cflags += ['-Wno-unused-result', '-Wno-unused-variable']
-        if configuration['platform'] in ['power8', 'power9']:
+        if configuration['platform'].name in ['power8', 'power9']:
             # -march isn't supported on power architectures
             self.cflags += ['-mcpu=native']
         else:
@@ -248,7 +248,7 @@ class IntelCompiler(Compiler):
     def __init__(self, *args, **kwargs):
         super(IntelCompiler, self).__init__(*args, **kwargs)
         self.cflags += ["-xhost"]
-        if configuration['platform'] == 'skx':
+        if configuration['platform'].name == 'skx':
             # Systematically use 512-bit vectors on skylake
             self.cflags += ["-qopt-zmm-usage=high"]
         try:
@@ -471,8 +471,6 @@ def make(loc, args):
     debug("Make <%s>: run in [%.2f s]" % (" ".join(args), toc-tic))
 
 
-# Registry dict for deriving Compiler classes according to the environment variable
-# DEVITO_ARCH. Developers should add new compiler classes here.
 compiler_registry = {
     'custom': CustomCompiler,
     'gnu': GNUCompiler,
@@ -485,5 +483,9 @@ compiler_registry = {
     'intel-knl': IntelKNLCompiler,
     'knl': IntelKNLCompiler,
 }
+"""
+Registry dict for deriving Compiler classes according to the environment variable
+DEVITO_ARCH. Developers should add new compiler classes here.
+"""
 compiler_registry.update({'gcc-%s' % i: partial(GNUCompiler, suffix=i)
                           for i in ['4.9', '5', '6', '7', '8']})

--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -135,7 +135,7 @@ class Compiler(GCCToolchain):
 
         self.suffix = kwargs.get('suffix')
         if not kwargs.get('mpi'):
-            self.cc = self.CC if kwargs.get('cpp', False) is False else self.CPP
+            self.cc = self.CC if kwargs.get('cpp', False) is False else self.CXX
             self.cc = self.cc if self.suffix is None else ('%s-%s' %
                                                            (self.cc, self.suffix))
         else:
@@ -173,7 +173,7 @@ class Compiler(GCCToolchain):
 
     def __lookup_cmds__(self):
         self.CC = 'unknown'
-        self.CPP = 'unknown'
+        self.CXX = 'unknown'
         self.MPICC = 'unknown'
         self.MPICXX = 'unknown'
 
@@ -220,7 +220,7 @@ class GNUCompiler(Compiler):
 
     def __lookup_cmds__(self):
         self.CC = 'gcc'
-        self.CPP = 'g++'
+        self.CXX = 'g++'
         self.MPICC = 'mpicc'
         self.MPICXX = 'mpicxx'
 
@@ -233,7 +233,7 @@ class ClangCompiler(Compiler):
 
     def __lookup_cmds__(self):
         self.CC = 'clang'
-        self.CPP = 'clang++'
+        self.CXX = 'clang++'
         self.MPICC = 'mpicc'
         self.MPICXX = 'mpicxx'
 
@@ -266,7 +266,7 @@ class IntelCompiler(Compiler):
 
     def __lookup_cmds__(self):
         self.CC = 'icc'
-        self.CPP = 'icpc'
+        self.CXX = 'icpc'
 
         # On some systems, the Intel distribution of MPI may be available, in
         # which case the MPI compiler may be shipped either as `mpiicc` or `mpicc`.
@@ -304,7 +304,7 @@ class CustomCompiler(Compiler):
     """
 
     CC = environ.get('CC', 'gcc')
-    CPP = environ.get('CPP', 'g++')
+    CXX = environ.get('CXX', 'g++')
     MPICC = environ.get('MPICC', 'mpicc')
     MPICXX = environ.get('MPICXX', 'mpicxx')
 
@@ -318,7 +318,7 @@ class CustomCompiler(Compiler):
 
     def __lookup_cmds__(self):
         self.CC = 'gcc'
-        self.CPP = 'g++'
+        self.CXX = 'g++'
         self.MPICC = 'mpicc'
         self.MPICXX = 'mpicxx'
 

--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -299,7 +299,7 @@ class CustomCompiler(Compiler):
     Notes
     -----
     Currently honours CC, CFLAGS and LDFLAGS, with defaults similar to the
-    default GNU settings. If DEVITO_ARCH is enabled, the OpenMP linker
+    default GNU/gcc settings. If DEVITO_ARCH is enabled, the OpenMP linker
     flags are read from OMP_LDFLAGS or otherwise default to ``-fopenmp``.
     """
 

--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -229,7 +229,12 @@ class ClangCompiler(Compiler):
 
     def __init__(self, *args, **kwargs):
         super(ClangCompiler, self).__init__(*args, **kwargs)
-        self.cflags += ['-march=native', '-Wno-unused-result', '-Wno-unused-variable']
+        self.cflags += ['-Wno-unused-result', '-Wno-unused-variable']
+        if configuration['platform'] in ['power8', 'power9']:
+            # -march isn't supported on power architectures
+            self.cflags += ['-mcpu=native']
+        else:
+            self.cflags += ['-march=native']
 
     def __lookup_cmds__(self):
         self.CC = 'clang'

--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -12,6 +12,7 @@ import numpy.ctypeslib as npct
 from codepy.jit import compile_from_string
 from codepy.toolchain import GCCToolchain
 
+from devito.archinfo import SKX, POWER8, POWER9
 from devito.exceptions import CompilationError
 from devito.logger import debug, warning, error
 from devito.parameters import configuration
@@ -181,7 +182,7 @@ class Compiler(GCCToolchain):
         return self.__class__.__name__
 
     def __repr__(self):
-        return "DevitoJITCompiler[%s]" % self.__class__.__name__
+        return "JITCompiler[%s]" % self.__class__.__name__
 
     def __getstate__(self):
         # The superclass would otherwise only return a subset of attributes
@@ -230,7 +231,7 @@ class ClangCompiler(Compiler):
     def __init__(self, *args, **kwargs):
         super(ClangCompiler, self).__init__(*args, **kwargs)
         self.cflags += ['-Wno-unused-result', '-Wno-unused-variable']
-        if configuration['platform'].name in ['power8', 'power9']:
+        if configuration['platform'] in [POWER8, POWER9]:
             # -march isn't supported on power architectures
             self.cflags += ['-mcpu=native']
         else:
@@ -248,7 +249,7 @@ class IntelCompiler(Compiler):
     def __init__(self, *args, **kwargs):
         super(IntelCompiler, self).__init__(*args, **kwargs)
         self.cflags += ["-xhost"]
-        if configuration['platform'].name == 'skx':
+        if configuration['platform'] is SKX:
             # Systematically use 512-bit vectors on skylake
             self.cflags += ["-qopt-zmm-usage=high"]
         try:

--- a/devito/core/__init__.py
+++ b/devito/core/__init__.py
@@ -4,17 +4,20 @@ common to all other backends. The ``core`` backend (and therefore the ``base``
 backend as well) are used to run Devito on standard CPU architectures.
 """
 
-from devito.dle import CPU64Rewriter, SpeculativeRewriter, init_dle
+from devito.archinfo import Cpu64, Intel64, Arm, Power
+from devito.dle import (CPU64Rewriter, Intel64Rewriter, ArmRewriter, PowerRewriter,
+                        SpeculativeRewriter, modes)
 from devito.parameters import Parameters, add_sub_configuration
 
 core_configuration = Parameters('core')
 env_vars_mapper = {}
 add_sub_configuration(core_configuration, env_vars_mapper)
 
-# Initialize the DLE
-modes = {'advanced': CPU64Rewriter,
-         'speculative': SpeculativeRewriter}
-init_dle(modes)
+# Add core-specific DLE modes
+modes.add(Cpu64, {'advanced': CPU64Rewriter, 'speculative': SpeculativeRewriter})
+modes.add(Intel64, {'advanced': Intel64Rewriter, 'speculative': SpeculativeRewriter})
+modes.add(Arm, {'advanced': ArmRewriter, 'speculative': SpeculativeRewriter})
+modes.add(Power, {'advanced': PowerRewriter, 'speculative': SpeculativeRewriter})
 
 # The following used by backends.backendSelector
 from devito.core.operator import OperatorCore as Operator  # noqa

--- a/devito/core/__init__.py
+++ b/devito/core/__init__.py
@@ -4,9 +4,9 @@ common to all other backends. The ``core`` backend (and therefore the ``base``
 backend as well) are used to run Devito on standard CPU architectures.
 """
 
-from devito.archinfo import Cpu64, Intel64, Arm, Power
+from devito.archinfo import Cpu64, Intel64, Arm, Power, Device
 from devito.dle import (CPU64Rewriter, Intel64Rewriter, ArmRewriter, PowerRewriter,
-                        SpeculativeRewriter, modes)
+                        SpeculativeRewriter, DeviceOffloadingRewriter, modes)
 from devito.parameters import Parameters, add_sub_configuration
 
 core_configuration = Parameters('core')
@@ -14,10 +14,16 @@ env_vars_mapper = {}
 add_sub_configuration(core_configuration, env_vars_mapper)
 
 # Add core-specific DLE modes
-modes.add(Cpu64, {'advanced': CPU64Rewriter, 'speculative': SpeculativeRewriter})
-modes.add(Intel64, {'advanced': Intel64Rewriter, 'speculative': SpeculativeRewriter})
-modes.add(Arm, {'advanced': ArmRewriter, 'speculative': SpeculativeRewriter})
-modes.add(Power, {'advanced': PowerRewriter, 'speculative': SpeculativeRewriter})
+modes.add(Cpu64, {'advanced': CPU64Rewriter,
+                  'speculative': SpeculativeRewriter})
+modes.add(Intel64, {'advanced': Intel64Rewriter,
+                    'speculative': SpeculativeRewriter})
+modes.add(Arm, {'advanced': ArmRewriter,
+                'speculative': SpeculativeRewriter})
+modes.add(Power, {'advanced': PowerRewriter,
+                  'speculative': SpeculativeRewriter})
+modes.add(Device, {'advanced': DeviceOffloadingRewriter,
+                   'speculative': DeviceOffloadingRewriter})
 
 # The following used by backends.backendSelector
 from devito.core.operator import OperatorCore as Operator  # noqa

--- a/devito/core/__init__.py
+++ b/devito/core/__init__.py
@@ -4,8 +4,7 @@ common to all other backends. The ``core`` backend (and therefore the ``base``
 backend as well) are used to run Devito on standard CPU architectures.
 """
 
-from devito.dle import (BasicRewriter, AdvancedRewriter, AdvancedRewriterSafeMath,
-                        SpeculativeRewriter, init_dle)
+from devito.dle import CPU64Rewriter, SpeculativeRewriter, init_dle
 from devito.parameters import Parameters, add_sub_configuration
 
 core_configuration = Parameters('core')
@@ -13,9 +12,7 @@ env_vars_mapper = {}
 add_sub_configuration(core_configuration, env_vars_mapper)
 
 # Initialize the DLE
-modes = {'basic': BasicRewriter,
-         'advanced': AdvancedRewriter,
-         'advanced-safemath': AdvancedRewriterSafeMath,
+modes = {'advanced': CPU64Rewriter,
          'speculative': SpeculativeRewriter}
 init_dle(modes)
 

--- a/devito/core/autotuning.py
+++ b/devito/core/autotuning.py
@@ -5,6 +5,7 @@ import resource
 
 import psutil
 
+from devito.archinfo import KNL
 from devito.dle import BlockDimension
 from devito.ir import Backward, retrieve_iteration_tree
 from devito.logger import perf, warning as _warning
@@ -317,7 +318,7 @@ def generate_nthreads(nthreads, args, level):
         # Be sure to try with:
         # 1) num_threads == num_physical_cores
         # 2) num_threads == num_hyperthreads
-        if configuration['platform'] == 'knl':
+        if configuration['platform'] is KNL:
             ret.extend([((nthreads.name, psutil.cpu_count() // 4),),
                         ((nthreads.name, psutil.cpu_count() // 2),),
                         ((nthreads.name, psutil.cpu_count()),)])

--- a/devito/data/allocators.py
+++ b/devito/data/allocators.py
@@ -8,6 +8,7 @@ import numpy as np
 import ctypes
 from ctypes.util import find_library
 
+from devito.archinfo import KNL
 from devito.logger import logger
 from devito.parameters import configuration
 from devito.tools import dtype_to_ctype
@@ -342,7 +343,7 @@ def default_allocator():
     if configuration['develop-mode']:
         return ALLOC_GUARD
     elif NumaAllocator.available():
-        if configuration['platform'].name == 'knl' and infer_knl_mode() == 'flat':
+        if configuration['platform'] is KNL and infer_knl_mode() == 'flat':
             return ALLOC_KNL_MCDRAM
         else:
             return ALLOC_NUMA_LOCAL

--- a/devito/data/allocators.py
+++ b/devito/data/allocators.py
@@ -342,7 +342,7 @@ def default_allocator():
     if configuration['develop-mode']:
         return ALLOC_GUARD
     elif NumaAllocator.available():
-        if configuration['platform'] == 'knl' and infer_knl_mode() == 'flat':
+        if configuration['platform'].name == 'knl' and infer_knl_mode() == 'flat':
             return ALLOC_KNL_MCDRAM
         else:
             return ALLOC_NUMA_LOCAL

--- a/devito/dle/parallelizer.py
+++ b/devito/dle/parallelizer.py
@@ -3,39 +3,23 @@ import os
 
 import numpy as np
 import cgen as c
-import psutil
 from sympy import Function, Or
 
 from devito.ir import (Call, Conditional, Block, Expression, List, Prodder,
                        FindSymbols, FindNodes, Return, COLLAPSED, Transformer,
                        IsPerfectIteration, retrieve_iteration_tree, filter_iterations)
-from devito.logger import dle_warning
 from devito.symbolics import CondEq
 from devito.parameters import configuration
-from devito.tools import is_integer, memoized_func
+from devito.tools import is_integer
 from devito.types import Constant, Symbol
 
 
-@memoized_func
 def ncores():
-    try:
-        return configuration['cross-compile'].cpu_count(logical=False)
-    except AttributeError:
-        return psutil.cpu_count(logical=False)
+    return configuration['platform'].cores_physical
 
 
-@memoized_func
 def nhyperthreads():
-    try:
-        logical = configuration['cross-compile'].cpu_count(logical=True)
-    except AttributeError:
-        logical = psutil.cpu_count(logical=True)
-    physical = ncores()
-    if logical % physical > 0:
-        dle_warning("Couldn't detect number of hyperthreads per core, assuming 1")
-        return 1
-    else:
-        return logical // physical
+    return configuration['platform'].threads_per_core
 
 
 class NThreads(Constant):

--- a/devito/dle/rewriters.py
+++ b/devito/dle/rewriters.py
@@ -416,9 +416,6 @@ class CPU64Rewriter(PlatformRewriter):
 
     _node_parallelizer_type = Ompizer
 
-    def __init__(self, params, platform):
-        super(CPU64Rewriter, self).__init__(params, platform)
-
     def _pipeline(self, state):
         self._avoid_denormals(state)
         self._optimize_halospots(state)

--- a/devito/dle/rewriters.py
+++ b/devito/dle/rewriters.py
@@ -469,8 +469,7 @@ class DeviceOffloadingRewriter(PlatformRewriter):
         if self.params['mpi']:
             self._dist_parallelize(state)
         self._simdize(state)
-        if self.params['openmp']:
-            self._node_parallelize(state)
+        self._node_parallelize(state)
         self._hoist_prodders(state)
 
     @dle_pass

--- a/devito/dle/transformer.py
+++ b/devito/dle/transformer.py
@@ -82,16 +82,19 @@ def transform(iet, mode='basic', options=None):
     if mode == 'noop' and params['openmp'] is True:
         mode = 'openmp'
 
+    # What is the target platform for which the optimizations are applied?
+    target = configuration['platform']
+
     # Process the Iteration/Expression tree through the DLE
     if mode is None or mode == 'noop':
         return iet, State(iet)
     elif mode not in default_modes:
         try:
-            rewriter = CustomRewriter(mode, params)
+            rewriter = CustomRewriter(mode, params, target)
             return rewriter.run(iet)
         except DLEException:
             dle_warning("Unknown transformer mode(s) %s" % mode)
             return iet, State(iet)
     else:
-        rewriter = default_modes[mode](params)
+        rewriter = default_modes[mode](params, target)
         return rewriter.run(iet)

--- a/devito/dle/transformer.py
+++ b/devito/dle/transformer.py
@@ -7,7 +7,10 @@ from devito.exceptions import DLEException
 from devito.logger import dle_warning
 from devito.parameters import configuration
 
-__all__ = ['modes', 'transform']
+__all__ = ['dle_registry', 'modes', 'transform']
+
+
+dle_registry = ('advanced', 'speculative')
 
 
 class DLEModes(OrderedDict):
@@ -24,7 +27,7 @@ class DLEModes(OrderedDict):
     def add(self, platform, mapper):
         assert issubclass(platform, Platform)
         assert isinstance(mapper, dict)
-        assert all(i in mapper for i in ['advanced', 'speculative'])
+        assert all(i in mapper for i in dle_registry)
         super(DLEModes, self).__setitem__(platform, mapper)
 
     def fetch(self, platform, mode):

--- a/devito/dle/transformer.py
+++ b/devito/dle/transformer.py
@@ -1,41 +1,46 @@
+from collections import OrderedDict
+
+from devito.archinfo import Platform, Cpu64
 from devito.ir.iet import Node
-from devito.dle.rewriters import CustomRewriter, State
+from devito.dle.rewriters import CPU64Rewriter, CustomRewriter, State
 from devito.exceptions import DLEException
 from devito.logger import dle_warning
 from devito.parameters import configuration
 
-__all__ = ['init_dle', 'transform']
+__all__ = ['modes', 'transform']
 
 
-default_modes = {
-    'advanced': None,
-    'speculative': None
-}
-"""The DLE transformation modes.
-This dictionary may be modified at backend-initialization time."""
+class DLEModes(OrderedDict):
 
-default_options = {
-    'blockinner': False,
-    'blockalways': False
-}
-"""Default values for the supported optimization options.
-This dictionary may be modified at backend-initialization time."""
+    """
+    The DLE transformation modes. This is a dictionary ``P -> {M -> R}``,
+    where P is a Platform, M a rewrite mode (e.g., 'advanced', 'speculative'),
+    and R a Rewriter.
 
-configuration.add('dle', 'advanced', list(default_modes))
-configuration.add('dle-options',
-                  ';'.join('%s:%s' % (k, v) for k, v in default_options.items()),
-                  list(default_options))
+    This dictionary is to be modified at backend-initialization time by adding
+    all Platform-keyed mappers as supported by the specific backend.
+    """
 
-all_options = tuple(default_options) + ('openmp',)
+    def add(self, platform, mapper):
+        assert issubclass(platform, Platform)
+        assert isinstance(mapper, dict)
+        assert all(i in mapper for i in ['advanced', 'speculative'])
+        super(DLEModes, self).__setitem__(platform, mapper)
 
-
-def init_dle(backend_modes):
-    global default_modes
-    for i in list(default_modes):
-        default_modes[i] = backend_modes[i]
+    def fetch(self, platform, mode):
+        # Try to fetch the most specific Rewriter for the given Platform
+        for cls in platform.__class__.mro():
+            for k, v in self.items():
+                if issubclass(k, cls):
+                    return v[mode]
+        raise KeyError("Couldn't find a rewriter mode for platform `%s`", platform)
 
 
-def transform(iet, mode='basic', options=None):
+modes = DLEModes()
+modes.add(Cpu64, {'advanced': CPU64Rewriter, 'speculative': CPU64Rewriter})
+
+
+def transform(iet, mode='advanced', options=None):
     """
     Transform Iteration/Expression trees (IET) to generate optimized C code.
 
@@ -46,9 +51,10 @@ def transform(iet, mode='basic', options=None):
     mode : str, optional
         The transformation mode.
         - ``noop``: Do nothing.
-        - ``basic``: Add instructions to avoid denormal numbers and create elemental
-                     functions for quicker JIT-compilation.
-        - ``advanced``: 'basic', vectorization, loop blocking.
+        - ``advanced``: flush denormals, vectorization, loop blocking, OpenMP-related
+                        optimizations (collapsing, nested parallelism, ...), MPI-related
+                        optimizations (aggregation of communications, reshuffling of
+                        communications, ...).
         - ``speculative``: Apply all of the 'advanced' transformations, plus other
                            transformations that might increase (or possibly decrease)
                            performance.
@@ -64,35 +70,42 @@ def transform(iet, mode='basic', options=None):
     """
     assert isinstance(iet, Node)
 
-    # Parse options (local values take precedence over global ones)
-    options = options or {}
-    params = options.copy()
-    for i in options:
-        if i not in all_options:
-            dle_warning("Illegal DLE option '%s'" % i)
-            params.pop(i)
-    params.update({k: v for k, v in configuration['dle-options'].items()
-                   if k not in params})
-    params.setdefault('openmp', configuration['openmp'])
-    params.setdefault('mpi', configuration['mpi'])
+    # Default options
+    params = {}
+    params['blockinner'] = configuration['dle-options'].get('blockinner', False)
+    params['blockalways'] = configuration['dle-options'].get('blockalways', False)
+    params['openmp'] = configuration['openmp']
+    params['mpi'] = configuration['mpi']
+
+    # Parse input options (potentially replacing defaults)
+    for k, v in (options or {}).items():
+        if k not in params:
+            dle_warning("Illegal DLE option '%s'" % k)
+        else:
+            params[k] = v
 
     # Force OpenMP if parallelism was requested, even though mode is 'noop'
     if mode == 'noop' and params['openmp'] is True:
         mode = 'openmp'
 
     # What is the target platform for which the optimizations are applied?
-    target = configuration['platform']
+    platform = configuration['platform']
 
-    # Process the Iteration/Expression tree through the DLE
+    # Run the DLE
     if mode is None or mode == 'noop':
+        # No-op case
         return iet, State(iet)
-    elif mode not in default_modes:
-        try:
-            rewriter = CustomRewriter(mode, params, target)
-            return rewriter.run(iet)
-        except DLEException:
-            dle_warning("Unknown transformer mode(s) %s" % mode)
-            return iet, State(iet)
-    else:
-        rewriter = default_modes[mode](params, target)
+    try:
+        # Preset rewriter (typical use case)
+        rewriter = modes.fetch(platform, mode)(params, platform)
         return rewriter.run(iet)
+    except KeyError:
+        pass
+    try:
+        # Fallback: custom rewriter -- `mode` is a specific sequence of
+        # transformation passes
+        rewriter = CustomRewriter(mode, params, platform)
+        return rewriter.run(iet)
+    except DLEException:
+        dle_warning("Unknown transformer mode(s) %s" % mode)
+        return iet, State(iet)

--- a/devito/dle/transformer.py
+++ b/devito/dle/transformer.py
@@ -8,9 +8,7 @@ __all__ = ['init_dle', 'transform']
 
 
 default_modes = {
-    'basic': None,
     'advanced': None,
-    'advanced-safemath': None,
     'speculative': None
 }
 """The DLE transformation modes.

--- a/devito/dse/transformer.py
+++ b/devito/dse/transformer.py
@@ -3,11 +3,12 @@ from devito.dse.backends import (BasicRewriter, AdvancedRewriter, SpeculativeRew
                                  AggressiveRewriter)
 from devito.dse.manipulation import cross_cluster_cse
 from devito.logger import dse_warning
-from devito.parameters import configuration
 from devito.tools import flatten
 
-__all__ = ['rewrite']
+__all__ = ['dse_registry', 'rewrite']
 
+
+dse_registry = ('basic', 'advanced', 'speculative', 'aggressive')
 
 modes = {
     'basic': BasicRewriter,
@@ -16,8 +17,6 @@ modes = {
     'aggressive': AggressiveRewriter
 }
 """The DSE transformation modes."""
-
-configuration.add('dse', 'advanced', list(modes))
 
 
 def rewrite(clusters, mode='advanced'):
@@ -55,7 +54,7 @@ def rewrite(clusters, mode='advanced'):
 
     if mode is None or mode == 'noop':
         return clusters
-    elif mode not in modes:
+    elif mode not in dse_registry:
         dse_warning("Unknown rewrite mode(s) %s" % mode)
         return clusters
 

--- a/devito/logger.py
+++ b/devito/logger.py
@@ -4,8 +4,6 @@ import logging
 import sys
 from contextlib import contextmanager
 
-from devito.parameters import configuration
-
 __all__ = ('set_log_level', 'set_log_noperf',
            'log', 'warning', 'error', 'perf', 'perf_adv', 'dse', 'dse_warning',
            'dle', 'dle_warning',
@@ -103,10 +101,6 @@ def set_log_level(level, comm=None):
 def set_log_noperf():
     """Do not print performance-related messages."""
     logger.setLevel(WARNING)
-
-
-configuration.add('log-level', 'INFO', list(logger_registry),
-                  lambda i: set_log_level(i), False)
 
 
 def log(msg, level=INFO, *args, **kwargs):

--- a/devito/ops/__init__.py
+++ b/devito/ops/__init__.py
@@ -12,7 +12,8 @@ env_vars_mapper = {}
 add_sub_configuration(ops_configuration, env_vars_mapper)
 
 # Add OPS-specific DLE modes
-modes.add(Cpu64, {'advanced': PlatformRewriter, 'speculative': PlatformRewriter})
+modes.add(Cpu64, {'advanced': PlatformRewriter,
+                  'speculative': PlatformRewriter})
 
 # The following used by backends.backendSelector
 from devito.ops.operator import OperatorOPS as Operator  # noqa

--- a/devito/ops/__init__.py
+++ b/devito/ops/__init__.py
@@ -3,17 +3,16 @@ The ``ops`` Devito backend uses the OPS library to generate,
 JIT-compile, and run kernels on multiple architectures.
 """
 
-from devito.dle import CPU64Rewriter, SpeculativeRewriter, init_dle
+from devito.archinfo import Cpu64
+from devito.dle import PlatformRewriter, modes
 from devito.parameters import Parameters, add_sub_configuration
 
 ops_configuration = Parameters('ops')
 env_vars_mapper = {}
 add_sub_configuration(ops_configuration, env_vars_mapper)
 
-# Initialize the DLE
-modes = {'advanced': CPU64Rewriter,
-         'speculative': SpeculativeRewriter}
-init_dle(modes)
+# Add OPS-specific DLE modes
+modes.add(Cpu64, {'advanced': PlatformRewriter, 'speculative': PlatformRewriter})
 
 # The following used by backends.backendSelector
 from devito.ops.operator import OperatorOPS as Operator  # noqa

--- a/devito/ops/__init__.py
+++ b/devito/ops/__init__.py
@@ -3,8 +3,7 @@ The ``ops`` Devito backend uses the OPS library to generate,
 JIT-compile, and run kernels on multiple architectures.
 """
 
-from devito.dle import (BasicRewriter, AdvancedRewriter, AdvancedRewriterSafeMath,
-                        SpeculativeRewriter, init_dle)
+from devito.dle import CPU64Rewriter, SpeculativeRewriter, init_dle
 from devito.parameters import Parameters, add_sub_configuration
 
 ops_configuration = Parameters('ops')
@@ -12,9 +11,7 @@ env_vars_mapper = {}
 add_sub_configuration(ops_configuration, env_vars_mapper)
 
 # Initialize the DLE
-modes = {'basic': BasicRewriter,
-         'advanced': AdvancedRewriter,
-         'advanced-safemath': AdvancedRewriterSafeMath,
+modes = {'advanced': CPU64Rewriter,
          'speculative': SpeculativeRewriter}
 init_dle(modes)
 

--- a/devito/parameters.py
+++ b/devito/parameters.py
@@ -109,7 +109,6 @@ class Parameters(OrderedDict, Signer):
 
 env_vars_mapper = {
     'DEVITO_ARCH': 'compiler',
-    'DEVITO_ISA': 'isa',
     'DEVITO_PLATFORM': 'platform',
     'DEVITO_PROFILING': 'profiling',
     'DEVITO_BACKEND': 'backend',

--- a/devito/parameters.py
+++ b/devito/parameters.py
@@ -115,7 +115,6 @@ env_vars_mapper = {
     'DEVITO_DEVELOP': 'develop-mode',
     'DEVITO_DSE': 'dse',
     'DEVITO_DLE': 'dle',
-    'DEVITO_DLE_OPTIONS': 'dle-options',
     'DEVITO_OPENMP': 'openmp',
     'DEVITO_MPI': 'mpi',
     'DEVITO_AUTOTUNING': 'autotuning',
@@ -134,10 +133,9 @@ configuration = Parameters("Devito-Configuration")
 def init_configuration(configuration=configuration, env_vars_mapper=env_vars_mapper):
     # Populate /configuration/ with user-provided options
     if environ.get('DEVITO_CONFIG') is None:
-        # At init time, it is important to first configure the compiler, then
-        # the backend (which is impacted by the compiler), finally everything
-        # else in any arbitrary order
-        process_order = filter_ordered(['compiler', 'backend'] +
+        # At init time, it is important to configure `platform`, `compiler` and `backend`
+        # in this order
+        process_order = filter_ordered(['platform', 'compiler', 'backend'] +
                                        list(env_vars_mapper.values()))
         queue = sorted(env_vars_mapper.items(), key=lambda i: process_order.index(i[1]))
         unprocessed = OrderedDict([(v, environ.get(k, configuration._defaults[v]))

--- a/devito/profiling.py
+++ b/devito/profiling.py
@@ -255,13 +255,12 @@ def create_profile(name):
         return profiler
 
 
-# Set up profiling levels
 profiler_registry = {
     'basic': Profiler,
     'advanced': AdvancedProfiler,
     'advisor': AdvisorProfiler
 }
-configuration.add('profiling', 'basic', list(profiler_registry), impacts_jit=False)
+"""Profiling levels."""
 
 
 def locate_intel_advisor():

--- a/devito/yask/__init__.py
+++ b/devito/yask/__init__.py
@@ -6,7 +6,7 @@ JIT-compile, and run kernels.
 import os
 import sys
 
-from devito.archinfo import Cpu64
+from devito.archinfo import Arm, Cpu64, CPU64, Power
 from devito.dle import modes
 from devito.exceptions import InvalidOperator
 from devito.logger import yask as log
@@ -25,6 +25,16 @@ def exit(emsg):
 
 
 log("Backend initialization...")
+
+# Not all devito `platform`s are supported by YASK
+if isinstance(configuration['platform'], (Arm, Power)):
+    raise ValueError("The YASK backend doesn't support platform `%s`" %
+                     configuration['platform'])
+# Some of the supported devito `platform`s (e.g., AMDs) may still be run through
+# YASK -- as they are x86-64 just like Intels -- but a proper `Platform` must be used
+if configuration['platform'] is CPU64:
+    configuration['platform'] = 'intel64'
+
 try:
     import yask as yc
     # YASK compiler factories

--- a/devito/yask/__init__.py
+++ b/devito/yask/__init__.py
@@ -90,7 +90,8 @@ env_vars_mapper = {
 add_sub_configuration(yask_configuration, env_vars_mapper)
 
 # Add YASK-specific DLE modes
-modes.add(Cpu64, {'advanced': YaskRewriter, 'speculative': YaskRewriter})
+modes.add(Cpu64, {'advanced': YaskRewriter,
+                  'speculative': YaskRewriter})
 
 # The following used by backends.backendSelector
 from devito.types import SparseFunction, SparseTimeFunction  # noqa

--- a/devito/yask/__init__.py
+++ b/devito/yask/__init__.py
@@ -6,7 +6,8 @@ JIT-compile, and run kernels.
 import os
 import sys
 
-from devito.dle import init_dle
+from devito.archinfo import Cpu64
+from devito.dle import modes
 from devito.exceptions import InvalidOperator
 from devito.logger import yask as log
 from devito.parameters import Parameters, configuration, add_sub_configuration
@@ -88,10 +89,8 @@ env_vars_mapper = {
 
 add_sub_configuration(yask_configuration, env_vars_mapper)
 
-# Initialize the DLE
-modes = {'advanced': YaskRewriter,
-         'speculative': YaskRewriter}
-init_dle(modes)
+# Add YASK-specific DLE modes
+modes.add(Cpu64, {'advanced': YaskRewriter, 'speculative': YaskRewriter})
 
 # The following used by backends.backendSelector
 from devito.types import SparseFunction, SparseTimeFunction  # noqa

--- a/devito/yask/__init__.py
+++ b/devito/yask/__init__.py
@@ -6,7 +6,7 @@ JIT-compile, and run kernels.
 import os
 import sys
 
-from devito.dle import BasicRewriter, init_dle
+from devito.dle import init_dle
 from devito.exceptions import InvalidOperator
 from devito.logger import yask as log
 from devito.parameters import Parameters, configuration, add_sub_configuration
@@ -89,9 +89,7 @@ env_vars_mapper = {
 add_sub_configuration(yask_configuration, env_vars_mapper)
 
 # Initialize the DLE
-modes = {'basic': BasicRewriter,
-         'advanced': YaskRewriter,
-         'advanced-safemath': YaskRewriter,
+modes = {'advanced': YaskRewriter,
          'speculative': YaskRewriter}
 init_dle(modes)
 

--- a/devito/yask/dle.py
+++ b/devito/yask/dle.py
@@ -1,4 +1,4 @@
-from devito.dle import AdvancedRewriter, Ompizer
+from devito.dle import Intel64Rewriter, Ompizer
 
 __all__ = ['YaskRewriter']
 
@@ -8,7 +8,7 @@ class YaskOmpizer(Ompizer):
     pass
 
 
-class YaskRewriter(AdvancedRewriter):
+class YaskRewriter(Intel64Rewriter):
 
     _shm_parallelizer_type = YaskOmpizer
 

--- a/devito/yask/dle.py
+++ b/devito/yask/dle.py
@@ -1,19 +1,12 @@
-from devito.dle import Intel64Rewriter, Ompizer
+from devito.dle import Intel64Rewriter
 
 __all__ = ['YaskRewriter']
 
 
-class YaskOmpizer(Ompizer):
-
-    pass
-
-
 class YaskRewriter(Intel64Rewriter):
-
-    _shm_parallelizer_type = YaskOmpizer
 
     def _pipeline(self, state):
         self._avoid_denormals(state)
         self._loop_wrapping(state)
         if self.params['openmp'] is True:
-            self._shm_parallelize(state)
+            self._node_parallelize(state)

--- a/devito/yask/dle.py
+++ b/devito/yask/dle.py
@@ -1,9 +1,30 @@
-from devito.dle import Intel64Rewriter
+from devito.dle import Intel64Rewriter, Ompizer
+from devito.ir import FindNodes
+
+from devito.yask.utils import Offloaded
 
 __all__ = ['YaskRewriter']
 
 
+class YaskOmpizer(Ompizer):
+
+    def __init__(self, key=None):
+        if key is None:
+            def key(i):
+                # If it's not parallel, nothing to do
+                if not i.is_ParallelRelaxed or i.is_Vectorizable:
+                    return False
+                # If some of the inner computation has been offloaded to YASK,
+                # avoid introducing an outer level of parallelism
+                if FindNodes(Offloaded).visit(i):
+                    return False
+                return True
+        super(YaskOmpizer, self).__init__(key=key)
+
+
 class YaskRewriter(Intel64Rewriter):
+
+    _node_parallelizer_type = YaskOmpizer
 
     def _pipeline(self, state):
         self._avoid_denormals(state)

--- a/devito/yask/operator.py
+++ b/devito/yask/operator.py
@@ -6,14 +6,15 @@ import numpy as np
 
 from devito.logger import yask as log
 from devito.ir.equations import LoweredEq
-from devito.ir.iet import ForeignExpression, MetaCall, Transformer, find_affine_trees
+from devito.ir.iet import MetaCall, Transformer, find_affine_trees
 from devito.ir.support import align_accesses
 from devito.operator import Operator
 from devito.tools import Signer, filter_ordered, flatten
 
 from devito.yask import configuration
 from devito.yask.data import DataScalar
-from devito.yask.utils import make_grid_accesses, make_sharedptr_funcall, namespace
+from devito.yask.utils import (Offloaded, make_grid_accesses, make_sharedptr_funcall,
+                               namespace)
 from devito.yask.wrappers import contexts
 from devito.yask.transformer import yaskit
 from devito.yask.types import YaskGridObject, YaskSolnObject
@@ -80,7 +81,7 @@ class OperatorYASK(Operator):
                 yk_soln_obj = YaskSolnObject(namespace['code-soln-name'](n))
                 funcall = make_sharedptr_funcall(namespace['code-soln-run'],
                                                  ['time'], yk_soln_obj)
-                funcall = ForeignExpression(funcall, self._dtype)
+                funcall = Offloaded(funcall, self._dtype)
                 mapper[trees[0].root] = funcall
                 mapper.update({i.root: mapper.get(i.root) for i in trees})  # Drop trees
 

--- a/devito/yask/utils.py
+++ b/devito/yask/utils.py
@@ -5,7 +5,16 @@ from devito.ir.iet import Expression, ForeignExpression, FindNodes, Transformer
 from devito.symbolics import FunctionFromPointer, ListInitializer, retrieve_indexed
 from devito.tools import ctypes_pointer
 
-__all__ = ['make_grid_accesses', 'make_sharedptr_funcall']
+__all__ = ['Offloaded', 'make_grid_accesses', 'make_sharedptr_funcall']
+
+
+class Offloaded(ForeignExpression):
+
+    """
+    Represent offloaded computation.
+    """
+
+    pass
 
 
 def make_sharedptr_funcall(call, params, sharedptr):

--- a/devito/yask/wrappers.py
+++ b/devito/yask/wrappers.py
@@ -68,7 +68,8 @@ class YaskKernel(object):
 
             # Write out the stencil file
             yk_codegen_file = os.path.join(yk_codegen, namespace['yask-codegen-file'])
-            yc_soln.format(configuration['isa'], ofac.new_file_output(yk_codegen_file))
+            yc_soln.format(configuration['platform'].isa,
+                           ofac.new_file_output(yk_codegen_file))
 
             # JIT-compile it
             compiler = configuration.yask['compiler']
@@ -132,7 +133,7 @@ class YaskKernel(object):
         # Redirect stdout to a string or file
         if configuration.yask['dump']:
             filename = 'yk_dump.%s.%s.%s.txt' % (name, configuration['platform'],
-                                                 configuration['isa'])
+                                                 configuration['platform'].isa)
             filename = os.path.join(configuration.yask['dump'], filename)
             self.output = yk.yask_output_factory().new_file_output(filename)
         else:
@@ -346,7 +347,7 @@ class YaskContext(Signer):
         # Redirect stdout/strerr to a string or file
         if configuration.yask['dump']:
             filename = 'yc_dump.%s.%s.%s.txt' % (name, configuration['platform'],
-                                                 configuration['isa'])
+                                                 configuration['platform'].isa)
             filename = os.path.join(configuration.yask['dump'], filename)
             yc_soln.set_debug_output(ofac.new_file_output(filename))
         else:
@@ -356,7 +357,7 @@ class YaskContext(Signer):
         yc_soln.set_element_bytes(self.dtype().itemsize)
 
         # Apply compile-time optimizations
-        if configuration['isa'] != 'cpp':
+        if configuration['platform'].isa != 'cpp':
             dimensions = [make_yask_ast(i, yc_soln) for i in self.space_dimensions]
             # Vector folding
             for i, j in zip(dimensions, configuration.yask['folding']):
@@ -395,7 +396,7 @@ class ContextManager(OrderedDict):
         self._ncontexts = 0
 
     def _getkey(self, grid, dtype, dimensions=None):
-        base = (configuration['isa'], dtype)
+        base = (configuration['platform'].isa, dtype)
         if grid is not None:
             dims = filter_sorted((grid.time_dim, grid.stepping_dim) + grid.dimensions)
             return base + (tuple(dims),)

--- a/tests/test_dse.py
+++ b/tests/test_dse.py
@@ -46,7 +46,7 @@ def run_acoustic_forward(dse=None):
     geometry = AcquisitionGeometry(model, rec_coordinates, src_coordinates,
                                    t0=t0, tn=tn, src_type='Ricker', f0=0.010)
 
-    solver = AcousticWaveSolver(model, geometry, dse=dse, dle='basic')
+    solver = AcousticWaveSolver(model, geometry, dse=dse, dle='noop')
     rec, u, _ = solver.forward(save=False)
 
     return u, rec
@@ -409,7 +409,7 @@ def test_makeit_ssa(exprs, exp_u, exp_v):
 
 
 @pytest.mark.parametrize('dse', ['noop', 'basic', 'advanced', 'aggressive'])
-@pytest.mark.parametrize('dle', ['noop', 'basic', 'advanced', 'speculative'])
+@pytest.mark.parametrize('dle', ['noop', 'advanced', 'speculative'])
 def test_time_dependent_split(dse, dle):
     grid = Grid(shape=(10, 10))
     u = TimeFunction(name='u', grid=grid, time_order=2, space_order=2, save=3)

--- a/tests/test_yask.py
+++ b/tests/test_yask.py
@@ -346,6 +346,15 @@ class TestOperatorSimple(object):
         assert np.all(u.data[1] == 1.)
         assert u.data[:].sum() == np.prod(grid.shape)
 
+    @switchconfig(openmp=True)
+    def test_no_omp_if_offloaded(self):
+        grid = Grid(shape=(4, 4, 4))
+        u = TimeFunction(name='yu4D', grid=grid, space_order=0)
+        u.data[:] = 0.
+        op = Operator(Eq(u, u + 1.))
+        assert 'run_solution' in str(op)
+        assert 'pragma omp' not in str(op)
+
 
 class TestOperatorAdvanced(object):
     """


### PR DESCRIPTION
This PR adds the Platform class hierarchy (CPU64, Intel64, KNL, ... ARM, ..., Power, ...) so that the compiler can make platform-specific choices when it comes to optimization. 

The nice thing now is that if you want to cross-compile (note: I'm talking about the code that devito generates, not the actual machine code) for a certain target architecture, now you can do it with ``DEVITO_PLATFORM=...`` and for example ``knl`` rather than ``hsw``. On KNL, for example, nested parallel loops are collapsed and nested parallelism is enabled.
By default, we stick to the ``cpu64`` mode, which is essentially what we have in master

This PR also drops now uselss environment variables: DEVITO_DLE_OPTIONS and DEVITO_ISA. In particular, the highest ISA now is bound directly to a Platform, so no need to set it up explicitly. 