### PR TITLE
Autotuning pickle fix

### DIFF
--- a/devito/core/autotuning.py
+++ b/devito/core/autotuning.py
@@ -7,7 +7,7 @@ import psutil
 
 from devito.archinfo import KNL
 from devito.dle import BlockDimension
-from devito.ir import Backward, retrieve_iteration_tree
+from devito.ir import Backward, Forward, retrieve_iteration_tree
 from devito.logger import perf, warning as _warning
 from devito.mpi.distributed import MPI, MPINeighborhood
 from devito.mpi.routines import MPIMsgEnriched
@@ -207,11 +207,14 @@ def init_time_bounds(stepper, at_args):
         if at_args[dim.max_name] < at_args[dim.min_name]:
             warning("too few time iterations; skipping")
             return False
-    else:
+    elif stepper.direction == Forward:
         at_args[dim.max_name] = at_args[dim.min_name] + options['squeezer']
         if at_args[dim.min_name] > at_args[dim.max_name]:
             warning("too few time iterations; skipping")
             return False
+    else:
+        warning("could not determine direction; skipping")
+        return False
 
     return stepper.size(at_args[dim.min_name], at_args[dim.max_name])
 

--- a/devito/core/autotuning.py
+++ b/devito/core/autotuning.py
@@ -202,7 +202,7 @@ def init_time_bounds(stepper, at_args):
     if stepper is None:
         return
     dim = stepper.dim.root
-    if stepper.direction is Backward:
+    if stepper.direction == Backward:
         at_args[dim.min_name] = at_args[dim.max_name] - options['squeezer']
         if at_args[dim.max_name] < at_args[dim.min_name]:
             warning("too few time iterations; skipping")
@@ -220,7 +220,7 @@ def check_time_bounds(stepper, at_args, args, mode):
     if mode != 'runtime' or stepper is None:
         return True
     dim = stepper.dim.root
-    if stepper.direction is Backward:
+    if stepper.direction == Backward:
         if at_args[dim.min_name] < args[dim.min_name]:
             warning("too few time iterations; stopping")
             return False
@@ -235,7 +235,7 @@ def update_time_bounds(stepper, at_args, timesteps, mode):
     if mode != 'runtime' or stepper is None:
         return
     dim = stepper.dim.root
-    if stepper.direction is Backward:
+    if stepper.direction == Backward:
         at_args[dim.max_name] -= timesteps
         at_args[dim.min_name] -= timesteps
     else:
@@ -247,7 +247,7 @@ def finalize_time_bounds(stepper, at_args, args, mode):
     if mode != 'runtime' or stepper is None:
         return
     dim = stepper.dim.root
-    if stepper.direction is Backward:
+    if stepper.direction == Backward:
         args[dim.max_name] = at_args[dim.max_name]
         args[dim.min_name] = args[dim.min_name]
     else:

--- a/tests/test_autotuner.py
+++ b/tests/test_autotuner.py
@@ -139,9 +139,9 @@ def test_mode_runtime_backward():
 def test_mode_destructive():
     """Test autotuning in destructive mode."""
     grid = Grid(shape=(64, 64, 64))
-    f = TimeFunction(name='f', grid=grid, time_order=0)
+    f = TimeFunction(name='f', grid=grid)
 
-    op = Operator(Eq(f, f + 1.), dle=('advanced', {'openmp': False}))
+    op = Operator(Eq(f.forward, f + 1.), dle=('advanced', {'openmp': False}))
     op.apply(time=100, autotune=('basic', 'destructive'))
 
     # AT is expected to have executed 30 timesteps (6 block shapes, 5 timesteps each)


### PR DESCRIPTION
This fixes a tricky issue where runtime autotuning generates incorrect results, if the Operator has been pickled/unpickled.  The unpickling process creates a new instance of `IterationDirection`, which is equal to but not identical to `Backward`, and so the `is` comparison fails.  The runtime autotuning then executes the timesteps in the wrong order.

This changes the comparisons to equality, which works correctly.

I've put the "be extra careful" as a separate commit to make it simpler to throw away if you don't want to go that far.

A potentially more elegant solution would somehow create `Forward`, `Backward`, and `Any` as singletons, and somehow override the unpickling to ensure that there is only one instance.

A grep of the rest of the code only shows up one other case where this kind of test is used.  In `devito/types/dense.py` there are a lot of comparisons using `is`, e.g.:

```
        if side is not None:
            idx = idx*2 + (0 if side is LEFT else 1)
```

These might or might not be an issue.