### PR TITLE
openmp scheduling fixes

### DIFF
--- a/devito/dle/parallelizer.py
+++ b/devito/dle/parallelizer.py
@@ -3,8 +3,6 @@ import os
 
 import numpy as np
 import cgen as c
-from functools import reduce
-from operator import mul
 from sympy import Function, Or
 
 from devito.ir import (Call, Conditional, Block, Expression, List, Prodder,
@@ -12,7 +10,7 @@ from devito.ir import (Call, Conditional, Block, Expression, List, Prodder,
                        IsPerfectIteration, retrieve_iteration_tree, filter_iterations)
 from devito.symbolics import CondEq
 from devito.parameters import configuration
-from devito.tools import is_integer
+from devito.tools import is_integer, prod
 from devito.types import Constant, Symbol
 
 
@@ -161,8 +159,9 @@ class Ompizer(object):
                 if i.is_Vectorizable:
                     break
 
+                # Would there be enough work per parallel iteration?
                 try:
-                    work = reduce(mul, [int(j.dim.symbolic_size) for j in candidates[n:]])
+                    work = prod([int(j.dim.symbolic_size) for j in candidates[n+1:]])
                     if work < Ompizer.COLLAPSE_WORK:
                         break
                 except TypeError:

--- a/devito/dle/rewriters.py
+++ b/devito/dle/rewriters.py
@@ -12,9 +12,9 @@ from devito.dle.blocking_utils import (BlockDimension, fold_blockable_tree,
 from devito.dle.parallelizer import Ompizer
 from devito.exceptions import DLEException
 from devito.ir.iet import (Call, Expression, Iteration, List, HaloSpot, Prodder, PARALLEL,
-                           FindSymbols, FindNodes, FindAdjacent, MapNodes, Transformer,
-                           compose_nodes, filter_iterations, retrieve_iteration_tree,
-                           make_efunc)
+                           AFFINE, FindSymbols, FindNodes, FindAdjacent, MapNodes,
+                           Transformer, compose_nodes, filter_iterations, make_efunc,
+                           retrieve_iteration_tree)
 from devito.logger import dle, perf_adv
 from devito.mpi import HaloExchangeBuilder
 from devito.parameters import configuration
@@ -299,7 +299,8 @@ class PlatformRewriter(AbstractRewriter):
                 d = BlockDimension(i.dim, name="%s%d_blk" % (i.dim.name, len(mapper)))
                 block_dims.append(d)
                 # Build Iteration over blocks
-                interb.append(Iteration([], d, d.symbolic_max, properties=PARALLEL))
+                properties = (PARALLEL,) + ((AFFINE,) if i.is_Affine else ())
+                interb.append(Iteration([], d, d.symbolic_max, properties=properties))
                 # Build Iteration within a block
                 intrab.append(i._rebuild([], limits=(d, d+d.step-1, 1), offsets=(0, 0)))
 

--- a/devito/tools/utils.py
+++ b/devito/tools/utils.py
@@ -14,8 +14,8 @@ __all__ = ['prod', 'as_tuple', 'is_integer', 'generator', 'grouper', 'split', 'r
            'ctypes_to_cstr', 'ctypes_pointer', 'pprint', 'sweep']
 
 
-def prod(iterable):
-    return reduce(mul, iterable, 1)
+def prod(iterable, initial=1):
+    return reduce(mul, iterable, initial)
 
 
 def as_tuple(item, type=None, length=None):

--- a/tests/test_autotuner.py
+++ b/tests/test_autotuner.py
@@ -185,7 +185,7 @@ def test_tti_aggressive():
 
 
 @switchconfig(develop_mode=False)
-@patch("devito.dle.parallelizer.Ompizer.COLLAPSE", 1)
+@patch("devito.dle.parallelizer.Ompizer.COLLAPSE_NCORES", 1)
 def test_discarding_runs():
     grid = Grid(shape=(64, 64, 64))
     f = TimeFunction(name='f', grid=grid)

--- a/tests/test_dle.py
+++ b/tests/test_dle.py
@@ -200,118 +200,119 @@ def test_cache_blocking_edge_cases_highorder(shape, blockshape):
     assert np.equal(wo_blocking.data, w_blocking.data).all()
 
 
-@pytest.mark.parametrize('exprs,expected', [
-    # trivial 1D
-    (['Eq(fa[x], fa[x] + fb[x])'],
-     (True, False)),
-    # trivial 1D
-    (['Eq(t0, fa[x] + fb[x])', 'Eq(fa[x], t0 + 1)'],
-     (True, False)),
-    # trivial 2D
-    (['Eq(t0, fc[x,y] + fd[x,y])', 'Eq(fc[x,y], t0 + 1)'],
-     (True, False)),
-    # outermost parallel, innermost sequential
-    (['Eq(t0, fc[x,y] + fd[x,y])', 'Eq(fc[x,y+1], t0 + 1)'],
-     (True, False)),
-    # outermost sequential, innermost parallel
-    (['Eq(t0, fc[x,y] + fd[x,y])', 'Eq(fc[x+1,y], t0 + 1)'],
-     (False, True)),
-    # outermost sequential, innermost parallel
-    (['Eq(fc[x,y], fc[x+1,y+1] + fc[x-1,y])'],
-     (False, True)),
-    # outermost parallel w/ repeated dimensions, but the compiler is conservative
-    # and makes it sequential, as it doesn't like what happens in the inner dims,
-    # where `x`, rather than `y`, is used
-    (['Eq(t0, fc[x,x] + fd[x,y+1])', 'Eq(fc[x,x], t0 + 1)'],
-     (False, False)),
-    # outermost sequential w/ repeated dimensions
-    (['Eq(t0, fc[x,x] + fd[x,y+1])', 'Eq(fc[x,x+1], t0 + 1)'],
-     (False, False)),
-    # outermost sequential, innermost sequential (classic skewing example)
-    (['Eq(fc[x,y], fc[x,y+1] + fc[x-1,y])'],
-     (False, False)),
-    # outermost parallel, innermost sequential w/ double tensor write
-    (['Eq(fc[x,y], fc[x,y+1] + fd[x-1,y])', 'Eq(fd[x-1,y+1], fd[x-1,y] + fc[x,y+1])'],
-     (True, False)),
-    # outermost sequential, innermost parallel w/ mixed dimensions
-    (['Eq(fc[x+1,y], fc[x,y+1] + fc[x,y])', 'Eq(fc[x+1,y], 2. + fc[x,y+1])'],
-     (False, True)),
-])
-def test_loops_ompized(fa, fb, fc, fd, t0, t1, t2, t3, exprs, expected, iters):
-    scope = [fa, fb, fc, fd, t0, t1, t2, t3]
-    node_exprs = [Expression(DummyEq(EVAL(i, *scope))) for i in exprs]
-    ast = iters[6](iters[7](node_exprs))
+class TestNodeParallelism(object):
 
-    ast = iet_analyze(ast)
+    @pytest.mark.parametrize('exprs,expected', [
+        # trivial 1D
+        (['Eq(fa[x], fa[x] + fb[x])'],
+         (True, False)),
+        # trivial 1D
+        (['Eq(t0, fa[x] + fb[x])', 'Eq(fa[x], t0 + 1)'],
+         (True, False)),
+        # trivial 2D
+        (['Eq(t0, fc[x,y] + fd[x,y])', 'Eq(fc[x,y], t0 + 1)'],
+         (True, False)),
+        # outermost parallel, innermost sequential
+        (['Eq(t0, fc[x,y] + fd[x,y])', 'Eq(fc[x,y+1], t0 + 1)'],
+         (True, False)),
+        # outermost sequential, innermost parallel
+        (['Eq(t0, fc[x,y] + fd[x,y])', 'Eq(fc[x+1,y], t0 + 1)'],
+         (False, True)),
+        # outermost sequential, innermost parallel
+        (['Eq(fc[x,y], fc[x+1,y+1] + fc[x-1,y])'],
+         (False, True)),
+        # outermost parallel w/ repeated dimensions, but the compiler is conservative
+        # and makes it sequential, as it doesn't like what happens in the inner dims,
+        # where `x`, rather than `y`, is used
+        (['Eq(t0, fc[x,x] + fd[x,y+1])', 'Eq(fc[x,x], t0 + 1)'],
+         (False, False)),
+        # outermost sequential w/ repeated dimensions
+        (['Eq(t0, fc[x,x] + fd[x,y+1])', 'Eq(fc[x,x+1], t0 + 1)'],
+         (False, False)),
+        # outermost sequential, innermost sequential (classic skewing example)
+        (['Eq(fc[x,y], fc[x,y+1] + fc[x-1,y])'],
+         (False, False)),
+        # outermost parallel, innermost sequential w/ double tensor write
+        (['Eq(fc[x,y], fc[x,y+1] + fd[x-1,y])', 'Eq(fd[x-1,y+1], fd[x-1,y] + fc[x,y+1])'],
+         (True, False)),
+        # outermost sequential, innermost parallel w/ mixed dimensions
+        (['Eq(fc[x+1,y], fc[x,y+1] + fc[x,y])', 'Eq(fc[x+1,y], 2. + fc[x,y+1])'],
+         (False, True)),
+    ])
+    def test_iterations_ompized(self, fa, fb, fc, fd, t0, t1, t2, t3,
+                                exprs, expected, iters):
+        scope = [fa, fb, fc, fd, t0, t1, t2, t3]
+        node_exprs = [Expression(DummyEq(EVAL(i, *scope))) for i in exprs]
+        ast = iters[6](iters[7](node_exprs))
 
-    iet, _ = transform(ast, mode='openmp')
-    iterations = FindNodes(Iteration).visit(iet)
-    assert len(iterations) == len(expected)
+        ast = iet_analyze(ast)
 
-    # Check for presence of pragma omp
-    for i, j in zip(iterations, expected):
-        pragmas = i.pragmas
-        if j is True:
-            assert len(pragmas) == 1
-            pragma = pragmas[0]
-            assert 'omp for' in pragma.value
+        iet, _ = transform(ast, mode='openmp')
+        iterations = FindNodes(Iteration).visit(iet)
+        assert len(iterations) == len(expected)
+
+        # Check for presence of pragma omp
+        for i, j in zip(iterations, expected):
+            pragmas = i.pragmas
+            if j is True:
+                assert len(pragmas) == 1
+                pragma = pragmas[0]
+                assert 'omp for' in pragma.value
+            else:
+                for k in pragmas:
+                    assert 'omp for' not in k.value
+
+    def test_dynamic_nthreads(self):
+        grid = Grid(shape=(16, 16, 16))
+        f = TimeFunction(name='f', grid=grid)
+
+        op = Operator(Eq(f.forward, f + 1.), dle='openmp')
+
+        # Check num_threads appears in the generated code
+        # Not very elegant, but it does the trick
+        assert 'num_threads(nthreads)' in str(op)
+
+        # Check `op` accepts the `nthreads` kwarg
+        op.apply(time=0)
+        op.apply(time_m=1, time_M=1, nthreads=4)
+        assert np.all(f.data[0] == 2.)
+
+        # Check the actual value assumed by `nthreads`
+        assert op.arguments(time=0)['nthreads'] == NThreads.default_value()
+        assert op.arguments(time=0, nthreads=123)['nthreads'] == 123  # user supplied
+
+    @pytest.mark.parametrize('eq,expected,blocking', [
+        ('Eq(f, 2*f)', [2, 0, 0], False),
+        ('Eq(u, 2*u)', [0, 2, 0, 0], False),
+        ('Eq(u, 2*u)', [3, 0, 0, 0, 0, 0], True)
+    ])
+    @patch("devito.dle.parallelizer.Ompizer.COLLAPSE", 1)
+    def test_collapsing(self, eq, expected, blocking):
+        grid = Grid(shape=(3, 3, 3))
+
+        f = Function(name='f', grid=grid)  # noqa
+        u = TimeFunction(name='u', grid=grid)  # noqa
+
+        eq = eval(eq)
+
+        if blocking:
+            op = Operator(eq, dle=('blocking', 'openmp', {'blockinner': True}))
+            iterations = FindNodes(Iteration).visit(op._func_table['bf0'])
         else:
-            for k in pragmas:
-                assert 'omp for' not in k.value
+            op = Operator(eq, dle='openmp')
+            iterations = FindNodes(Iteration).visit(op)
 
+        assert len(iterations) == len(expected)
 
-def test_dynamic_nthreads():
-    grid = Grid(shape=(16, 16, 16))
-    f = TimeFunction(name='f', grid=grid)
-
-    op = Operator(Eq(f.forward, f + 1.), dle='openmp')
-
-    # Check num_threads appears in the generated code
-    # Not very elegant, but it does the trick
-    assert 'num_threads(nthreads)' in str(op)
-
-    # Check `op` accepts the `nthreads` kwarg
-    op.apply(time=0)
-    op.apply(time_m=1, time_M=1, nthreads=4)
-    assert np.all(f.data[0] == 2.)
-
-    # Check the actual value assumed by `nthreads`
-    assert op.arguments(time=0)['nthreads'] == NThreads.default_value()
-    assert op.arguments(time=0, nthreads=123)['nthreads'] == 123  # user supplied
-
-
-@pytest.mark.parametrize('eq,expected,blocking', [
-    ('Eq(f, 2*f)', [2, 0, 0], False),
-    ('Eq(u, 2*u)', [0, 2, 0, 0], False),
-    ('Eq(u, 2*u)', [3, 0, 0, 0, 0, 0], True)
-])
-@patch("devito.dle.parallelizer.Ompizer.COLLAPSE", 1)
-def test_loops_collapsed(eq, expected, blocking):
-    grid = Grid(shape=(3, 3, 3))
-
-    f = Function(name='f', grid=grid)  # noqa
-    u = TimeFunction(name='u', grid=grid)  # noqa
-
-    eq = eval(eq)
-
-    if blocking:
-        op = Operator(eq, dle=('blocking', 'openmp', {'blockinner': True}))
-        iterations = FindNodes(Iteration).visit(op._func_table['bf0'])
-    else:
-        op = Operator(eq, dle='openmp')
-        iterations = FindNodes(Iteration).visit(op)
-
-    assert len(iterations) == len(expected)
-
-    # Check for presence of pragma omp + collapse clause
-    for i, j in zip(iterations, expected):
-        if j > 0:
-            assert len(i.pragmas) == 1
-            pragma = i.pragmas[0]
-            assert 'omp for collapse(%d)' % j in pragma.value
-        else:
-            for k in i.pragmas:
-                assert 'omp for collapse' not in k.value
+        # Check for presence of pragma omp + collapse clause
+        for i, j in zip(iterations, expected):
+            if j > 0:
+                assert len(i.pragmas) == 1
+                pragma = i.pragmas[0]
+                assert 'omp for collapse(%d)' % j in pragma.value
+            else:
+                for k in i.pragmas:
+                    assert 'omp for collapse' not in k.value
 
 
 class TestNestedParallelism(object):

--- a/tests/test_dle.py
+++ b/tests/test_dle.py
@@ -287,6 +287,7 @@ class TestNodeParallelism(object):
         ('Eq(u, 2*u)', [3, 0, 0, 0, 0, 0], True)
     ])
     @patch("devito.dle.parallelizer.Ompizer.COLLAPSE_NCORES", 1)
