### PR TITLE
operator: configuration settings are saved and printed in performance logging

### DIFF
--- a/devito/operator.py
+++ b/devito/operator.py
@@ -190,6 +190,11 @@ class Operator(Callable):
         iet = self._finalize(iet, parameters)
 
         super(Operator, self).__init__(self.name, iet, 'int', parameters, ())
+        config_state = {}
+        self._state['optimizations'] = config_state
+        for key in configuration.keys():
+            config_val = kwargs.get(key, configuration[key])
+            config_state[key] = config_val
 
     # Read-only fields exposed to the outside world
 
@@ -539,6 +544,10 @@ class Operator(Callable):
             gpointss = ", %.2f GPts/s" % v.gpointss if v.gpointss else ''
             perf("* %s with OI=%.2f computed in %.3f s [%.2f GFlops/s%s]" %
                  (name, v.oi, v.time, v.gflopss, gpointss))
+
+        perf("* %s configuration:  %s " %
+             (self.name, self._state['optimizations']))
+
         return summary
 
     @cached_property

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -154,7 +154,7 @@ class Operator(Callable):
 
         # Internal state. May be used to store information about previous runs,
         # autotuning reports, etc
-        self._state = {}
+        self._state = self._initialize_state(**kwargs)
 
         # Form and gather any required implicit expressions
         expressions = self._add_implicit(expressions)
@@ -190,11 +190,6 @@ class Operator(Callable):
         iet = self._finalize(iet, parameters)
 
         super(Operator, self).__init__(self.name, iet, 'int', parameters, ())
-        config_state = {}
-        self._state['optimizations'] = config_state
-        for key in configuration.keys():
-            config_val = kwargs.get(key, configuration[key])
-            config_state[key] = config_val
 
     # Read-only fields exposed to the outside world
 
@@ -214,6 +209,9 @@ class Operator(Callable):
     @cached_property
     def objects(self):
         return tuple(i for i in self.parameters if i.is_Object)
+
+    def _initialize_state(self, **kwargs):
+        return {'optimizations': {k: kwargs.get(k, v) for k, v in configuration.items()}}
 
     # Compilation
 

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -211,7 +211,8 @@ class Operator(Callable):
         return tuple(i for i in self.parameters if i.is_Object)
 
     def _initialize_state(self, **kwargs):
-        return {'optimizations': {k: kwargs.get(k, v) for k, v in configuration.items()}}
+        return {'optimizations': {k: kwargs.get(k, configuration[k])
+                                  for k in ('dse', 'dle')}}
 
     # Compilation
 


### PR DESCRIPTION
The devito configuration dictionary at the time an operator is constructed is now saved to that operator's state, accessible via Operator._state['optimizations']. 

The purpose of this is to allow reproducibility in the case that a user did not modify their Python script (same operator, space_order, etc.) but maybe called a Python script from a terminal or runscript where certain environment variables (e.g. DEVITO_DSE) were set. New printouts include pertinent configuration settings for a given operator. 

