### PR TITLE
Data slice fix

### DIFF
--- a/devito/data/__init__.py
+++ b/devito/data/__init__.py
@@ -2,3 +2,4 @@ from devito.data.meta import *  # noqa
 from devito.data.allocators import *  # noqa
 from devito.data.decomposition import *  # noqa
 from devito.data.data import *  # noqa
+from devito.data.utils import *  # noqa

--- a/devito/data/decomposition.py
+++ b/devito/data/decomposition.py
@@ -4,7 +4,7 @@ import numpy as np
 from cached_property import cached_property
 
 from devito.data.meta import LEFT
-from devito.tools import is_integer
+from devito.tools import is_integer, as_tuple
 
 __all__ = ['Decomposition']
 
@@ -121,11 +121,20 @@ class Decomposition(tuple):
             ret.append(item)
         return 'Decomposition(%s)' % ', '.join(ret)
 
-    def __call__(self, *args, rel=True):
-        """Alias for ``self.convert_index``."""
-        return self.convert_index(*args, rel=rel)
+    def __call__(self, *args, mode='glb_to_loc', rel=True):
+        """
+        Alias for ``self.index_glb_to_loc`` or ``self.index_loc_to_glb``
+        depending on mode.
+        """
+        if mode == 'glb_to_loc':
+            return self.index_glb_to_loc(*args, rel=rel)
+        elif mode == 'loc_to_glb':
+            return self.index_loc_to_glb(*args, rel=rel)
+        else:
+            raise ValueError("Mode not recognised. Available options: "
+                             "'glb_to_loc', 'loc_to_glb'")
 
-    def convert_index(self, *args, rel=True):
+    def index_glb_to_loc(self, *args, rel=True):
         """
         Convert a global index into a relative (default) or absolute local index.
 
@@ -166,33 +175,33 @@ class Decomposition(tuple):
 
         A global index as single argument:
 
-        >>> d.convert_index(5)
+        >>> d.index_glb_to_loc(5)
         0
-        >>> d.convert_index(6)
+        >>> d.index_glb_to_loc(6)
         1
-        >>> d.convert_index(7)
+        >>> d.index_glb_to_loc(7)
         2
-        >>> d.convert_index(3)
+        >>> d.index_glb_to_loc(3)
 
 
         Retrieve relative local min/man given global min/max
 
-        >>> d.convert_index((5, 7))
+        >>> d.index_glb_to_loc((5, 7))
         (0, 2)
-        >>> d.convert_index((5, 9))
+        >>> d.index_glb_to_loc((5, 9))
         (0, 2)
-        >>> d.convert_index((1, 3))
+        >>> d.index_glb_to_loc((1, 3))
         (-1, -3)
-        >>> d.convert_index((1, 6))
+        >>> d.index_glb_to_loc((1, 6))
         (0, 1)
-        >>> d.convert_index((None, None))
+        >>> d.index_glb_to_loc((None, None))
         (0, 2)
 
         Retrieve absolute local min/max given global min/max
 
-        >>> d.convert_index((5, 9), rel=False)
+        >>> d.index_glb_to_loc((5, 9), rel=False)
         (5, 7)
-        >>> d.convert_index((1, 6), rel=False)
+        >>> d.index_glb_to_loc((1, 6), rel=False)
         (5, 6)
         """
 
@@ -202,7 +211,7 @@ class Decomposition(tuple):
         if len(args) == 1:
             glb_idx = args[0]
             if is_integer(glb_idx):
-                # convert_index(index)
+                # index_glb_to_loc(index)
                 # -> Base case, empty local subdomain
                 if self.loc_empty:
                     return None
@@ -218,8 +227,8 @@ class Decomposition(tuple):
                     # This should raise an exception when used to access a numpy.array
                     return glb_idx
             else:
-                # convert_index((min, max))
-                # convert_index(slice(...))
+                # index_glb_to_loc((min, max))
+                # index_glb_to_loc(slice(...))
                 if isinstance(glb_idx, tuple):
                     if len(glb_idx) != 2:
                         raise TypeError("Cannot convert index from `%s`" % type(glb_idx))
