### PR TITLE
seismic: source return itself if resampling not required

### DIFF
--- a/examples/seismic/model.py
+++ b/examples/seismic/model.py
@@ -619,7 +619,7 @@ class Model(GenericModel):
         # dt <= coeff * h / (max(velocity))
         coeff = 0.38 if len(self.shape) == 3 else 0.42
         dt = self.dtype(coeff * mmin(self.spacing) / (self.scale*mmax(self.vp)))
-        return .001 * int(1000 * dt)
+        return self.dtype("%.3f" % dt)
 
     @property
     def vp(self):

--- a/examples/seismic/source.py
+++ b/examples/seismic/source.py
@@ -166,7 +166,7 @@ class PointSource(SparseTimeFunction):
             new_time_range = TimeAxis(start=start, stop=stop, step=dt)
 
         if np.isclose(dt, dt0):
-            return
+            return self
 
         nsamples, ntraces = self.data.shape
 


### PR DESCRIPTION
Tiny fix as currently `src.resample(dt=src.dt)` returns None instead of itself.