### PR TITLE
compiler: change load/save/make/get_jit_dir/get_codepy_dir into methods

### DIFF
--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -472,8 +472,6 @@ class CustomCompiler(Compiler):
         self.MPICXX = 'mpicxx'
 
 
-
-
 compiler_registry = {
     'custom': CustomCompiler,
     'gnu': GNUCompiler,

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -5,7 +5,6 @@ from operator import mul
 from cached_property import cached_property
 import ctypes
 
-from devito.compiler import jit_compile
 from devito.dle import transform
 from devito.dse import rewrite
 from devito.equation import Eq
@@ -419,7 +418,7 @@ class Operator(Callable):
         Operator, reagardless of how many times this method is invoked.
         """
         if self._lib is None:
-            jit_compile(self._soname, str(self.ccode), self._compiler)
+            self._compiler.jit_compile(self._soname, str(self.ccode))
 
     @property
     def cfunction(self):

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -5,7 +5,7 @@ from operator import mul
 from cached_property import cached_property
 import ctypes
 
-from devito.compiler import jit_compile, load, save
+from devito.compiler import jit_compile
 from devito.dle import transform
 from devito.dse import rewrite
 from devito.equation import Eq
@@ -426,7 +426,7 @@ class Operator(Callable):
         """The JIT-compiled C function as a ctypes.FuncPtr object."""
         if self._lib is None:
             self._compile()
-            self._lib = load(self._soname)
+            self._lib = self._compiler.load(self._soname)
             self._lib.name = self._soname
 
         if self._cfunction is None:
@@ -616,8 +616,8 @@ class Operator(Callable):
                 warning("The pickled and unpickled Operators have different .sonames; "
                         "this might be a bug, or simply a harmless difference in "
                         "`configuration`. You may check they produce the same code.")
-            save(self._soname, binary, self._compiler)
-            self._lib = load(self._soname)
+            self._compiler.save(self._soname, binary)
+            self._lib = self._compiler.load(self._soname)
             self._lib.name = self._soname
 
 

--- a/devito/yask/wrappers.py
+++ b/devito/yask/wrappers.py
@@ -8,7 +8,6 @@ from collections import OrderedDict
 
 from codepy.jit import CacheLockManager, CleanupManager
 
-from devito.compiler import make
 from devito.logger import debug, yask as log, yask_warning as warning
 from devito.tools import Signer, powerset, filter_sorted
 
@@ -106,7 +105,7 @@ class YaskKernel(object):
                 args.append('check=1')   # Activate internal YASK asserts
                 args.append('trace=1')   # Print out verbose progress msgs w/-trace knob
                 args.append('trace_mem=0')   # Print out verbose mem-access msgs
-            make(namespace['path'], args)
+            compiler.make(namespace['path'], args)
 
             # Now we must be able to import the SWIG-generated Python module
             invalidate_caches()


### PR DESCRIPTION
This allows Compiler subclasses to customise the locations of the build directories etc, for cases where `tempfile.gettempdir()` returns something that we don't want to use.