@@ -230,9 +239,18 @@ class Decomposition(tuple):
                 elif isinstance(glb_idx, slice):
                     if self.loc_empty:
                         return slice(-1, -3)
-                    glb_idx_min = self.glb_min if glb_idx.start is None else glb_idx.start
-                    glb_idx_max = self.glb_max if glb_idx.stop is None else glb_idx.stop-1
-                    retfunc = lambda a, b: slice(a, b + 1, glb_idx.step)
+                    if glb_idx.step >= 0:
+                        glb_idx_min = self.glb_min if glb_idx.start is None \
+                            else glb_idx.start
+                        glb_idx_max = self.glb_max if glb_idx.stop is None \
+                            else glb_idx.stop-1
+                        retfunc = lambda a, b: slice(a, b + 1, glb_idx.step)
+                    else:
+                        glb_idx_min = self.glb_min if glb_idx.stop is None \
+                            else glb_idx.stop+1
+                        glb_idx_max = self.glb_max if glb_idx.start is None \
+                            else glb_idx.start
+                        retfunc = lambda a, b: slice(b, a - 1, glb_idx.step)
                 else:
                     raise TypeError("Cannot convert index from `%s`" % type(glb_idx))
                 # -> Handle negative min/max
@@ -241,21 +259,59 @@ class Decomposition(tuple):
                 if glb_idx_max is not None and glb_idx_max < 0:
                     glb_idx_max = self.glb_max + glb_idx_max + 1
                 # -> Do the actual conversion
-                if glb_idx_min is None or glb_idx_min < self.loc_abs_min:
+                # Compute loc_min. For a slice with step > 0 this will be
+                # used to produce slice.start and for a slice with step < 0 slice.stop.
+                # If glb_idx is a slice with step > 1 then for any given decomposition
+                # this case must be treated separately since the slice start may not
+                # coincide with loc_abs_min.
+                if isinstance(glb_idx, slice) and glb_idx.step is not None \
+                        and glb_idx.step > 1:
+                    if glb_idx_min > self.loc_abs_max:
+                        return retfunc(-1, -3)
+                    elif glb_idx.start is None:  # glb start is zero.
+                        loc_min = self.loc_abs_min - base \
+                            + np.mod(glb_idx.step - np.mod(base, glb_idx.step),
+                                     glb_idx.step)
+                    else:  # glb start is given explicitly
+                        loc_min = self.loc_abs_min - base \
+                            + np.mod(glb_idx.step - np.mod(base - glb_idx.start,
+                                                           glb_idx.step), glb_idx.step)
+                elif glb_idx_min is None or glb_idx_min < self.loc_abs_min:
                     loc_min = self.loc_abs_min - base
                 elif glb_idx_min > self.loc_abs_max:
                     return retfunc(-1, -3)
                 else:
                     loc_min = glb_idx_min - base
-                if glb_idx_max is None or glb_idx_max > self.loc_abs_max:
+                # Compute loc_max. For a slice with step > 0 this will be
+                # used to produce slice.stop and for a slice with step < 0 slice.start.
+                # If glb_idx is a slice with step < -1 then for any given decomposition
+                # this case must be treated separately since the slice start may not
+                # coincide with loc_abs_max.
+                if isinstance(glb_idx, slice) and glb_idx.step is not None \
+                        and glb_idx.step < -1:
+                    if glb_idx_max < self.loc_abs_min:
+                        return retfunc(-1, -3)
+                    elif glb_idx.start is None:
+                        loc_max = top - base \
+                            + np.mod(glb_idx.step - np.mod(top - self.glb_max,
+                                                           glb_idx.step), glb_idx.step)
+                    else:
+                        loc_max = top - base \
+                            + np.mod(glb_idx.step - np.mod(top - glb_idx.start,
+                                                           glb_idx.step), glb_idx.step)
+                elif glb_idx_max is None or glb_idx_max > self.loc_abs_max:
                     loc_max = self.loc_abs_max - base
                 elif glb_idx_max < self.loc_abs_min:
                     return retfunc(-1, -3)
                 else:
                     loc_max = glb_idx_max - base