+    @patch("devito.dle.parallelizer.Ompizer.COLLAPSE_WORK", 0)
     def test_collapsing(self, eq, expected, blocking):
         grid = Grid(shape=(3, 3, 3))
 
@@ -362,6 +363,7 @@ class TestNestedParallelism(object):
 
     @patch("devito.dle.parallelizer.Ompizer.NESTED", 0)
     @patch("devito.dle.parallelizer.Ompizer.COLLAPSE_NCORES", 1)
+    @patch("devito.dle.parallelizer.Ompizer.COLLAPSE_WORK", 0)
     def test_collapsing(self):
         grid = Grid(shape=(3, 3, 3))
 

--- a/tests/test_dle.py
+++ b/tests/test_dle.py
@@ -99,7 +99,7 @@ def _new_operator3(shape, blockshape=None, dle=None):
     (False, 4, 5),
     (True, 8, 6)
 ])
-@patch("devito.dle.parallelizer.Ompizer.COLLAPSE", 1)
+@patch("devito.dle.parallelizer.Ompizer.COLLAPSE_NCORES", 1)
 def test_cache_blocking_structure(blockinner, exp_calls, exp_iters):
     # Check code structure
     _, op = _new_operator1((10, 31, 45), dle=('blocking', {'blockalways': True,
@@ -286,7 +286,7 @@ class TestNodeParallelism(object):
         ('Eq(u, 2*u)', [0, 2, 0, 0], False),
         ('Eq(u, 2*u)', [3, 0, 0, 0, 0, 0], True)
     ])
-    @patch("devito.dle.parallelizer.Ompizer.COLLAPSE", 1)
+    @patch("devito.dle.parallelizer.Ompizer.COLLAPSE_NCORES", 1)
     def test_collapsing(self, eq, expected, blocking):
         grid = Grid(shape=(3, 3, 3))
 
@@ -361,7 +361,7 @@ class TestNestedParallelism(object):
              % nhyperthreads())
 
     @patch("devito.dle.parallelizer.Ompizer.NESTED", 0)
-    @patch("devito.dle.parallelizer.Ompizer.COLLAPSE", 1)
+    @patch("devito.dle.parallelizer.Ompizer.COLLAPSE_NCORES", 1)
     def test_collapsing(self):
         grid = Grid(shape=(3, 3, 3))
 


### PR DESCRIPTION
all non-affine loop nests now use ``schedule(static)`` rather than ``schedule(static,1)``. This improve performance of ompized sparse loops