### PR TITLE
knl detection fix

### DIFF
--- a/devito/data/allocators.py
+++ b/devito/data/allocators.py
@@ -8,7 +8,6 @@ import numpy as np
 import ctypes
 from ctypes.util import find_library
 
-from devito.archinfo import KNL
 from devito.logger import logger
 from devito.parameters import configuration
 from devito.tools import dtype_to_ctype
@@ -310,7 +309,7 @@ ALLOC_NUMA_LOCAL = NumaAllocator('local')
 
 
 def infer_knl_mode():
-    path = os.path.join('sys', 'bus', 'node', 'devices', 'node1')
+    path = os.path.join('/sys', 'bus', 'node', 'devices', 'node1')
     return 'flat' if os.path.exists(path) else 'cache'
 
 
@@ -343,7 +342,7 @@ def default_allocator():
     if configuration['develop-mode']:
         return ALLOC_GUARD
     elif NumaAllocator.available():
-        if configuration['platform'] is KNL and infer_knl_mode() == 'flat':
+        if configuration['platform'].name == 'knl' and infer_knl_mode() == 'flat':
             return ALLOC_KNL_MCDRAM
         else:
             return ALLOC_NUMA_LOCAL


### PR DESCRIPTION
Trivial fixes to KNL flat mode detection.  The "is KNL" doesn't work anymore because there is a second definition of the KNL7210 platform now, which is a distinct object.