### PR TITLE
Lifting expressions in OPS kernels

### DIFF
--- a/devito/ir/iet/visitors.py
+++ b/devito/ir/iet/visitors.py
@@ -152,7 +152,9 @@ class CGen(Visitor):
         """Generate cgen declarations from an iterable of symbols and expressions."""
         ret = []
         for i in args:
-            if i.is_Tensor:
+            if i.is_Tensor and i.is_OPS:
+                ret.append(c.Value(i._C_typename, i.name))
+            elif i.is_Tensor:
                 ret.append(c.Value('%srestrict' % i._C_typename, i._C_name))
             elif i.is_AbstractObject or i.is_Symbol:
                 ret.append(c.Value(i._C_typename, i._C_name))
@@ -314,6 +316,11 @@ class CGen(Visitor):
                 esigns.append(c.FunctionDeclaration(c.Value(i.root.retval, i.root.name),
                                                     self._args_decl(i.root.parameters)))
                 efuncs.extend([i.root.ccode, blankline])
+
+        for i in o._callables:
+            esigns.append(c.FunctionDeclaration(c.Value(i.retval, i.name),
+                                                self._args_decl(i.parameters)))
+            efuncs.extend([i.ccode, blankline])
 
         # Header files, extra definitions, ...
         header = [c.Line(i) for i in o._headers]

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -143,6 +143,7 @@ class Operator(Callable):
         self._headers = list(self._default_headers)
         self._includes = list(self._default_includes)
         self._globals = list(self._default_globals)
+        self._callables = []
 
         # Required for compilation
         self._compiler = configuration['compiler']

--- a/devito/ops/operator.py
+++ b/devito/ops/operator.py
@@ -1,5 +1,7 @@
 from devito.logger import warning
+from devito.ir.iet import find_affine_trees
 from devito.operator import Operator
+from devito.ops.transformer import opsit
 
 __all__ = ['OperatorOPS']
 
@@ -11,6 +13,10 @@ class OperatorOPS(Operator):
     """
 
     def _specialize_iet(self, iet, **kwargs):
+        for n, (section, trees) in enumerate(find_affine_trees(iet).items()):
+            callable_kernel, par_loop_call_block = opsit(trees, n)
+
+            self._callables.append(callable_kernel)
 
         warning("The OPS backend is still work-in-progress")
 

--- a/devito/ops/transformer.py
+++ b/devito/ops/transformer.py
@@ -1,3 +1,29 @@
+from devito.ir.iet import Callable, Expression, FindNodes
+from devito.ops.node_factory import OPSNodeFactory
+
+
+def opsit(trees, count):
+    node_factory = OPSNodeFactory()
+    expressions = []
+    for tree in trees:
+        expressions.extend([
+            Expression(make_ops_ast(i.expr, node_factory))
+            for i in FindNodes(Expression).visit(tree.inner)
+        ])
+
+    arguments = []
+    for exp in expressions:
+        func = [f for f in exp.functions if f.name != "OPS_ACC_size"]
+        for f in func:
+            f.is_OPS = True
+            f.is_LocalObject = True
+        arguments.extend(func)
+
+    callable_kernel = Callable("Kernel{}".format(count), expressions, "void", arguments)
+
+    return callable_kernel, None
+
+
 def make_ops_ast(expr, nfops):
     """
     Transform a devito expression into an OPS expression.

--- a/devito/types/basic.py
+++ b/devito/types/basic.py
@@ -81,6 +81,7 @@ class Basic(object):
     # Basic symbolic object properties
     is_Scalar = False
     is_Tensor = False
+    is_OPS = False
 
     @abc.abstractmethod
     def __init__(self, *args, **kwargs):


### PR DESCRIPTION
Using `find_affine_trees` iterations that can be offloaded to OPS are located. These expressions are then transformed to use OPS indexing and placed into a `Callable`. The generated kernel will then become an argument of calls to `ops_par_loop`.

In this PR we simply generate the ops kernels without changing anything else.

example generated code (from running example_diffusion.py with the OPS backend):

```
#define _POSIX_C_SOURCE 200809L
#include "stdlib.h"
#include "math.h"
#include "sys/time.h"

struct dataobj
{
  void *restrict data;
  int * size;
  int * npsize;
  int * dsize;
  int * hsize;
  int * hofs;
  int * oofs;
} ;

struct profiler
{
  double section0;
} ;

void Kernel0(const float dt, const float h_x, const float h_y, float * ut00, float * ut10);

int Kernel(const float dt, const float h_x, const float h_y, struct dataobj *restrict u_vec, const int time_M, const int time_m, struct profiler * timers, const int x_M, const int x_m, const int y_M, const int y_m)
{
  float (*restrict u)[u_vec->size[1]][u_vec->size[2]] __attribute__ ((aligned (64))) = (float (*)[u_vec->size[1]][u_vec->size[2]]) u_vec->data;
  for (int time = time_m, t0 = (time)%(2), t1 = (time + 1)%(2); time <= time_M; time += 1, t0 = (time)%(2), t1 = (time + 1)%(2))
  {
    struct timeval start_section0, end_section0;
    gettimeofday(&start_section0, NULL);
    /* Begin section0 */
    for (int x = x_m; x <= x_M; x += 1)
    {
      for (int y = y_m; y <= y_M; y += 1)
      {
        u[t1][x][y] = -1.0F*(dt*u[t0][x][y]/((h_y*h_y)) + dt*u[t0][x][y]/((h_x*h_x))) + 5.0e-1F*(dt*u[t0][x][y - 1]/((h_y*h_y)) + dt*u[t0][x][y + 1]/((h_y*h_y)) + dt*u[t0][x - 1][y]/((h_x*h_x)) + dt*u[t0][x + 1][y]/((h_x*h_x))) + u[t0][x][y];
      }
    }
    /* End section0 */
    gettimeofday(&end_section0, NULL);
    timers->section0 += (double)(end_section0.tv_sec-start_section0.tv_sec)+(double)(end_section0.tv_usec-start_section0.tv_usec)/1000000;
  }
  return 0;
}

void Kernel0(const float dt, const float h_x, const float h_y, float * ut00, float * ut10)
{
  ut10[OPS_ACC0(0,0)] = -1.0F*(dt*ut00[OPS_ACC1(0,0)]/((h_y*h_y)) + dt*ut00[OPS_ACC1(0,0)]/((h_x*h_x))) + 5.0e-1F*(dt*ut00[OPS_ACC1(0,-1)]/((h_y*h_y)) + dt*ut00[OPS_ACC1(0,1)]/((h_y*h_y)) + dt*ut00[OPS_ACC1(-1,0)]/((h_x*h_x)) + dt*ut00[OPS_ACC1(1,0)]/((h_x*h_x))) + ut00[OPS_ACC1(0,0)];
}
```