-                return retfunc(loc_min, loc_max)
+                # Check for the special case of a slice with negative step
+                if isinstance(glb_idx, slice) and glb_idx.step < 0 and loc_min <= 0:
+                    return slice(loc_max, None, glb_idx.step)
+                else:
+                    return retfunc(loc_min, loc_max)
         elif len(args) == 2:
-            # convert_index(offset, side)
+            # index_glb_to_loc(offset, side)
             if self.loc_empty:
                 return 0
             rel_ofs, side = args
@@ -269,6 +325,98 @@ class Decomposition(tuple):
                 return min(top - abs_ofs, size) if abs_ofs < top else 0
         else:
             raise TypeError("Expected 1 or 2 arguments, found %d" % len(args))
+
+    def index_loc_to_glb(self, *args):
+        """
+        Convert a local index into a global index.
+
+        Parameters
+        ----------
+        *args
+            There are two possible cases:
+            * int. Given ``I``, a local index, return the corresponding
+              global local.
+            * slice(a, b, c). As above, return the corresponding global slice.
+
+        Raises
+        ------
+        TypeError
+            If the input doesn't adhere to any of the supported format.
+
+        Examples
+        --------
+        In the following example, the domain consists of 12 indices, split over
+        four subdomains [0, 3]. We pick 2 as local subdomain.
+
+        >>> d = Decomposition([[0, 1, 2], [3, 4], [5, 6, 7], [8, 9, 10, 11]], 2)
+        >>> d
+        Decomposition([0,2], [3,4], <<[5,7]>>, [8,11])
+
+        A local index as single argument:
+
+        >>> d.index_loc_to_glb(0)
+        5
+        >>> d.index_loc_to_glb(1)
+        6
+        >>> d.index_loc_to_glb(2)
+        7
+
+        A local slice as an argument:
+
+        >>> d.index_loc_to_glb(slice(0, 2, 1))
+        slice(5, 7, 1)
+        """
+
+        rank_length = self.loc_abs_max - self.loc_abs_min
+
+        if len(args) == 1:
+            loc_idx = args[0]
+            if is_integer(loc_idx):
+                # index_loc_to_glb(index)
+                # -> Check the index is in range
+                if loc_idx < 0 or loc_idx > rank_length:
+                    return slice(-1, -2, 1)
+                # -> Do the actual conversion
+                else:
+                    return loc_idx + self.loc_abs_min
+            else:
+                # index_loc_to_glb((min, max))
+                if isinstance(loc_idx, tuple):
+                    if len(loc_idx) != 2:
+                        raise TypeError("Cannot convert index from `%s`" % type(loc_idx))
+                    shifted = [slice(-1, -2, 1) if (i < 0 or i > rank_length) else
+                               i + self.loc_abs_min for i in loc_idx]
+                    return as_tuple(shifted)
+                # index_loc_to_glb(slice(...))
+                elif isinstance(loc_idx, slice):
+                    if loc_idx.start is not None \
+                            and loc_idx.start < 0 or loc_idx.start > rank_length:
+                        return slice(-1, -2, 1)
+                    if loc_idx.start is not None \
+                            and loc_idx.stop < 0 or loc_idx.stop > rank_length + 1:
+                        return slice(-1, -2, 1)
+                    if loc_idx.step >= 0 or loc_idx.step is None:
+                        if loc_idx.start is None:
+                            glb_start = self.loc_abs_min
+                        else:
+                            glb_start = loc_idx.start + self.loc_abs_min
+                        if loc_idx.stop is None:
+                            glb_stop = self.loc_abs_max
+                        else:
+                            glb_stop = loc_idx.stop + self.loc_abs_min
+                        return slice(glb_start, glb_stop, loc_idx.step)
+                    else:
+                        if loc_idx.start is None:
+                            glb_start = self.loc_abs_max
+                        else:
+                            glb_start = loc_idx.start + self.loc_abs_min
+                        if loc_idx.stop is None:
+                            glb_stop = None
+                        else:
+                            glb_stop = loc_idx.stop + self.loc_abs_min
+                        return slice(glb_start, glb_stop, loc_idx.step)
+        else:
+            raise TypeError("Expected 1 arguments, found %d" % len(args))
 
     def reshape(self, *args):
         """

--- a/devito/data/utils.py
+++ b/devito/data/utils.py
@@ -1,0 +1,330 @@
+import numpy as np
+
+from devito.tools import Tag, as_tuple, is_integer
+
+__all__ = ['Index', 'NONLOCAL', 'PROJECTED', 'index_is_basic', 'index_apply_modulo',
+           'index_dist_to_repl', 'convert_index', 'index_handle_oob',
+           'loc_data_idx', 'mpi_index_maps']
+
+
+class Index(Tag):
+    pass
+NONLOCAL = Index('nonlocal')  # noqa
+PROJECTED = Index('projected')
+
+
+def index_is_basic(idx):
+    if is_integer(idx):
+        return True
+    elif isinstance(idx, (slice, np.ndarray)):
+        return False
+    else:
+        return all(is_integer(i) or (i is NONLOCAL) for i in idx)
+
+
+def index_apply_modulo(idx, modulo):
+    if is_integer(idx):
+        return idx % modulo
+    elif isinstance(idx, slice):
+        if idx.start is None:
+            start = idx.start
+        elif idx.start >= 0:
+            start = idx.start % modulo
+        else:
+            start = -(idx.start % modulo)
+        if idx.stop is None:
+            stop = idx.stop
+        elif idx.stop >= 0:
+            stop = idx.stop % (modulo + 1)
+        else:
+            stop = -(idx.stop % (modulo + 1))
+        return slice(start, stop, idx.step)
+    elif isinstance(idx, (tuple, list)):
+        return [i % modulo for i in idx]
+    elif isinstance(idx, np.ndarray):
+        return idx
+    else:
+        raise ValueError("Cannot apply modulo to index of type `%s`" % type(idx))
+
+
+def index_dist_to_repl(idx, decomposition):
+    """Convert a distributed array index into a replicated array index."""
+    if decomposition is None:
+        return PROJECTED if is_integer(idx) else slice(None)
+
+    # Derive shift value
+    if isinstance(idx, slice):
+        if idx.step is None or idx.step >= 0:
+            value = idx.start
+        else:
+            value = idx.stop
+    else:
+        value = idx
+    if value is None:
+        value = 0
+    elif not is_integer(value):
+        raise ValueError("Cannot derive shift value from type `%s`" % type(value))
+
+    # Convert into absolute local index
+    idx = decomposition.index_glb_to_loc(idx, rel=False)
+
+    if is_integer(idx):
+        return PROJECTED
+    elif idx is None:
+        return NONLOCAL
+    elif isinstance(idx, (tuple, list)):
+        return [i - value for i in idx]
+    elif isinstance(idx, np.ndarray):
+        return idx - value
+    elif isinstance(idx, slice):
+        if idx.step is not None and idx.step < 0:
+            if idx.stop is None:
+                return slice(idx.start - value, None, idx.step)
+        return slice(idx.start - value, idx.stop - value, idx.step)
+    else:
+        raise ValueError("Cannot apply shift to type `%s`" % type(idx))
+
+
+def convert_index(idx, decomposition, mode='glb_to_loc'):
+    """Convert a global index into a local index or vise versa according to mode."""
+    if is_integer(idx) or isinstance(idx, slice):
+        return decomposition(idx, mode=mode)
+    elif isinstance(idx, (tuple, list)):
+        return [decomposition(i, mode=mode) for i in idx]
+    elif isinstance(idx, np.ndarray):
+        return np.vectorize(lambda i: decomposition(i, mode=mode))(idx)
+    else:
+        raise ValueError("Cannot convert index of type `%s` " % type(idx))
+
+
+def index_handle_oob(idx):
+    # distributed.index_glb_to_loc returns None when the index is globally
+    # legal, but out-of-bounds for the calling MPI rank
+    if idx is None:
+        return NONLOCAL
+    elif isinstance(idx, (tuple, list)):
+        return [i for i in idx if i is not None]
+    elif isinstance(idx, np.ndarray):
+        if idx.dtype == np.bool_:
+            # A boolean mask, nothing to do
+            return idx
+        elif idx.ndim == 1:
+            return np.delete(idx, np.where(idx == None))  # noqa
+        else:
+            raise ValueError("Cannot identify OOB accesses when using "
+                             "multidimensional index arrays")
+    else:
+        return idx
+
+
+def loc_data_idx(loc_idx):
+    """
+    Return tuple of slices containing the unflipped idx corresponding to loc_idx.
+    By 'unflipped' we mean that if a slice has a negative step, we wish to retrieve
+    the corresponding indices but not in reverse order.
+
+    Examples
+    --------
+    >>> loc_data_idx(slice(11, None, -3))
+    (slice(2, 12, 3),)
+    """
+    retval = []
+    for i in as_tuple(loc_idx):
+        if isinstance(i, slice) and i.step is not None and i.step == -1:
+            if i.stop is None:
+                retval.append(slice(0, i.start+1, -i.step))
+            else:
+                retval.append(slice(i.stop+1, i.start+1, -i.step))
+        elif isinstance(i, slice) and i.step is not None and i.step < -1:
+            if i.stop is None:
+                lmin = i.start
+                while lmin >= 0:
+                    lmin += i.step
+                retval.append(slice(lmin-i.step, i.start+1, -i.step))
+            else:
+                retval.append(slice(i.stop+1, i.start+1, -i.step))
+        elif is_integer(i):
+            retval.append(slice(i, i+1, 1))
+        else:
+            retval.append(i)
+    return as_tuple(retval)
+
+
+def mpi_index_maps(loc_idx, shape, topology, coords, comm):
+    """
+    Generate various data structures used to determine what MPI communication
+    is required. The function creates the following:
+
+    owners: An array of shape ``shape`` where each index signifies the rank on which
+    that data is stored.
+
+    send: An array of shape ``shape`` where each index signifies the rank to which
+    data beloning to that index should be sent.
+
+    global_si: An array of ``shape`` shape where each index contains the global index
+    to which that index should be sent.
+
+    local_si: An array of shape ``shape`` where each index contains the local index
+    (on the destination rank) to which that index should be sent.
+
+    Examples
+    --------
+    An array is given by A = [[  0,  1,  2,  3],
+                              [  4,  5,  6,  7],
+                              [  8,  9, 10, 11],
+                              [ 12, 13, 14, 15]],
+    which is then distributed over four ranks such that on rank 0:
+
+    A = [[ 0, 1],
+         [ 4, 5]],
+
+    on rank 1:
+
+    A = [[ 2, 3],
+         [ 6, 7]],
+
+    on rank 2:
+
+    A = [[  8,  9],
+         [ 12, 13]],
+
+    on rank 3:
+
+    A = [[ 10, 11],
+         [ 14, 15]].
+
+    Taking the slice A[2:0:-1, 2:0:-1] the expected output (in serial) is
+
+    [[  0,  1,  2,  3],
+     [  4, 10,  9,  7],
+     [  8,  6,  5, 11],
+     [ 12, 13, 14, 15]],
+
+    Hence, in this case the following would be generated:
+
+    owners = [[0, 1],
+              [2, 3]],
+
+    send = [[3, 2],
+            [1, 0]],
+
+    global_si = [[(2, 2), (2, 1)],
+                 [(1, 2), (1, 1)]],
+
+    local_si = [[(0, 0), (0, 1)],
+                [(1, 0), (1, 1)]].
+    """
+
+    nprocs = comm.Get_size()
+
+    # Gather data structures from all ranks in order to produce the
+    # relevant mappings.
+    dat_len = np.zeros(topology, dtype=tuple)
+    for j in range(nprocs):
+        dat_len[coords[j]] = comm.bcast(shape, root=j)
+        if any(k == 0 for k in dat_len[coords[j]]):
+            dat_len[coords[j]] = as_tuple([0]*len(dat_len[coords[j]]))
+    # Work out the cumulative data shape
+    dat_len_cum = np.zeros(topology, dtype=tuple)
+    for i in range(nprocs):
+        my_coords = coords[i]
+        if i == 0:
+            dat_len_cum[my_coords] = dat_len[my_coords]
+            continue
+        left_neighbours = []
+        for j in range(len(my_coords)):
+            left_coord = list(my_coords)
+            left_coord[j] -= 1
+            left_neighbours.append(as_tuple(left_coord))
+        left_neighbours = as_tuple(left_neighbours)
+        n_dat = []  # Normalised data size
+        for j in range(len(my_coords)):
+            if left_neighbours[j][j] < 0:
+                c_dat = dat_len[my_coords][j]
+                n_dat.append(c_dat)
+            else:
+                c_dat = dat_len[my_coords][j]  # Current length
+                p_dat = dat_len[left_neighbours[j]][j]  # Previous length
+                n_dat.append(c_dat+p_dat)
+        dat_len_cum[my_coords] = as_tuple(n_dat)
+    # This 'transform' will be required to produce the required maps
+    transform = []
+    for i in as_tuple(loc_idx):
+        if isinstance(i, slice):
+            if i.step is not None:
+                transform.append(slice(None, None, np.sign(i.step)))
+            else:
+                transform.append(slice(None, None, None))
+        else:
+            transform.append(0)
+    transform = as_tuple(transform)
+
+    global_size = dat_len_cum[coords[-1]]
+
+    indices = np.zeros(global_size, dtype=tuple)
+    global_si = np.zeros(global_size, dtype=tuple)
+    it = np.nditer(indices, flags=['refs_ok', 'multi_index'])
+    while not it.finished:
+        index = it.multi_index
+        indices[index] = index
+        it.iternext()
+    global_si[:] = indices[transform]
+
+    # Create the 'rank' slices
+    rank_slice = []
+    for j in coords:
+        this_rank = []
+        for k in dat_len[j]:
+            this_rank.append(slice(0, k, 1))
+        rank_slice.append(this_rank)
+    # Normalize the slices:
+    n_rank_slice = []
+    for i in range(len(rank_slice)):
+        my_coords = coords[i]
+        if any([j.stop == j.start for j in rank_slice[i]]):
+            n_rank_slice.append(as_tuple([None]*len(rank_slice[i])))
+            continue
+        if i == 0:
+            n_rank_slice.append(as_tuple(rank_slice[i]))
+            continue
+        left_neighbours = []
+        for j in range(len(my_coords)):
+            left_coord = list(my_coords)
+            left_coord[j] -= 1
+            left_neighbours.append(as_tuple(left_coord))
+        left_neighbours = as_tuple(left_neighbours)
+        n_slice = []
+        for j in range(len(my_coords)):
+            if left_neighbours[j][j] < 0:
+                start = 0
+                stop = dat_len_cum[my_coords][j]
+            else:
+                start = dat_len_cum[left_neighbours[j]][j]
+                stop = dat_len_cum[my_coords][j]
+            n_slice.append(slice(start, stop, 1))
+        n_rank_slice.append(as_tuple(n_slice))
+    n_rank_slice = as_tuple(n_rank_slice)
+
+    # Now fill each elements owner:
+    owners = np.zeros(global_size, dtype=np.int32)
+    send = np.zeros(global_size, dtype=np.int32)
+    for i in range(len(n_rank_slice)):
+        if any([j is None for j in n_rank_slice[i]]):
+            continue
+        else:
+            owners[n_rank_slice[i]] = i
+    send[:] = owners[transform]
+
+    # Construct local_si
+    local_si = np.zeros(global_size, dtype=tuple)
+    it = np.nditer(local_si, flags=['refs_ok', 'multi_index'])
+    while not it.finished:
+        index = it.multi_index
+        owner = owners[index]
+        my_slice = n_rank_slice[owner]
+        rnorm_index = []
+        for j, k in zip(my_slice, index):
+            rnorm_index.append(k-j.start)
+        local_si[index] = as_tuple(rnorm_index)
+        it.iternext()
+    return owners, send, global_si, local_si

--- a/devito/mpi/distributed.py
+++ b/devito/mpi/distributed.py
@@ -144,7 +144,7 @@ class AbstractDistributor(ABC):
             The global index Dimension.
         *args
             There are several possibilities, documented in
-            :meth:`Decomposition.convert_index`.
+            :meth:`Decomposition.index_glb_to_loc`.
         strict : bool, optional
             If False, return args without raising an error if `dim` does not appear
             among the Distributor Dimensions.
@@ -154,7 +154,7 @@ class AbstractDistributor(ABC):
                 raise ValueError("`%s` must be one of the Distributor dimensions" % dim)
             else:
                 return args[0]
-        return self.decomposition[dim].convert_index(*args)
+        return self.decomposition[dim].index_glb_to_loc(*args)
 
 
 class Distributor(AbstractDistributor):
@@ -374,6 +374,10 @@ class Distributor(AbstractDistributor):
         in the decomposed grid.
         """
         return MPINeighborhood(self.neighborhood)
