### PR TITLE
conftest: updating EVAL function

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -286,8 +286,6 @@ def EVAL(exprs, *args):
     for i in args:
         try:
             scope[i.base.function.name] = i
-            for j in i.base.function.indices:
-                scope[j.name] = j
         except AttributeError:
             scope[i.label.name] = i
             for j in i.function.indices:


### PR DESCRIPTION
This PR is for updating the function `EVAL` from the file `conftest.py`. 

It seems that the removed lines were added in a previous version of Devito.
They are currently never reached.

If the input is an `Indexed`, then 