### PR TITLE
restore _lib when unpickling Operator

### DIFF
--- a/devito/operator.py
+++ b/devito/operator.py
@@ -577,7 +577,7 @@ class Operator(Callable):
     def __getstate__(self):
         if self._lib:
             state = dict(self.__dict__)
-            state.pop('_soname')
+            # state.pop('_soname')
             # The compiled shared-object will be pickled; upon unpickling, it
             # will be restored into a potentially different temporary directory,
             # so the entire process during which the shared-object is loaded and
@@ -618,6 +618,8 @@ class Operator(Callable):
                         "this might be a bug, or simply a harmless difference in "
                         "`configuration`. You may check they produce the same code.")
             save(self._soname, binary, self._compiler)
+            self._lib = load(self._soname)
+            self._lib.name = self._soname
 
 
 # Misc helpers


### PR DESCRIPTION
There are really two changes here:

* save `soname` in `__getstate__`, so that the matching logic in `__setstate__` is executed
* add loading of the library as part of `__setstate__`, so that `_compile` doesn't recompile it after unpickling