+
+    def _rebuild(self, shape=None, dimensions=None, comm=None):
+        return Distributor(shape or self.shape, dimensions or self.dimensions,
+                           comm or self.comm)
 
 
 class SparseDistributor(AbstractDistributor):

--- a/devito/types/dense.py
+++ b/devito/types/dense.py
@@ -112,7 +112,8 @@ class DiscreteFunction(AbstractCachedFunction, ArgProvider):
             if self._data is None:
                 debug("Allocating memory for %s%s" % (self.name, self.shape_allocated))
                 self._data = Data(self.shape_allocated, self.dtype,
-                                  modulo=self._mask_modulo, allocator=self._allocator)
+                                  modulo=self._mask_modulo, allocator=self._allocator,
+                                  distributor=self._distributor)
                 if self._first_touch:
                     assign(self, 0)
                 if callable(self._initializer):

--- a/tests/test_docstrings.py
+++ b/tests/test_docstrings.py
@@ -25,7 +25,7 @@ pytestmark = skipif(['yask', 'ops'])
     'types.dense', 'types.sparse', 'equation', 'operator',
     'data.decomposition', 'finite_differences.finite_difference',
     'finite_differences.coefficients', 'finite_differences.derivative',
-    'ir.support.space'
+    'ir.support.space', 'data.utils'
 ])
 def test_docstrings(modname):
     module = import_module('devito.%s' % modname)

--- a/tests/test_interpolation.py
+++ b/tests/test_interpolation.py
@@ -127,7 +127,7 @@ def test_precomputed_interpolation_time():
     op(time_m=0, time_M=4)
 
     for it in range(5):
-        assert all(np.isclose(sf.data[it, :], it))
+        assert np.allclose(sf.data[it, :], it)
 
 
 @pytest.mark.parametrize('shape, coords', [


### PR DESCRIPTION
In the current master, slicing function data does not work correctly when the step is negative i.e. something along the lines of `u.data[5::-1]` does not return the expected result.

This problem occurs due to how the `start` and `stop` of a `slice` are set in `convert_index` (found in `devito/data/decomposition.py`).

The purpose of this PR will be to fix the bug stated above and to add some tests checking slicing with negative steps is carried out correctly.

Note that the main purpose PR in its current state is to ensure that the update passes all tests. The manner in which the bug is addressed in `convert_index` can still potentially be tidied up.