### PR TITLE
Performance optimizations

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -12,8 +12,8 @@ jobs:
     vmImage: 'Ubuntu 16.04'
   strategy:
     matrix:
-      pip-gcc6-py36:
-        gccVersion: '6'
+      pip-gcc8-py36:
+        gccVersion: '8'
         DEVITO_OPENMP: '0'
         MPI_INSTALL: '0'
         installWithPip: 'true'

--- a/benchmarks/user/benchmark.py
+++ b/benchmarks/user/benchmark.py
@@ -5,7 +5,7 @@ import numpy as np
 import click
 
 from devito import clear_cache, configuration, mode_develop, mode_benchmark, warning
-from devito.tools import as_tuple, flatten, sweep
+from devito.tools import as_tuple, sweep
 from examples.seismic.acoustic.acoustic_example import run as acoustic_run, acoustic_setup
 from examples.seismic.tti.tti_example import run as tti_run, tti_setup
 
@@ -96,8 +96,8 @@ def option_performance(f):
 @benchmark.command(name='run')
 @option_simulation
 @option_performance
-@click.option('-bs', '--block-shape', default=(0, 0, 0), multiple=True,
-              help='Loop-blocking shape, bypass autotuning')
+@click.option('-bs', '--block-shape', nargs=3, type=(int, int, int),
+              multiple=True, help='Loop-blocking shape, bypass autotuning')
 def cli_run(problem, **kwargs):
     """
     A single run with a specific set of performance parameters.
@@ -120,7 +120,7 @@ def run(problem, **kwargs):
 
     # Should a specific block-shape be used? Useful if one wants to skip
     # the autotuning pass as a good block-shape is already known
-    if all(flatten(block_shapes)):
+    if block_shapes:
         if autotune:
             warning("Skipping autotuning (using explicit block-shape `%s`)"
                     % str(block_shapes))

--- a/devito/__init__.py
+++ b/devito/__init__.py
@@ -52,7 +52,7 @@ configuration.add('log-level', 'INFO', list(logger_registry),
 configuration.add('jit-backdoor', 0, [0, 1], lambda i: bool(i), False)
 
 # Enable/disable automatic padding for allocated data
-configuration.add('autopadding', True, [False, True])
+configuration.add('autopadding', False, [False, True])
 
 # Execution mode setup
 def _reinit_compiler(val):  # noqa

--- a/devito/__init__.py
+++ b/devito/__init__.py
@@ -51,6 +51,9 @@ configuration.add('log-level', 'INFO', list(logger_registry),
 # and will instead use the custom kernel
 configuration.add('jit-backdoor', 0, [0, 1], lambda i: bool(i), False)
 
+# Enable/disable automatic padding for allocated data
+configuration.add('autopadding', True, [False, True])
+
 # Execution mode setup
 def _reinit_compiler(val):  # noqa
     # Force re-build the compiler

--- a/devito/core/__init__.py
+++ b/devito/core/__init__.py
@@ -6,7 +6,8 @@ backend as well) are used to run Devito on standard CPU architectures.
 
 from devito.archinfo import Cpu64, Intel64, Arm, Power, Device
 from devito.dle import (CPU64Rewriter, Intel64Rewriter, ArmRewriter, PowerRewriter,
-                        SpeculativeRewriter, DeviceOffloadingRewriter, modes)
+                        PlatformRewriter, SpeculativeRewriter, DeviceOffloadingRewriter,
+                        modes)
 from devito.parameters import Parameters, add_sub_configuration
 
 core_configuration = Parameters('core')
@@ -14,15 +15,20 @@ env_vars_mapper = {}
 add_sub_configuration(core_configuration, env_vars_mapper)
 
 # Add core-specific DLE modes
-modes.add(Cpu64, {'advanced': CPU64Rewriter,
+modes.add(Cpu64, {'noop': PlatformRewriter,
+                  'advanced': CPU64Rewriter,
                   'speculative': SpeculativeRewriter})
-modes.add(Intel64, {'advanced': Intel64Rewriter,
+modes.add(Intel64, {'noop': PlatformRewriter,
+                    'advanced': Intel64Rewriter,
                     'speculative': SpeculativeRewriter})
-modes.add(Arm, {'advanced': ArmRewriter,
+modes.add(Arm, {'noop': PlatformRewriter,
+                'advanced': ArmRewriter,
                 'speculative': SpeculativeRewriter})
-modes.add(Power, {'advanced': PowerRewriter,
+modes.add(Power, {'noop': PlatformRewriter,
+                  'advanced': PowerRewriter,
                   'speculative': SpeculativeRewriter})
-modes.add(Device, {'advanced': DeviceOffloadingRewriter,
+modes.add(Device, {'noop': PlatformRewriter,
+                   'advanced': DeviceOffloadingRewriter,
                    'speculative': DeviceOffloadingRewriter})
 
 # The following used by backends.backendSelector

--- a/devito/dle/blocking_utils.py
+++ b/devito/dle/blocking_utils.py
@@ -64,7 +64,7 @@ class Blocker(object):
             level_i = [[] for i in range(1, self.nlevels)]  # Inner levels of blocking
             intra = []  # Within the smallest block
             for i in iterations:
-                template = "%s%d_blk%s" % (i.dim.name, len(mapper), '%d')
+                template = "%s%d_blk%s" % (i.dim.name, self.nblocked, '%d')
                 properties = (PARALLEL,) + ((AFFINE,) if i.is_Affine else ())
 
                 # Build Iteration across `level_0` blocks

--- a/devito/dle/parallelizer.py
+++ b/devito/dle/parallelizer.py
@@ -69,7 +69,7 @@ class Ompizer(object):
     than this threshold.
     """
 
-    COLLAPSE_NCORES = 32
+    COLLAPSE_NCORES = 4
     """
     Use a collapse clause if the number of available physical cores is greater
     than this threshold.

--- a/devito/dle/rewriters.py
+++ b/devito/dle/rewriters.py
@@ -8,13 +8,12 @@ import cgen
 from devito.dle.blocking_utils import Blocker, BlockDimension
 from devito.dle.parallelizer import Ompizer
 from devito.exceptions import DLEException
-from devito.ir.iet import (Call, Expression, Iteration, List, HaloSpot, Prodder,
-                           FindSymbols, FindNodes, FindAdjacent, MapNodes, Transformer,
-                           compose_nodes, filter_iterations, retrieve_iteration_tree)
+from devito.ir.iet import (Call, Iteration, List, HaloSpot, Prodder, FindSymbols,
+                           FindNodes, FindAdjacent, MapNodes, Transformer,
+                           filter_iterations, retrieve_iteration_tree)
 from devito.logger import perf_adv
 from devito.mpi import HaloExchangeBuilder, HaloScheme
 from devito.parameters import configuration
-from devito.symbolics import ccode
 from devito.tools import DAG, as_tuple, filter_ordered
 
 __all__ = ['PlatformRewriter', 'CPU64Rewriter', 'Intel64Rewriter', 'PowerRewriter',
@@ -335,6 +334,34 @@ class PlatformRewriter(AbstractRewriter):
         return self._node_parallelizer.make_parallel(iet)
 
     @dle_pass
+    def _minimize_remainders(self, iet):
+        """
+        Adjust ROUNDABLE Iteration bounds so as to avoid the insertion of remainder
+        loops by the backend compiler.
+        """
+        roundable = [i for i in FindNodes(Iteration).visit(iet) if i.is_Roundable]
+
+        mapper = {}
+        for i in roundable:
+            functions = FindSymbols().visit(i)
+
+            # Get the SIMD vector length
+            dtypes = {f.dtype for f in functions if f.is_Tensor}
+            assert len(dtypes) == 1
+            vl = configuration['platform'].simd_items_per_reg(dtypes.pop())
+
+            # Round up `i`'s max point so that at runtime only vector iterations
+            # will be performed (i.e., remainder loops won't be necessary)
+            m, M, step = i.limits
+            limits = (m, M + (i.symbolic_size % vl), step)
+
+            mapper[i] = i._rebuild(limits=limits)
+
+        iet = Transformer(mapper).visit(iet)
+
+        return iet, {}
+
+    @dle_pass
     def _hoist_prodders(self, iet):
         """
         Move Prodders within the outer levels of an Iteration tree.
@@ -371,6 +398,7 @@ class CPU64Rewriter(PlatformRewriter):
         self._simdize(state)
         if self.params['openmp']:
             self._node_parallelize(state)
+        self._minimize_remainders(state)
         self._hoist_prodders(state)
 
 
@@ -465,72 +493,6 @@ class SpeculativeRewriter(CPU64Rewriter):
                 if i.is_Vectorizable:
                     mapper[i] = List(header=pragma, body=i)
         processed = Transformer(mapper).visit(processed)
-
-        return processed, {}
-
-    @dle_pass
-    def _minimize_remainders(self, iet):
-        """
-        Reshape temporary tensors and adjust loop trip counts to prevent as many
-        compiler-generated remainder loops as possible.
-        """
-        # The innermost dimension is the one that might get padded
-        p_dim = -1
-
-        mapper = {}
-        for tree in retrieve_iteration_tree(iet):
-            vector_iterations = [i for i in tree if i.is_Vectorizable]
-            if not vector_iterations or len(vector_iterations) > 1:
-                continue
-            root = vector_iterations[0]
-
-            # Padding
-            writes = [i.write for i in FindNodes(Expression).visit(root)
-                      if i.write.is_Array]
-            padding = []
-            for i in writes:
-                try:
-                    simd_items = self.platform.simd_items_per_reg(i.dtype)
-                except KeyError:
-                    return iet, {}
-                padding.append(simd_items - i.shape[-1] % simd_items)
-            if len(set(padding)) == 1:
-                padding = padding[0]
-                for i in writes:
-                    padded = (i._padding[p_dim][0], i._padding[p_dim][1] + padding)
-                    i.update(padding=i._padding[:p_dim] + (padded,))
-            else:
-                # Padding must be uniform -- not the case, so giving up
-                continue
-
-            # Dynamic trip count adjustment
-            endpoint = root.symbolic_max
-            if not endpoint.is_Symbol:
-                continue
-            condition = []
-            externals = set(i.symbolic_shape[-1] for i in FindSymbols().visit(root)
-                            if i.is_Tensor)
-            for i in root.uindices:
-                for j in externals:
-                    condition.append(root.symbolic_max + padding < j)
-            condition = ' && '.join(ccode(i) for i in condition)
-            endpoint_padded = endpoint.func('_%s' % endpoint.name)
-            init = cgen.Initializer(
-                cgen.Value("const int", endpoint_padded),
-                cgen.Line('(%s) ? %s : %s' % (condition,
-                                              ccode(endpoint + padding),
-                                              endpoint))
-            )
-
-            # Update the Iteration bound
-            limits = list(root.limits)
-            limits[1] = endpoint_padded.func(endpoint_padded.name)
-            rebuilt = list(tree)
-            rebuilt[rebuilt.index(root)] = root._rebuild(limits=limits)
-
-            mapper[tree[0]] = List(header=init, body=compose_nodes(rebuilt))
-
-        processed = Transformer(mapper).visit(iet)
 
         return processed, {}
 

--- a/devito/dle/rewriters.py
+++ b/devito/dle/rewriters.py
@@ -265,7 +265,7 @@ class PlatformRewriter(AbstractRewriter):
     @dle_pass
     def _loop_blocking(self, iet):
         """
-        Apply loop blocking to PARALLEL Iteration trees.
+        Apply hierarchical loop blocking to PARALLEL Iteration trees.
         """
         return self._node_blocker.make_blocking(iet)
 

--- a/devito/dle/transformer.py
+++ b/devito/dle/transformer.py
@@ -2,14 +2,14 @@ from collections import OrderedDict
 
 from devito.archinfo import Platform, Cpu64
 from devito.ir.iet import Node
-from devito.dle.rewriters import CPU64Rewriter, CustomRewriter, State
+from devito.dle.rewriters import CPU64Rewriter, CustomRewriter, PlatformRewriter, State
 from devito.logger import dle as log, dle_warning as warning
 from devito.parameters import configuration
 
 __all__ = ['dle_registry', 'modes', 'transform']
 
 
-dle_registry = ('advanced', 'speculative')
+dle_registry = ('noop', 'advanced', 'speculative')
 
 
 class DLEModes(OrderedDict):
@@ -39,7 +39,9 @@ class DLEModes(OrderedDict):
 
 
 modes = DLEModes()
-modes.add(Cpu64, {'advanced': CPU64Rewriter, 'speculative': CPU64Rewriter})
+modes.add(Cpu64, {'noop': PlatformRewriter,
+                  'advanced': CPU64Rewriter,
+                  'speculative': CPU64Rewriter})
 
 
 def transform(iet, mode='advanced', options=None):

--- a/devito/dle/transformer.py
+++ b/devito/dle/transformer.py
@@ -69,6 +69,9 @@ def transform(iet, mode='advanced', options=None):
         - ``blockalways``: Pass True to unconditionally apply loop blocking, even when
                            the compiler heuristically thinks that it might not be
                            profitable and/or dangerous for performance.
+        - ``blocklevels``: Levels of blocking for hierarchical tiling (blocks,
+                           sub-blocks, sub-sub-blocks, ...). Different Platforms have
+                           different default values.
     """
     assert isinstance(iet, Node)
 
@@ -76,6 +79,7 @@ def transform(iet, mode='advanced', options=None):
     params = {}
     params['blockinner'] = configuration['dle-options'].get('blockinner', False)
     params['blockalways'] = configuration['dle-options'].get('blockalways', False)
+    params['blocklevels'] = configuration['dle-options'].get('blocklevels', None)
     params['openmp'] = configuration['openmp']
     params['mpi'] = configuration['mpi']
 

--- a/devito/dse/rewriters.py
+++ b/devito/dse/rewriters.py
@@ -247,7 +247,7 @@ class AdvancedRewriter(BasicRewriter):
         Search aliasing expressions and capture them into vector temporaries.
 
         Examples
-        ========
+        --------
         1) temp = (a[x,y,z]+b[x,y,z])*c[t,x,y,z]
            >>>
            ti[x,y,z] = a[x,y,z] + b[x,y,z]

--- a/devito/ir/clusters/algorithms.py
+++ b/devito/ir/clusters/algorithms.py
@@ -206,9 +206,12 @@ class Enforce(Queue):
     `t`, we need up-to-date information on the RHS".
     """
 
-    def callback(self, clusters, prefix, backlog=None, known_flow_break=None):
+    def callback(self, clusters, prefix, backlog=None, known_break=None):
         if not prefix:
             return clusters
+
+        known_break = known_break or set()
+        backlog = backlog or []
 
         # Take the innermost Dimension -- no other Clusters other than those in
         # `clusters` are supposed to share it
@@ -216,17 +219,30 @@ class Enforce(Queue):
 
         scope = Scope(exprs=flatten(c.exprs for c in clusters))
 
-        # The most nasty case:
+        # The nastiest case:
         # eq0 := u[t+1, x] = ... u[t, x]
         # eq1 := v[t+1, x] = ... v[t, x] ... u[t, x] ... u[t+1, x] ... u[t+2, x]
         # Here, `eq0` marches forward along `t`, while `eq1` has both a flow and an
         # anti dependence with `eq0`, which ultimately will require `eq1` to go in
         # a separate t-loop
-        require_flow_break = (scope.d_flow.cause & scope.d_anti.cause) & candidates
-        if require_flow_break and len(clusters) > 1:
-            backlog = [clusters[-1]] + (backlog or [])
+        require_break = (scope.d_flow.cause & scope.d_anti.cause) & candidates
+        if require_break and len(clusters) > 1:
+            backlog = [clusters[-1]] + backlog
             # Try with increasingly smaller Cluster groups until the ambiguity is solved
-            return self.callback(clusters[:-1], prefix, backlog, require_flow_break)
+            return self.callback(clusters[:-1], prefix, backlog, require_break)
+
+        # If the flow- or anti-dependences are not coupled, one or more Clusters
+        # might be scheduled separately, to increase parallelism (this is basically
+        # what low-level compilers call "loop fission")
+        for n, _ in enumerate(clusters):
+            d_cross = scope.d_from_access(scope.a_query(n, 'R')).cross()
+            if any(d.is_storage_volatile(candidates) for d in d_cross):
+                break
+            elif d_cross.cause & candidates:
+                if n > 0:
+                    return self.callback(clusters[:n], prefix, clusters[n:] + backlog,
+                                         (d_cross.cause & candidates) | known_break)
+                break
 
         # Compute iteration direction
         direction = {d: Backward for d in candidates if d.root in scope.d_anti.cause}
@@ -240,14 +256,14 @@ class Enforce(Queue):
                                     {**c.ispace.directions, **direction})
             processed.append(Cluster(c.exprs, ispace, c.dspace))
 
-        if backlog is None:
+        if not backlog:
             return processed
 
-        # Handle the backlog -- the Clusters characterized by flow+anti dependences along
-        # one or more Dimensions
-        direction = {d: Any for d in known_flow_break}
-        for i, c in enumerate(as_tuple(backlog)):
-            ispace = IterationSpace(c.ispace.intervals.lift(known_flow_break),
+        # Handle the backlog -- the Clusters characterized by flow- and anti-dependences
+        # along one or more Dimensions
+        direction = {d: Any for d in known_break}
+        for i, c in enumerate(list(backlog)):
+            ispace = IterationSpace(c.ispace.intervals.lift(known_break),
                                     c.ispace.sub_iterators,
                                     {**c.ispace.directions, **direction})
             backlog[i] = Cluster(c.exprs, ispace, c.dspace)

--- a/devito/ir/clusters/algorithms.py
+++ b/devito/ir/clusters/algorithms.py
@@ -137,17 +137,12 @@ class Toposort(Queue):
 
     def _build_dag(self, cgroups, prefix):
         """
-        A DAG capturing dependences between *all* ClusterGroups within an
-        iteration space.
+        A DAG capturing data dependences between ClusterGroups up to a given
+        iteration space depth.
 
         Examples
         --------
-        When do we need to sequentialize two ClusterGroup `cg0` and `cg1`?
-        Essentially any time there's a dependence between them, apart from when
-        it's a carried flow-dependence within the given iteration space.
-
-        Let's consider two ClusterGroups `cg0` and `cg1` within the iteration
-        space identified by the Dimension `i`.
+        Consider two ClusterGroups `c0` and `c1`, within the iteration space `i`.
 
         1) cg0 := b[i, j] = ...
            cg1 := ... = ... b[i, j] ...
@@ -167,7 +162,7 @@ class Toposort(Queue):
            cg1 := ... = ... b[i, j-1] ...
            Flow-dependence in `j`, so `cg1` must go after `cg0`.
            Unlike case 3), the flow-dependence is along an inner Dimension, so
-           `cg0` and `cg1 need to be sequentialized.
+           `cg0` and `cg1 are sequentialized.
         """
         prefix = {i.dim for i in as_tuple(prefix)}
 
@@ -285,9 +280,12 @@ def optimize(clusters):
 class Lift(Queue):
 
     """
-    Remove invariant Dimensions from Clusters, to avoid redundant computation.
-    This is conceptually analogous to a general-purpose compiler transformation
-    known as "loop-invariant code motion".
+    Remove invariant Dimensions from Clusters to avoid redundant computation.
+
+    Notes
+    -----
+    This is analogous to the compiler transformation known as
+    "loop-invariant code motion".
     """
 
     def callback(self, clusters, prefix):

--- a/devito/ir/iet/nodes.py
+++ b/devito/ir/iet/nodes.py
@@ -11,7 +11,7 @@ import cgen as c
 from devito.data import FULL
 from devito.ir.equations import ClusterizedEq
 from devito.ir.iet import (IterationProperty, SEQUENTIAL, PARALLEL, PARALLEL_IF_ATOMIC,
-                           VECTOR, WRAPPABLE, AFFINE, USELESS, OVERLAPPABLE)
+                           VECTOR, WRAPPABLE, ROUNDABLE, AFFINE, USELESS, OVERLAPPABLE)
 from devito.ir.support import Forward, detect_io
 from devito.symbolics import FunctionFromPointer, as_symbol, ccode
 from devito.tools import (Signer, as_tuple, filter_ordered, filter_sorted, flatten,
@@ -416,6 +416,10 @@ class Iteration(Node):
     @property
     def is_Wrappable(self):
         return WRAPPABLE in self.properties
+
+    @property
+    def is_Roundable(self):
+        return ROUNDABLE in self.properties
 
     @property
     def ncollapsed(self):

--- a/devito/ir/iet/properties.py
+++ b/devito/ir/iet/properties.py
@@ -31,14 +31,25 @@ VECTOR = IterationProperty('vector-dim')
 """The Iteration can be SIMD-vectorized."""
 
 WRAPPABLE = IterationProperty('wrappable')
-"""The Iteration implements modulo buffered iteration and its expressions are so that
+"""
+The Iteration implements modulo buffered iteration and its expressions are so that
 one or more buffer slots can be dropped without affecting correctness. For example,
-u[t+1, ...] = f(u[t, ...], u[t-1, ...]) --> u[t-1, ...] = f(u[t, ...], u[t-1, ...])."""
+u[t+1, ...] = f(u[t, ...], u[t-1, ...]) --> u[t-1, ...] = f(u[t, ...], u[t-1, ...]).
+"""
+
+ROUNDABLE = IterationProperty('roundable')
+"""
+The Iteration writes (only) to Arrays and the trip count can be rounded up to a
+multiple of the SIMD vector length without affecting correctness (thanks to the
+presence of sufficient padding).
+"""
 
 AFFINE = IterationProperty('affine')
-"""All Indexed access functions using the Iteration dimension ``d`` are
+"""
+All Indexed access functions using the Iteration dimension ``d`` are
 affine in ``d``. Further, the Iteration does not contain any Indexed varying in
-``d`` used to indirectly access some other Indexed."""
+``d`` used to indirectly access some other Indexed.
+"""
 
 
 class HaloSpotProperty(Tag):
@@ -51,8 +62,10 @@ class HaloSpotProperty(Tag):
 
 
 USELESS = HaloSpotProperty('useless')
-"""The HaloSpot can be ignored as an halo update at this point would be completely
-useless."""
+"""
+The HaloSpot can be ignored as an halo update at this point would be completely
+useless.
+"""
 
 OVERLAPPABLE = HaloSpotProperty('overlappable')
 """The HaloSpot supports computation-communication overlap."""

--- a/devito/ir/support/basic.py
+++ b/devito/ir/support/basic.py
@@ -357,11 +357,11 @@ class TimedAccess(IterationInstance):
             else:
                 assert False
 
-        # If `m + (self[d] - d) < self.function._size_halo[d].left`, then `self`
+        # If `m + (self[d] - d) < self.function._size_nodomain[d].left`, then `self`
         # will definitely touch the left-halo, at least when `d=0`
-        size_halo_left = self.function._size_halo[findex].left
+        size_nodomain_left = self.function._size_nodomain[findex].left
         try:
-            touch_halo_left = bool(m + (self[findex] - d) < size_halo_left)
+            touch_halo_left = bool(m + (self[findex] - d) < size_nodomain_left)
         except TypeError:
             # Two reasons we might end up here:
             # * `d` is a constant integer
@@ -371,10 +371,10 @@ class TimedAccess(IterationInstance):
             #         assuming, conservatively, `touch_halo_left = True`
             touch_halo_left = True
 
-        # If `M + (self[d] - d) > self.function._size_halo[d].left`, then
+        # If `M + (self[d] - d) > self.function._size_nodomain[d].left`, then
         # `self` will definitely touch the right-halo, at least when `d=d_M`
         try:
-            touch_halo_right = bool(M + (self[findex] - d) > size_halo_left)
+            touch_halo_right = bool(M + (self[findex] - d) > size_nodomain_left)
         except TypeError:
             # See comments in the except block above
             touch_halo_right = True

--- a/devito/mpi/routines.py
+++ b/devito/mpi/routines.py
@@ -278,7 +278,7 @@ class BasicHaloExchangeBuilder(HaloExchangeBuilder):
             if d not in hse.loc_indices:
                 buf_dims.append(Dimension(name='buf_%s' % d.root))
                 buf_indices.append(d.root)
-        buf = Array(name='buf', dimensions=buf_dims, dtype=f.dtype)
+        buf = Array(name='buf', dimensions=buf_dims, dtype=f.dtype, padding=0)
 
         f_offsets = []
         f_indices = []
@@ -308,8 +308,10 @@ class BasicHaloExchangeBuilder(HaloExchangeBuilder):
 
         buf_dims = [Dimension(name='buf_%s' % d.root) for d in f.dimensions
                     if d not in hse.loc_indices]
-        bufg = Array(name='bufg', dimensions=buf_dims, dtype=f.dtype, scope='heap')
-        bufs = Array(name='bufs', dimensions=buf_dims, dtype=f.dtype, scope='heap')
+        bufg = Array(name='bufg', dimensions=buf_dims, dtype=f.dtype,
+                     padding=0, scope='heap')
+        bufs = Array(name='bufs', dimensions=buf_dims, dtype=f.dtype,
+                     padding=0, scope='heap')
 
         ofsg = [Symbol(name='og%s' % d.root) for d in f.dimensions]
         ofss = [Symbol(name='os%s' % d.root) for d in f.dimensions]

--- a/devito/mpi/routines.py
+++ b/devito/mpi/routines.py
@@ -746,15 +746,15 @@ class Overlap2HaloExchangeBuilder(OverlapHaloExchangeBuilder):
         assert callcompute.is_Call
 
         dim = Dimension(name='i')
-        regioni = IndexedPointer(region, dim)
+        region_i = IndexedPointer(region, dim)
 
         dynamic_args_mapper = {}
         for i in hs.arguments:
             if i.is_Dimension:
-                dynamic_args_mapper[i] = (FieldFromComposite(i.min_name, regioni),
-                                          FieldFromComposite(i.max_name, regioni))
+                dynamic_args_mapper[i] = (FieldFromComposite(i.min_name, region_i),
+                                          FieldFromComposite(i.max_name, region_i))
             else:
-                dynamic_args_mapper[i] = (FieldFromComposite(i.name, regioni),)
+                dynamic_args_mapper[i] = (FieldFromComposite(i.name, region_i),)
 
         iet = callcompute._rebuild(dynamic_args_mapper=dynamic_args_mapper)
         # The -1 below is because an Iteration, by default, generates <=

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -359,6 +359,9 @@ class Operator(Callable):
         # Sanity check
         for p in self.parameters:
             p._arg_check(args, self._dspace[p])
+        for d in self.dimensions:
+            if d.is_Derived:
+                d._arg_check(args, self._dspace[p])
 
         # Turn arguments into a format suitable for the generated code
         # E.g., instead of NumPy arrays for Functions, the generated code expects

--- a/devito/ops/__init__.py
+++ b/devito/ops/__init__.py
@@ -12,7 +12,8 @@ env_vars_mapper = {}
 add_sub_configuration(ops_configuration, env_vars_mapper)
 
 # Add OPS-specific DLE modes
-modes.add(Cpu64, {'advanced': PlatformRewriter,
+modes.add(Cpu64, {'noop': PlatformRewriter,
+                  'advanced': PlatformRewriter,
                   'speculative': PlatformRewriter})
 
 # The following used by backends.backendSelector

--- a/devito/parameters.py
+++ b/devito/parameters.py
@@ -203,7 +203,11 @@ class switchconfig(object):
                 configuration[k] = v
             result = func(*args, **kwargs)
             for k, v in self.params.items():
-                configuration[k] = previous[k]
+                try:
+                    configuration[k] = previous[k]
+                except ValueError:
+                    # E.g., `platform` and `compiler` will end up here
+                    configuration[k] = previous[k].name
             return result
         return wrapper
 

--- a/devito/types/basic.py
+++ b/devito/types/basic.py
@@ -823,7 +823,7 @@ class Array(AbstractCachedFunction):
         padding = kwargs.get('padding')
         if padding is None:
             padding = [(0, 0) for _ in range(self.ndim)]
-            if configuration['autopadding']:
+            if kwargs.get('autopadding', configuration['autopadding']):
                 # Heuristic 1; Arrays are typically introduced for DSE-produced
                 # temporaries, and are almost always used together with loop
                 # blocking.  Since the typical block size is a multiple of the SIMD

--- a/devito/types/dense.py
+++ b/devito/types/dense.py
@@ -1015,7 +1015,7 @@ class Function(DiscreteFunction, Differentiable):
     def __padding_setup__(self, **kwargs):
         padding = kwargs.get('padding')
         if padding is None:
-            if configuration['autopadding']:
+            if kwargs.get('autopadding', configuration['autopadding']):
                 # Auto-padding
                 # 0-padding in all Dimensions except in the Fastest Varying Dimension,
                 # `fvd`, which is the innermost one

--- a/devito/types/dense.py
+++ b/devito/types/dense.py
@@ -871,15 +871,17 @@ class Function(DiscreteFunction, Differentiable):
         to ``np.float32``.
     staggered : Dimension or tuple of Dimension or Stagger, optional
         Define how the Function is staggered.
-    padding : int or tuple of ints, optional
-        Allocate extra grid points to maximize data access alignment. When a tuple
-        of ints, one int per Dimension should be provided.
     initializer : callable or any object exposing the buffer interface, optional
         Data initializer. If a callable is provided, data is allocated lazily.
     allocator : MemoryAllocator, optional
         Controller for memory allocation. To be used, for example, when one wants
         to take advantage of the memory hierarchy in a NUMA architecture. Refer to
         `default_allocator.__doc__` for more information.
+    padding : int or tuple of ints, optional
+        .. deprecated:: shouldn't be used; padding is now automatically inserted.
+
+        Allocate extra grid points to maximize data access alignment. When a tuple
+        of ints, one int per Dimension should be provided.
 
     Examples
     --------
@@ -1141,15 +1143,17 @@ class TimeFunction(Function):
         TimeDimension to be used in the TimeFunction. Defaults to ``grid.time_dim``.
     staggered : Dimension or tuple of Dimension or Stagger, optional
         Define how the Function is staggered.
-    padding : int or tuple of ints, optional
-        Allocate extra grid points to maximize data access alignment. When a tuple
-        of ints, one int per Dimension should be provided.
     initializer : callable or any object exposing the buffer interface, optional
         Data initializer. If a callable is provided, data is allocated lazily.
     allocator : MemoryAllocator, optional
         Controller for memory allocation. To be used, for example, when one wants
         to take advantage of the memory hierarchy in a NUMA architecture. Refer to
         `default_allocator.__doc__` for more information.
+    padding : int or tuple of ints, optional
+        .. deprecated:: shouldn't be used; padding is now automatically inserted.
+
+        Allocate extra grid points to maximize data access alignment. When a tuple
+        of ints, one int per Dimension should be provided.
 
     Examples
     --------

--- a/devito/yask/__init__.py
+++ b/devito/yask/__init__.py
@@ -7,7 +7,7 @@ import os
 import sys
 
 from devito.archinfo import Arm, Cpu64, CPU64, Power
-from devito.dle import modes
+from devito.dle import PlatformRewriter, modes
 from devito.exceptions import InvalidOperator
 from devito.logger import yask as log
 from devito.parameters import Parameters, configuration, add_sub_configuration
@@ -101,7 +101,8 @@ env_vars_mapper = {
 add_sub_configuration(yask_configuration, env_vars_mapper)
 
 # Add YASK-specific DLE modes
-modes.add(Cpu64, {'advanced': YaskRewriter,
+modes.add(Cpu64, {'noop': PlatformRewriter,
+                  'advanced': YaskRewriter,
                   'speculative': YaskRewriter})
 
 # The following used by backends.backendSelector

--- a/devito/yask/types.py
+++ b/devito/yask/types.py
@@ -71,6 +71,10 @@ class Function(dense.Function, Signer):
             newobj = cls.__base__.__new__(klass, *args, **kwargs)
         return newobj
 
+    def __padding_setup__(self, **kwargs):
+        # YASK calculates the padding, so we bypass the dense.Function's autopadding
+        return tuple((0, 0) for i in range(self.ndim))
+
     def _allocate_memory(func):
         """Allocate memory in terms of YASK vars."""
         def wrapper(self):

--- a/examples/cfd/01_convection.ipynb
+++ b/examples/cfd/01_convection.ipynb
@@ -219,7 +219,7 @@
    "source": [
     "Nice. Now we can look at deriving our 3-point stencil using the symbolic capabilities given to our function $u$ by SymPy. For this we will first construct our derivative terms in space and time. For the forward derivative in time we can easily use Devito's shorthand notation `u.dt` to denote the first derivative in time and `u.dxl` and `u.dyl` to denote the space derivatives. Note that the `l` means were using the \"left\" or backward difference here to adhere to the discretization used in the original tutorials.\n",
     "\n",
-    "From the resulting terms we can then create a `sympy.Equation` object that contains the fully discretised equation, but from a neat high-level notation, as shown below."
+    "From the resulting terms we can then create a `sympy.Equation` object that contains the fully discretized equation, but from a neat high-level notation, as shown below."
    ]
   },
   {
@@ -249,9 +249,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The above step resulted in a fully discretised version of our equation, which includes place-holder symbols for the spacing in time (`s`) and space (`h`). These symbols are based on an internal convention and will later be replaced when we build an operator.\n",
+    "The above step resulted in a fully discretized version of our equation, which includes place-holder symbols for the spacing in time (`s`) and space (`h`). These symbols are based on an internal convention and will later be replaced when we build an operator.\n",
     "\n",
-    "But before we can build an operator, we first need to change our discretised expression so that we are updating the forward stencil point in our timestepping scheme - Devito provides another short-hand notation for this: `u.forward`. For the actual symoblic reordering, SymPy comes to the rescue with the `solve` utility that we can use to re-organise our equation."
+    "But before we can build an operator, we first need to change our discretized expression so that we are updating the forward stencil point in our timestepping scheme - Devito provides another short-hand notation for this: `u.forward`. For the actual symbolic reordering, SymPy comes to the rescue with the `solve` utility that we can use to re-organise our equation."
    ]
   },
   {
@@ -338,14 +338,14 @@
    "source": [
     "Great, that looks to have done the same thing as the original NumPy example, so we seem to be doing something right, at least.\n",
     "\n",
-    "**A note on performance:** During the code generation phase of the previous operatorm Devito has created some log output with information about two optimisation steps: The DSE (Devito Symbolics Engine) and the DLE (Devito Loop Engine). We can ignore these for now, because our exmaple is tiny - but for large runs where performance matters, these are the engines that make the Devito kernel run very fast in comparison to raw Python/NumPy.\n",
+    "**A note on performance:** During the code generation phase of the previous operator Devito has created some log output with information about two optimisation steps: The DSE (Devito Symbolics Engine) and the DLE (Devito Loop Engine). We can ignore these for now, because our example is tiny - but for large runs where performance matters, these are the engines that make the Devito kernel run very fast in comparison to raw Python/NumPy.\n",
     "\n",
     "Now, despite getting a correct looking result, there is still one problem with the above operator: It doesn't set any boundary conditions as part of the time loop. We also note that the operator includes a time loop, but at this point Devito doesn;t actually provide any language constructs to explicitly define different types of boundary conditions (Devito is probably still a kind of prototype at this point). Luckily though, Devito provides a backdoor for us to insert custom expression in the so-called \"indexed\" or \"low-level\" API that allow us to encode the Dirichlet boundary condition of the original example.\n",
     "\n",
     "#### The \"indexed\" or low-level API\n",
     "The `TimeFunction` field we created earlier behaves symbolically like a `sympy.Function` object with the appropriate indices, eg. `u(t, x, y)`. If we take a simple first-order derivative of that we have a term that includes the spacing variable `h`, which Devito uses as the default for encoding $dx$ or $dy$. For example, `u.dx` simply expands to `-u(t, x, y)/h + u(t, x + h, y)/h`.\n",
     "\n",
-    "Now, when the `Operator` creates explicit C-code from that expression, it at some point \"lowers\" that expression by resolving explicit data accesses (or indices) into our grid by transforming it into a `sympy.Indexed` object. During this process all occurences of `h` in data accesses get replaced with integers, so that the expression now looks like `-u[t, x, y]/h + u[t, x + 1, y]/h`. This is the \"indexed\" notation and we can create custom expression of the same kind by explicitly writing `u[...]`, that is with indices in square-bracket notation. These custom expressions can then be injected into our operator like this:"
+    "Now, when the `Operator` creates explicit C-code from that expression, it at some point \"lowers\" that expression by resolving explicit data accesses (or indices) into our grid by transforming it into a `sympy.Indexed` object. During this process all occurrences of `h` in data accesses get replaced with integers, so that the expression now looks like `-u[t, x, y]/h + u[t, x + 1, y]/h`. This is the \"indexed\" notation and we can create custom expression of the same kind by explicitly writing `u[...]`, that is with indices in square-bracket notation. These custom expressions can then be injected into our operator like this:"
    ]
   },
   {

--- a/examples/cfd/01_convection_revisited.ipynb
+++ b/examples/cfd/01_convection_revisited.ipynb
@@ -16,7 +16,7 @@
     "\n",
     "In the previous example, the system was initialised with a hat function. As easy as this example seems, it actually highlights a few limitations of finite differences and related methods:\n",
     " - The governing equation above contains spatial derivatives ($\\frac{\\partial u}{\\partial x}$ and $\\frac{\\partial u}{\\partial y}$). The hat, with its sharp corners, is discontinuous and therefore non-smooth, meaning that the derivatives do not exist at the corners of the hat. This means that the governing equation has no solution in the strict sense for this problem. Mathematically, this problem can be overcome by introducing weak solutions, which still exist in the presence of discontinuities, as long as the problem is smooth almost everywhere. The Finite Volume (FV), Finite Element (FEM) and related schemes are based on this weak form.\n",
-    " - The finite differences method only works well if finite differences are a good approximation of the derivatives. With the chosen discretisation above, this requires that $\\frac{u_{i,j}^n-u_{i-1,j}^n}{\\Delta x} \\approx \\frac{\\partial u}{\\partial x}$ and $\\frac{u_{i,j}^n-u_{i,j-1}^n}{\\Delta y} \\approx \\frac{\\partial u}{\\partial y}$. This is the case for systems with a smooth solution if $\\Delta x$ and $\\Delta y$ are sufficiently small. But if the solution is non-smooth, as in this example, then we can't expect much regardless of the grid size.\n",
+    " - The finite differences method only works well if finite differences are a good approximation of the derivatives. With the chosen discretization above, this requires that $\\frac{u_{i,j}^n-u_{i-1,j}^n}{\\Delta x} \\approx \\frac{\\partial u}{\\partial x}$ and $\\frac{u_{i,j}^n-u_{i,j-1}^n}{\\Delta y} \\approx \\frac{\\partial u}{\\partial y}$. This is the case for systems with a smooth solution if $\\Delta x$ and $\\Delta y$ are sufficiently small. But if the solution is non-smooth, as in this example, then we can't expect much regardless of the grid size.\n",
     " - First-order methods, such as the backward differences that we have used in this exampe, are known to create artificial diffusion. Higher-order schemes, such as central differences, avoid this problem. However, in the presence of discontinuities these methods introduce so-called spurious oscillations. These oscillations may even build up (grow infinitely) and cause the computation to diverge.\n",
     " - Discontinuities can appear by themselves for some equations (such as the Burgers equation that we discuss next), even if the intial condition is smooth. In CFD, discontinuities appear for example as shocks in the simulation of transonic flow. For this reason, numerical schemes that behave well in the presence of discontinuities have been a research subject for a long time. A thorough discussion is beyond the scope of this tutorial, but can be found in [R. LeVeque (1992): Numerical Methods for Conservation Laws, 2nd ed., Birkhäuser Verlag, pp. 8-13].\n",
     " \n",
@@ -200,7 +200,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We create again the discretised equation as shown below. Note that the equation is still the same, only the initial condition has changed."
+    "We create again the discretized equation as shown below. Note that the equation is still the same, only the initial condition has changed."
    ]
   },
   {

--- a/examples/cfd/02_convection_nonlinear.ipynb
+++ b/examples/cfd/02_convection_nonlinear.ipynb
@@ -16,7 +16,7 @@
     "\\frac{\\partial v}{\\partial t} + u \\frac{\\partial v}{\\partial x} + v \\frac{\\partial v}{\\partial y} = 0\\\\\n",
     "\\end{aligned}\n",
     "\n",
-    "and rearranging the discretised version gives us an expression for the update of both variables\n",
+    "and rearranging the discretized version gives us an expression for the update of both variables\n",
     "\n",
     "\\begin{aligned}\n",
     "u_{i,j}^{n+1} &= u_{i,j}^n - u_{i,j} \\frac{\\Delta t}{\\Delta x} (u_{i,j}^n-u_{i-1,j}^n) - v_{i,j}^n \\frac{\\Delta t}{\\Delta y} (u_{i,j}^n-u_{i,j-1}^n) \\\\\n",
@@ -91,7 +91,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we can create the two stencil expression for our two coupled equations according to the discretised equation above. We again use some simple Dirichlet boundary conditions to keep the values on all sides constant."
+    "Now we can create the two stencil expression for our two coupled equations according to the discretized equation above. We again use some simple Dirichlet boundary conditions to keep the values on all sides constant."
    ]
   },
   {
@@ -168,7 +168,7 @@
     "#NBVAL_IGNORE_OUTPUT\n",
     "from devito import Grid, TimeFunction\n",
     "\n",
-    "# First we need two time-dependent data fields, both initialised with the hat function\n",
+    "# First we need two time-dependent data fields, both initialized with the hat function\n",
     "grid = Grid(shape=(nx, ny), extent=(2., 2.))\n",
     "u = TimeFunction(name='u', grid=grid)\n",
     "init_hat(field=u.data[0], dx=dx, dy=dy, value=2.)\n",

--- a/examples/cfd/03_diffusion.ipynb
+++ b/examples/cfd/03_diffusion.ipynb
@@ -212,7 +212,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Excellent. Now for the Devito part, we need to note one important detail to our previous examples: we now have a second-order derivative. So, when creating our `TimeFunction` object we need to tell it about our spatial discretisation by setting `space_order=2`. Only then can we use the shorthand notation `u.dx2` and `u.dx2` to denote second order derivatives."
+    "Excellent. Now for the Devito part, we need to note one important detail to our previous examples: we now have a second-order derivative. So, when creating our `TimeFunction` object we need to tell it about our spatial discretization by setting `space_order=2`. Only then can we use the shorthand notation `u.dx2` and `u.dx2` to denote second order derivatives."
    ]
   },
   {

--- a/examples/cfd/03_diffusion_nonuniform.ipynb
+++ b/examples/cfd/03_diffusion_nonuniform.ipynb
@@ -243,7 +243,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Excellent. Now for the Devito part, we need to note one important detail to our previous examples: we now have a second-order derivative. So, when creating our `TimeFunction` object we need to tell it about our spatial discretisation by setting `space_order=2`. Only then can we use the shorthand notation `u.dx2` and `u.dx2` to denote second order derivatives."
+    "Excellent. Now for the Devito part, we need to note one important detail to our previous examples: we now have a second-order derivative. So, when creating our `TimeFunction` object we need to tell it about our spatial discretization by setting `space_order=2`. Only then can we use the shorthand notation `u.dx2` and `u.dx2` to denote second order derivatives."
    ]
   },
   {

--- a/examples/cfd/04_burgers.ipynb
+++ b/examples/cfd/04_burgers.ipynb
@@ -6,7 +6,7 @@
    "source": [
     "### Example 4: Burgers' equation\n",
     "\n",
-    "Now that we have seen how to construct the non-linear convection and diffusion examples, we can combine them to form Burgers' equations. We again create a set of coupled equations which are actually starting to form quite complicated stencil expressions, even if we are only using low-order discretisations.\n",
+    "Now that we have seen how to construct the non-linear convection and diffusion examples, we can combine them to form Burgers' equations. We again create a set of coupled equations which are actually starting to form quite complicated stencil expressions, even if we are only using low-order discretizations.\n",
     "\n",
     "Let's start with the definition fo the governing equations:\n",
     "$$ \\frac{\\partial u}{\\partial t} + u \\frac{\\partial u}{\\partial x} + v \\frac{\\partial u}{\\partial y} = \\nu \\; \\left(\\frac{\\partial ^2 u}{\\partial x^2} + \\frac{\\partial ^2 u}{\\partial y^2}\\right)$$\n",
@@ -262,7 +262,7 @@
    "source": [
     "Nice, our wave looks just like the original. Now we shall attempt to write our entire Burgers' equation operator in a single cell - but before we can demonstrate this, there is one slight problem.\n",
     "\n",
-    "The diffusion term in our equation requires a second-order space discretisation on our velocity fields, which we set through the `TimeFunction` constructor for $u$ and $v$. The `TimeFunction` objects will store this dicretisation information and use it as default whenever we use the shorthand notations for derivative, like `u.dxl` or `u.dyl`. For the advection term, however, we want to use a first-order discretisation, which we now have to create by hand when combining terms with different stencil discretisations. To illustrate let's consider the following example: "
+    "The diffusion term in our equation requires a second-order space discretization on our velocity fields, which we set through the `TimeFunction` constructor for $u$ and $v$. The `TimeFunction` objects will store this dicretisation information and use it as default whenever we use the shorthand notations for derivative, like `u.dxl` or `u.dyl`. For the advection term, however, we want to use a first-order discretization, which we now have to create by hand when combining terms with different stencil discretizations. To illustrate let's consider the following example: "
    ]
   },
   {
@@ -308,7 +308,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Ok, so by constructing derivative terms explicitly we again have full control of the spatial discretisation - the power of symbolic computation. Armed with that trick, we can now build and execute our advection-diffusion operator from scratch in one cell."
+    "Ok, so by constructing derivative terms explicitly we again have full control of the spatial discretization - the power of symbolic computation. Armed with that trick, we can now build and execute our advection-diffusion operator from scratch in one cell."
    ]
   },
   {
@@ -451,7 +451,7 @@
     "#NBVAL_IGNORE_OUTPUT\n",
     "from devito import Operator, Constant, Eq, solve\n",
     "\n",
-    "# Define our velocity fields and initialise with hat function\n",
+    "# Define our velocity fields and initialize with hat function\n",
     "u = TimeFunction(name='u', grid=grid, space_order=2)\n",
     "v = TimeFunction(name='v', grid=grid, space_order=2)\n",
     "init_hat(field=u.data[0], dx=dx, dy=dy, value=2.)\n",

--- a/examples/cfd/05_laplace.ipynb
+++ b/examples/cfd/05_laplace.ipynb
@@ -11,10 +11,10 @@
     "First, we again define our governing equation:\n",
     "$$\\frac{\\partial ^2 p}{\\partial x^2} + \\frac{\\partial ^2 p}{\\partial y^2} = 0$$\n",
     "\n",
-    "We are again discretizing second-order derivatives using a central difference scheme to construct a diffusion problem (see tutorial 3). This time we have no time-dependent term in our equation though, since there is no term $p_{i,j}^{n+1}$. This means that we are simply updating our field variable $p$ over and over again, until we have reached an equilibrium state. In a discretised form, after rearranging to update the central point $p_{i,j}^n$ we have\n",
+    "We are again discretizing second-order derivatives using a central difference scheme to construct a diffusion problem (see tutorial 3). This time we have no time-dependent term in our equation though, since there is no term $p_{i,j}^{n+1}$. This means that we are simply updating our field variable $p$ over and over again, until we have reached an equilibrium state. In a discretized form, after rearranging to update the central point $p_{i,j}^n$ we have\n",
     "$$p_{i,j}^n = \\frac{\\Delta y^2(p_{i+1,j}^n+p_{i-1,j}^n)+\\Delta x^2(p_{i,j+1}^n + p_{i,j-1}^n)}{2(\\Delta x^2 + \\Delta y^2)}$$\n",
     "\n",
-    "And, as always, we first re-create the original implementation to see what we are aiming for. Here we initialise the field $p$ to $0$ and apply the following bounday conditions:\n",
+    "And, as always, we first re-create the original implementation to see what we are aiming for. Here we initialize the field $p$ to $0$ and apply the following boundary conditions:\n",
     "\n",
     "$p=0$ at $x=0$\n",
     " \n",
@@ -133,7 +133,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Ok, nice. Now, to re-create this example in Devito we need to look a little bit further under the hood. There are two things that make this different to the examples we covered so far:\n",
+    "OK, nice. Now, to re-create this example in Devito we need to look a little bit further under the hood. There are two things that make this different to the examples we covered so far:\n",
     "* We have no time dependence in the `p` field, but we still need to advance the state of p in between buffers. So, instead of using `TimeFunction` objects that provide multiple data buffers for timestepping schemes, we will use `Function` objects that have no time dimension and only allocate a single buffer according to the space dimensions. However, since we are still implementing a pseudo-timestepping loop, we will need two objects, say `p` and `pn`, to act as alternating buffers.\n",
     "* If we're using two different symbols to denote our buffers, any operator we create will only perform a single timestep. This is desired though, since we need to check a convergence criterion outside of the main stencil update to determine when we stop iterating. As a result we will need to call the operator repeatedly after instantiating it outside the convergence loop.\n",
     "\n",
@@ -197,7 +197,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Now we can create a set of expressions for the BCs again, where we wet prescribed values on the right and left of our grid. For the Neuman BCs along the top and bottom boundaries we simply copy the second rwo from the outside into the outermost row, just as the original tutorial did. Using these expressions and our stencil update we can now create an operator."
+    "Now we can create a set of expressions for the BCs again, where we wet prescribed values on the right and left of our grid. For the Neumann BCs along the top and bottom boundaries we simply copy the second row from the outside into the outermost row, just as the original tutorial did. Using these expressions and our stencil update we can now create an operator."
    ]
   },
   {

--- a/examples/cfd/06_poisson.ipynb
+++ b/examples/cfd/06_poisson.ipynb
@@ -97,7 +97,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can now pretty much use our previous implementation, although we will use `pd` instead of `pn` for consistency with the original. Our boundary conditions are even simpler since they are $0$ everywhere. Our source term is neatly wrapped in the smbol `b` and we can again use a Python-driven timestepping loop with switching buffers to repeatedly execute the operator we create."
+    "We can now pretty much use our previous implementation, although we will use `pd` instead of `pn` for consistency with the original. Our boundary conditions are even simpler since they are $0$ everywhere. Our source term is neatly wrapped in the symbol `b` and we can again use a Python-driven timestepping loop with switching buffers to repeatedly execute the operator we create."
    ]
   },
   {

--- a/examples/cfd/__init__.py
+++ b/examples/cfd/__init__.py
@@ -1,1 +1,5 @@
 from .tools import *  # noqa
+
+# Disable autopadding to avoid polluting the generated example code
+from devito import configuration
+configuration['autopadding'] = False

--- a/examples/cfd/__init__.py
+++ b/examples/cfd/__init__.py
@@ -1,5 +1,1 @@
 from .tools import *  # noqa
-
-# Disable autopadding to avoid polluting the generated example code
-from devito import configuration
-configuration['autopadding'] = False

--- a/examples/compiler/01_data_regions.ipynb
+++ b/examples/compiler/01_data_regions.ipynb
@@ -20,9 +20,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from devito import Eq, Grid, TimeFunction, Operator, configuration\n",
-    "\n",
-    "configuration['autopadding'] = False  # We will explicitly deal with padding\n",
+    "from devito import Eq, Grid, TimeFunction, Operator\n",
     "\n",
     "grid = Grid(shape=(3, 3))\n",
     "u = TimeFunction(name='u', grid=grid)\n",

--- a/examples/compiler/01_data_regions.ipynb
+++ b/examples/compiler/01_data_regions.ipynb
@@ -20,7 +20,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from devito import Eq, Grid, TimeFunction, Operator\n",
+    "from devito import Eq, Grid, TimeFunction, Operator, configuration\n",
+    "\n",
+    "configuration['autopadding'] = False  # We will explicitly deal with padding\n",
     "\n",
     "grid = Grid(shape=(3, 3))\n",
     "u = TimeFunction(name='u', grid=grid)\n",

--- a/examples/compiler/03_iet-A.ipynb
+++ b/examples/compiler/03_iet-A.ipynb
@@ -19,7 +19,6 @@
    "outputs": [],
    "source": [
     "from devito import configuration\n",
-    "configuration['autopadding'] = False\n",
     "configuration['dle'] = 'noop'\n",
     "configuration['openmp'] = False"
    ]

--- a/examples/compiler/03_iet-A.ipynb
+++ b/examples/compiler/03_iet-A.ipynb
@@ -9,47 +9,26 @@
     "\n",
     "# Part I - Top Down\n",
     "\n",
-    "Let's start with a fairly trivial example."
+    "Let's start with a fairly trivial example. First of all, we disable all performance-related optimizations, to maximize the simplicity of the created IET as well as the readability of the generated code."
    ]
   },
   {
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Data([[[0., 0., 0.],\n",
-       "       [0., 0., 0.],\n",
-       "       [0., 0., 0.]],\n",
-       "\n",
-       "      [[0., 0., 0.],\n",
-       "       [0., 0., 0.],\n",
-       "       [0., 0., 0.]]], dtype=float32)"
-      ]
-     },
-     "execution_count": 1,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
+   "outputs": [],
    "source": [
-    "from devito import Eq, Grid, TimeFunction, Operator\n",
-    "\n",
-    "grid = Grid(shape=(3, 3))\n",
-    "u = TimeFunction(name='u', grid=grid)\n",
-    "u.data"
+    "from devito import configuration\n",
+    "configuration['autopadding'] = False\n",
+    "configuration['dle'] = 'noop'\n",
+    "configuration['openmp'] = False"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Here, we just defined a time-varying grid with 3x3 points in each of the space `Dimension`s _x_ and _y_. `u.data` gives us access to the actual data values. In particular, `u.data[0, :, :]` holds the data values at timestep `t=0`, whereas `u.data[1, :, :]` holds the data values at timestep `t=1`.\n",
-    "\n",
-    "We now create an `Operator` that increments by 1 all points in the computational domain.\n",
-    "Note: we disable all loop-level optimizations to avoid obfuscating the IET structure."
+    "Then, we create a `TimeFunction` with 3 points in each of the space `Dimension`s _x_ and _y_."
    ]
   },
   {
@@ -58,11 +37,29 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from devito import configuration\n",
-    "configuration['openmp'] = 0  # We don't care about OpenMP in this example\n",
+    "from devito import Grid, TimeFunction\n",
+    "\n",
+    "grid = Grid(shape=(3, 3))\n",
+    "u = TimeFunction(name='u', grid=grid)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We now create an `Operator` that increments by 1 all points in the computational domain."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from devito import Eq, Operator\n",
     "\n",
     "eq = Eq(u.forward, u+1)\n",
-    "op = Operator(eq, dle='noop')"
+    "op = Operator(eq)"
    ]
   },
   {
@@ -74,7 +71,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [
     {
@@ -86,7 +83,7 @@
        "Eq(u(t + dt, x, y), u(t, x, y) + 1)"
       ]
      },
-     "execution_count": 3,
+     "execution_count": 4,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -104,7 +101,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [
     {
@@ -166,128 +163,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "As shown in other tutorials, we can JIT-compile and run `op` by executing:"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 5,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Operator `Kernel` run in 0.00 s\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "Data([[[2., 2., 2.],\n",
-       "       [2., 2., 2.],\n",
-       "       [2., 2., 2.]],\n",
-       "\n",
-       "      [[3., 3., 3.],\n",
-       "       [3., 3., 3.],\n",
-       "       [3., 3., 3.]]], dtype=float32)"
-      ]
-     },
-     "execution_count": 5,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "op.apply(time=2)\n",
-    "u.data"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "This is the first time we are calling `apply` on `op`, so the `Operator` code gets written in a `.c` file and compiled into a library (a `.so` shared object if on Linux).\n",
-    "\n",
-    "`op` runs with the user-provided `time_M=2` and with the default arguments `u=u, x_m=0, x_M=2, y_m=0, y_M=2,` and `time_m=0`. The indices `*_m` and `*_M` represent the minimum and maximum iteration points along `Dimension` `*`.\n",
-    "\n",
-    "`op` can be used for a completely different run, for example providing a new `TimeFunction`."
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/plain": [
-       "Data([[[0., 0., 0.],\n",
-       "       [0., 0., 0.],\n",
-       "       [0., 0., 0.]],\n",
-       "\n",
-       "      [[0., 0., 0.],\n",
-       "       [0., 0., 0.],\n",
-       "       [0., 0., 0.]]], dtype=float32)"
-      ]
-     },
-     "execution_count": 6,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "u2 = TimeFunction(name='u', grid=grid)\n",
-    "u2.data"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Any of the `Operator` default arguments may be replaced by passing suitable key-value parameters.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Operator `Kernel` run in 0.00 s\n"
-     ]
-    },
-    {
-     "data": {
-      "text/plain": [
-       "Data([[[0., 0., 0.],\n",
-       "       [4., 4., 0.],\n",
-       "       [4., 4., 0.]],\n",
-       "\n",
-       "      [[0., 0., 0.],\n",
-       "       [3., 3., 0.],\n",
-       "       [3., 3., 0.]]], dtype=float32)"
-      ]
-     },
-     "execution_count": 7,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "op.apply(u=u2, x_m=1, x_M=2, y_m=0, y_M=1, time_M=3)\n",
-    "u2.data"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "Note, however, that there is no need for recompilation. JIT compilation occurs only once, triggered by the first call to `op.apply()`.\n",
-    "\n",
     "An `Operator` is the root of an IET that typically consists of several nested `Iteration`s and `Expression`s – two other fundamental IET node types. The user-provided SymPy equations are wrapped within `Expressions`. Loop nest embedding such expressions are constructed by suitably nesting `Iterations`.\n",
     "\n",
     "The Devito compiler constructs the IET from a collection of `Cluster`s, which represent a higher-level intermediate representation (not covered in this tutorial).\n",
@@ -299,7 +174,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [
     {
@@ -346,7 +221,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "metadata": {},
    "outputs": [
     {
@@ -355,7 +230,7 @@
        "['#define _POSIX_C_SOURCE 200809L']"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -366,7 +241,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [
     {
@@ -375,7 +250,7 @@
        "['stdlib.h', 'math.h', 'sys/time.h']"
       ]
      },
-     "execution_count": 10,
+     "execution_count": 8,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -386,7 +261,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [
     {
@@ -395,7 +270,7 @@
        "(<List (0, 2, 0)>,)"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -413,7 +288,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [
     {
@@ -430,7 +305,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -469,7 +344,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -478,7 +353,7 @@
        "<WithProperties[affine,sequential,wrappable]::Iteration time[t0,t1]; (time_m, time_M, 1)>"
       ]
      },
-     "execution_count": 14,
+     "execution_count": 12,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -490,7 +365,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 13,
    "metadata": {},
    "outputs": [
     {
@@ -529,7 +404,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 16,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
@@ -538,7 +413,7 @@
        "(time_m, time_M, 1)"
       ]
      },
-     "execution_count": 16,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -556,7 +431,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 17,
+   "execution_count": 15,
    "metadata": {
     "scrolled": false
    },
@@ -567,7 +442,7 @@
        "'<Expression u[t1, x + 1, y + 1] = u[t0, x + 1, y + 1] + 1>'"
       ]
      },
-     "execution_count": 17,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -587,7 +462,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 16,
    "metadata": {},
    "outputs": [
     {
@@ -596,7 +471,7 @@
        "'<Expression u[t1, x + 1, y + 1] = u[t0, x + 1, y + 1] + 1>'"
       ]
      },
-     "execution_count": 18,
+     "execution_count": 16,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/examples/seismic/model.py
+++ b/examples/seismic/model.py
@@ -375,8 +375,6 @@ def initialize_damp(damp, nbpml, spacing, mask=False):
 
     dampcoeff = 1.5 * np.log(1.0 / 0.001) / (40.)
 
-    assert all(damp._offset_domain[0] == i for i in damp._offset_domain)
-
     for i in range(damp.ndim):
         for j in range(nbpml):
             # Dampening coefficient

--- a/examples/seismic/tutorials/06_elastic.ipynb
+++ b/examples/seismic/tutorials/06_elastic.ipynb
@@ -284,6 +284,8 @@
     }
    ],
    "source": [
+    "#NBVAL_IGNORE_OUTPUT\n",
+    "\n",
     "assert np.isclose(norm(vx), 1.150313, atol=1e-4, rtol=0)"
    ]
   },
@@ -430,6 +432,8 @@
     }
    ],
    "source": [
+    "#NBVAL_IGNORE_OUTPUT\n",
+    "\n",
     "assert np.isclose(norm(vx), 1.1253732, atol=1e-4, rtol=0)"
    ]
   }

--- a/examples/userapi/apply.ipynb
+++ b/examples/userapi/apply.ipynb
@@ -46,6 +46,7 @@
     }
    ],
    "source": [
+    "#NBVAL_IGNORE_OUTPUT\n",
     "summary = op.apply()"
    ]
   },
@@ -129,7 +130,7 @@
     {
      "data": {
       "text/plain": [
-       "{'u': <cparam 'P' (0x7fbe3ea27c38)>,\n",
+       "{'u': <cparam 'P' (0x7fb0d01d45a8)>,\n",
        " 'time_m': 0,\n",
        " 'time_size': 3,\n",
        " 'time_M': 1,\n",
@@ -139,7 +140,7 @@
        " 'y_m': 0,\n",
        " 'y_size': 4,\n",
        " 'y_M': 3,\n",
-       " 'timers': <cparam 'P' (0x7fbe3edabe68)>}"
+       " 'timers': <cparam 'P' (0x7fb0d0550918)>}"
       ]
      },
      "execution_count": 5,
@@ -148,6 +149,7 @@
     }
    ],
    "source": [
+    "#NBVAL_IGNORE_OUTPUT\n",
     "op.arguments()"
    ]
   },
@@ -174,6 +176,7 @@
     }
    ],
    "source": [
+    "#NBVAL_IGNORE_OUTPUT\n",
     "u.data[:] = 0.  # Explicit reset to initial value\n",
     "summary = op.apply(x_m=2, y_m=2, time_M=0)"
    ]
@@ -271,7 +274,19 @@
      "text": [
       "Operator `Kernel` run in 0.00 s\n"
      ]
-    },
+    }
+   ],
+   "source": [
+    "#NBVAL_IGNORE_OUTPUT\n",
+    "u2 = TimeFunction(name='u', grid=grid, save=5)\n",
+    "summary = op.apply(u=u2)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
     {
      "data": {
       "text/plain": [
@@ -301,14 +316,12 @@
        "       [4., 4., 4., 4.]]], dtype=float32)"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 10,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "u2 = TimeFunction(name='u', grid=grid, save=5)\n",
-    "summary = op.apply(u=u2)\n",
     "u2.data"
    ]
   },
@@ -323,7 +336,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 11,
    "metadata": {},
    "outputs": [
     {
@@ -345,7 +358,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 12,
    "metadata": {},
    "outputs": [
     {
@@ -354,7 +367,18 @@
      "text": [
       "Operator `Kernel` run in 0.00 s\n"
      ]
-    },
+    }
+   ],
+   "source": [
+    "#NBVAL_IGNORE_OUTPUT\n",
+    "summary = op2.apply(time_M=4)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
     {
      "data": {
       "text/plain": [
@@ -369,13 +393,12 @@
        "       [5., 5., 5., 5.]]], dtype=float32)"
       ]
      },
-     "execution_count": 11,
+     "execution_count": 13,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "summary = op2.apply(time_M=4)\n",
     "v.data"
    ]
   },
@@ -388,22 +411,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 14,
    "metadata": {},
    "outputs": [
     {
      "data": {
       "text/plain": [
        "PerformanceSummary([('section0',\n",
-       "                     PerfEntry(time=4e-06, gflopss=0.0, gpointss=0.0, oi=0.0, ops=0, itershapes=[]))])"
+       "                     PerfEntry(time=3e-06, gflopss=0.0, gpointss=0.0, oi=0.0, ops=0, itershapes=[]))])"
       ]
      },
-     "execution_count": 12,
+     "execution_count": 14,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
+    "#NBVAL_IGNORE_OUTPUT\n",
     "summary"
    ]
   },
@@ -416,7 +440,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 15,
    "metadata": {},
    "outputs": [
     {
@@ -430,20 +454,58 @@
      "data": {
       "text/plain": [
        "PerformanceSummary([('section0',\n",
-       "                     PerfEntry(time=2e-06, gflopss=0.016, gpointss=0.016, oi=0.08333333333333333, ops=1, itershapes=[(2, 4, 4)]))])"
+       "                     PerfEntry(time=3e-06, gflopss=0.021333333333333333, gpointss=0.010666666666666666, oi=0.16666666666666666, ops=2, itershapes=[(2, 4, 4)]))])"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 15,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
+    "#NBVAL_IGNORE_OUTPUT\n",
     "from devito import configuration\n",
     "configuration['profiling'] = 'advanced'\n",
     "\n",
-    "op = Operator(Eq(u.forward, u*u + 1))\n",
+    "op = Operator(Eq(u.forward, u*u + 1.))\n",
     "op.apply()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "A `PerformanceSummary` will contain as many entries as \"sections\" in the generated code. Currently, there is no way to automatically tie a compiler-generated section to the user-provided `Eq`s (in general, there can be more than one `Eq` in a section). The only option is to look at the generated code and search for bodies of code wrapped within C comments such as\n",
+    "```\n",
+    "/* Begin section0 */\n",
+    "<code>\n",
+    "/* End section0 \\*/\"\n",
+    "```\n",
+    "For example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Uncomment me and search for /* Begin section0 */ ... /* End section0 */\n",
+    "# print(op)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In the `PerformanceSummary`, associated to `section0` is a `PerfEntry`, whose entries represent:\n",
+    "\n",
+    "* time: The time, in seconds, to execute the section.\n",
+    "* gflopss: Performance of the section in Gigaflops per second.\n",
+    "* gpointss: Performance of the section in Gigapoints per second.\n",
+    "* oi: Operational intensity.\n",
+    "* ops: Floating point operations at each (innermost loop) iteration.\n",
+    "* itershape: The shape of the iteration space."
    ]
   }
  ],

--- a/examples/userapi/apply.ipynb
+++ b/examples/userapi/apply.ipynb
@@ -1,0 +1,471 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This tutorial describes two fundamental user APIs:\n",
+    "\n",
+    "* Operator.apply\n",
+    "* Operator.arguments\n",
+    "\n",
+    "We will use a trivial `Operator` that, at each time step, increments by 1 all points in the physical domain."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from devito import Grid, TimeFunction, Eq, Operator\n",
+    "\n",
+    "grid = Grid(shape=(4, 4))\n",
+    "u = TimeFunction(name='u', grid=grid, save=3)\n",
+    "op = Operator(Eq(u.forward, u + 1))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "To run `op`, we have to \"`apply`\" it."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Operator `Kernel` run in 0.00 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "summary = op.apply()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Under-the-hood, some code has been generated (`print(op)` to display the generated code), JIT-compiled, and executed. Since no additional arguments have been passed, `op` has used `u` as input. We can verify that the content of `u.data` is as expected"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "((time, x, y), (3, 4, 4))"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "u.dimensions, u.shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Data([[[0., 0., 0., 0.],\n",
+       "       [0., 0., 0., 0.],\n",
+       "       [0., 0., 0., 0.],\n",
+       "       [0., 0., 0., 0.]],\n",
+       "\n",
+       "      [[1., 1., 1., 1.],\n",
+       "       [1., 1., 1., 1.],\n",
+       "       [1., 1., 1., 1.],\n",
+       "       [1., 1., 1., 1.]],\n",
+       "\n",
+       "      [[2., 2., 2., 2.],\n",
+       "       [2., 2., 2., 2.],\n",
+       "       [2., 2., 2., 2.],\n",
+       "       [2., 2., 2., 2.]]], dtype=float32)"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "u.data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "In particular, we observe that:\n",
+    "\n",
+    "* `u` has size 3 along the time dimension, since it was built with `save=3`. Therefore `op` could only execute 2 timesteps, namely time=0 and time=1; given `Eq(u.forward, u + 1)`, executing time=2 would cause out-of-bounds access errors. Devito figures this out automatically and sets appropriate minimum and maximum iteration points.\n",
+    "* All 16 points in each timeslice of the 4x4 `Grid` have been computed.\n",
+    "\n",
+    "To access all default arguments used by `op` *without* running the `Operator`, one can run"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'u': <cparam 'P' (0x7fbe3ea27c38)>,\n",
+       " 'time_m': 0,\n",
+       " 'time_size': 3,\n",
+       " 'time_M': 1,\n",
+       " 'x_m': 0,\n",
+       " 'x_size': 4,\n",
+       " 'x_M': 3,\n",
+       " 'y_m': 0,\n",
+       " 'y_size': 4,\n",
+       " 'y_M': 3,\n",
+       " 'timers': <cparam 'P' (0x7fbe3edabe68)>}"
+      ]
+     },
+     "execution_count": 5,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "op.arguments()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "`'u'` stores a pointer to the allocated data; `'timers'` stores a pointer to a data structure used for C-level performance profiling.\n",
+    "\n",
+    "One may want to replace some of these default arguments. For example, we could increase the minimum iteration point along the spatial Dimensions `x` and `y`, and execute only the very first timestep:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Operator `Kernel` run in 0.00 s\n"
+     ]
+    }
+   ],
+   "source": [
+    "u.data[:] = 0.  # Explicit reset to initial value\n",
+    "summary = op.apply(x_m=2, y_m=2, time_M=0)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We look again at the computed data to convince ourselves that everything went as intended to go"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Data([[[0., 0., 0., 0.],\n",
+       "       [0., 0., 0., 0.],\n",
+       "       [0., 0., 0., 0.],\n",
+       "       [0., 0., 0., 0.]],\n",
+       "\n",
+       "      [[0., 0., 0., 0.],\n",
+       "       [0., 0., 0., 0.],\n",
+       "       [0., 0., 1., 1.],\n",
+       "       [0., 0., 1., 1.]],\n",
+       "\n",
+       "      [[0., 0., 0., 0.],\n",
+       "       [0., 0., 0., 0.],\n",
+       "       [0., 0., 0., 0.],\n",
+       "       [0., 0., 0., 0.]]], dtype=float32)"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "u.data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Given a generic `Dimension` `d`, the naming convention is such that:\n",
+    "\n",
+    "* `d_m` is the minimum iteration point\n",
+    "* `d_M` is the maximum iteration point\n",
+    "\n",
+    "Hence, `op.apply(..., d_m=4, d_M=7, ...)` will run `op` in the compact interval `[4, 7]` along `d`. For historical reasons, `d=...` aliases to `d_M=...`; in many Devito examples it happens to see `op.apply(..., time=10, ...)` -- this is just equivalent to `op.apply(..., time_M=10, ...)`.\n",
+    "\n",
+    "If we try to specify an invalid iteration extreme, Devito will raise an exception."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "OOB detected due to time_M=2\n"
+     ]
+    }
+   ],
+   "source": [
+    "from devito.exceptions import InvalidArgument\n",
+    "try:\n",
+    "    op.apply(time_M=2)\n",
+    "except InvalidArgument as e:\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The same `Operator` can be applied to a different `TimeFunction`. For example:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Operator `Kernel` run in 0.00 s\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Data([[[0., 0., 0., 0.],\n",
+       "       [0., 0., 0., 0.],\n",
+       "       [0., 0., 0., 0.],\n",
+       "       [0., 0., 0., 0.]],\n",
+       "\n",
+       "      [[1., 1., 1., 1.],\n",
+       "       [1., 1., 1., 1.],\n",
+       "       [1., 1., 1., 1.],\n",
+       "       [1., 1., 1., 1.]],\n",
+       "\n",
+       "      [[2., 2., 2., 2.],\n",
+       "       [2., 2., 2., 2.],\n",
+       "       [2., 2., 2., 2.],\n",
+       "       [2., 2., 2., 2.]],\n",
+       "\n",
+       "      [[3., 3., 3., 3.],\n",
+       "       [3., 3., 3., 3.],\n",
+       "       [3., 3., 3., 3.],\n",
+       "       [3., 3., 3., 3.]],\n",
+       "\n",
+       "      [[4., 4., 4., 4.],\n",
+       "       [4., 4., 4., 4.],\n",
+       "       [4., 4., 4., 4.],\n",
+       "       [4., 4., 4., 4.]]], dtype=float32)"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "u2 = TimeFunction(name='u', grid=grid, save=5)\n",
+    "summary = op.apply(u=u2)\n",
+    "u2.data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Note that this was the third call to `op.apply`, but code generation and JIT-compilation only occurred upon the very first call.\n",
+    "\n",
+    "There is one relevant case in which the maximum iteration point along the time dimension must be specified -- whenever `save` is unset, as in such a case the `Operator` wouldn't know for how many iterations to run."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "No value found for parameter time_M\n"
+     ]
+    }
+   ],
+   "source": [
+    "v = TimeFunction(name='v', grid=grid)\n",
+    "op2 = Operator(Eq(v.forward, v + 1))\n",
+    "try:\n",
+    "    op2.apply()\n",
+    "except ValueError as e:\n",
+    "    print(e)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Operator `Kernel` run in 0.00 s\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "Data([[[4., 4., 4., 4.],\n",
+       "       [4., 4., 4., 4.],\n",
+       "       [4., 4., 4., 4.],\n",
+       "       [4., 4., 4., 4.]],\n",
+       "\n",
+       "      [[5., 5., 5., 5.],\n",
+       "       [5., 5., 5., 5.],\n",
+       "       [5., 5., 5., 5.],\n",
+       "       [5., 5., 5., 5.]]], dtype=float32)"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "summary = op2.apply(time_M=4)\n",
+    "v.data"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The `summary` variable can be inspected to retrieve performance metrics."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "PerformanceSummary([('section0',\n",
+       "                     PerfEntry(time=4e-06, gflopss=0.0, gpointss=0.0, oi=0.0, ops=0, itershapes=[]))])"
+      ]
+     },
+     "execution_count": 12,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "summary"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We observe that basically all entries except for the execution time are fixed at 0. This is because by default Devito avoids to compute performance metrics, to minimize the processing time before returning control to the user (in complex `Operators`, the processing time to retrieve, for instance, the operation count or the memory footprint could be significant). To compute all performance metrics, a user could either export the environment variable `DEVITO_PROFILING` to `'advanced'` or change the profiling level programmatically *before* the `Operator` is constructed"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Operator `Kernel` run in 0.00 s\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "PerformanceSummary([('section0',\n",
+       "                     PerfEntry(time=2e-06, gflopss=0.016, gpointss=0.016, oi=0.08333333333333333, ops=1, itershapes=[(2, 4, 4)]))])"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from devito import configuration\n",
+    "configuration['profiling'] = 'advanced'\n",
+    "\n",
+    "op = Operator(Eq(u.forward, u*u + 1))\n",
+    "op.apply()"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.8"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/tests/test_autotuner.py
+++ b/tests/test_autotuner.py
@@ -102,7 +102,7 @@ def test_timesteps_per_at_run():
 @switchconfig(profiling='advanced')
 def test_mode_runtime_forward():
     """Test autotuning in runtime mode."""
-    grid = Grid(shape=(64, 64, 64))
+    grid = Grid(shape=(96, 96, 96))
     f = TimeFunction(name='f', grid=grid)
 
     op = Operator(Eq(f.forward, f + 1.), dle=('advanced', {'openmp': False}))
@@ -120,7 +120,7 @@ def test_mode_runtime_forward():
 @switchconfig(profiling='advanced')
 def test_mode_runtime_backward():
     """Test autotuning in runtime mode."""
-    grid = Grid(shape=(64, 64, 64))
+    grid = Grid(shape=(96, 96, 96))
     f = TimeFunction(name='f', grid=grid)
 
     op = Operator(Eq(f.backward, f + 1.), dle=('advanced', {'openmp': False}))
@@ -138,7 +138,7 @@ def test_mode_runtime_backward():
 @switchconfig(profiling='advanced')
 def test_mode_destructive():
     """Test autotuning in destructive mode."""
-    grid = Grid(shape=(64, 64, 64))
+    grid = Grid(shape=(96, 96, 96))
     f = TimeFunction(name='f', grid=grid, time_order=0)
 
     op = Operator(Eq(f, f + 1.), dle=('advanced', {'openmp': False}))
@@ -151,7 +151,7 @@ def test_mode_destructive():
 
 
 def test_blocking_only():
-    grid = Grid(shape=(64, 64, 64))
+    grid = Grid(shape=(96, 96, 96))
     f = TimeFunction(name='f', grid=grid)
 
     op = Operator(Eq(f.forward, f + 1.), dle=('advanced', {'openmp': False}))
@@ -164,7 +164,7 @@ def test_blocking_only():
 
 
 def test_mixed_blocking_nthreads():
-    grid = Grid(shape=(64, 64, 64))
+    grid = Grid(shape=(96, 96, 96))
     f = TimeFunction(name='f', grid=grid)
 
     op = Operator(Eq(f.forward, f + 1.), dle=('advanced', {'openmp': True}))
@@ -181,7 +181,7 @@ def test_tti_aggressive():
     wave_solver = tti_operator(dse='aggressive', dle=('advanced', {'openmp': False}))
     op = wave_solver.op_fwd(kernel='centered', save=False)
     op.apply(time=0, autotune='aggressive')
-    assert op._state['autotuning'][0]['runs'] == 33
+    assert op._state['autotuning'][0]['runs'] == 28
 
 
 @switchconfig(develop_mode=False)
@@ -193,7 +193,7 @@ def test_discarding_runs():
     op = Operator(Eq(f.forward, f + 1.), dle=('advanced', {'openmp': True}))
     op.apply(time=100, nthreads=4, autotune='aggressive')
 
-    assert op._state['autotuning'][0]['runs'] == 20
+    assert op._state['autotuning'][0]['runs'] == 18
     assert op._state['autotuning'][0]['tpr'] == options['squeezer'] + 1
     assert len(op._state['autotuning'][0]['tuned']) == 3
     assert op._state['autotuning'][0]['tuned']['nthreads'] == 4
@@ -201,7 +201,7 @@ def test_discarding_runs():
     # With 1 < 4 threads, the AT eventually tries many more combinations
     op.apply(time=100, nthreads=1, autotune='aggressive')
 
-    assert op._state['autotuning'][1]['runs'] == 30
+    assert op._state['autotuning'][1]['runs'] == 25
     assert op._state['autotuning'][1]['tpr'] == options['squeezer'] + 1
     assert len(op._state['autotuning'][1]['tuned']) == 3
     assert op._state['autotuning'][1]['tuned']['nthreads'] == 1
@@ -262,7 +262,7 @@ def test_multiple_blocking():
     cartesian product of all possible block shapes across the various
     blocked nests.
     """
-    grid = Grid(shape=(64, 64, 64))
+    grid = Grid(shape=(96, 96, 96))
 
     u = TimeFunction(name='u', grid=grid, space_order=2)
     v = TimeFunction(name='v', grid=grid)
@@ -306,13 +306,13 @@ def test_hierarchical_blocking():
 
     # 'basic' mode
     op.apply(time_M=0, autotune='basic')
-    assert op._state['autotuning'][0]['runs'] == 12  # 6 for each Iteration nest
+    assert op._state['autotuning'][0]['runs'] == 10
     assert op._state['autotuning'][0]['tpr'] == options['squeezer'] + 1
     assert len(op._state['autotuning'][0]['tuned']) == 4
 
     # 'aggressive' mode
     op.apply(time_M=0, autotune='aggressive')
-    assert op._state['autotuning'][1]['runs'] == 60
+    assert op._state['autotuning'][1]['runs'] == 38
     assert op._state['autotuning'][1]['tpr'] == options['squeezer'] + 1
     assert len(op._state['autotuning'][1]['tuned']) == 4
 
@@ -322,7 +322,7 @@ def test_multiple_threads():
     Test autotuning when different ``num_threads`` for a given OpenMP parallel
     region are attempted.
     """
-    grid = Grid(shape=(64, 64, 64))
+    grid = Grid(shape=(96, 96, 96))
 
     v = TimeFunction(name='v', grid=grid)
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -3,7 +3,7 @@ import numpy as np
 
 from conftest import skipif
 from devito import (Grid, Function, TimeFunction, SparseTimeFunction, Dimension, # noqa
-                    Eq, Operator, ALLOC_GUARD, ALLOC_FLAT)
+                    Eq, Operator, ALLOC_GUARD, ALLOC_FLAT, switchconfig)
 from devito.data import LEFT, RIGHT, Decomposition
 
 pytestmark = skipif('ops')
@@ -178,64 +178,6 @@ class TestDataBasic(object):
         assert np.all(v_mod.data[-1] == v_mod.data[1])
         assert np.all(v_mod.data[-2] == v_mod.data[0])
 
-    def test_data_regions_metadata(self):
-        """
-        Test correctness of metadata describing size and offset of the various
-        data regions, such as DOMAIN, HALO, etc.
-        """
-        grid = Grid(shape=(4, 4, 4))
-
-        # Without halo and without padding
-        u0 = Function(name='u0', grid=grid, space_order=0)
-
-        assert u0.shape == u0._shape_with_inhalo == u0.shape_allocated
-        assert u0.shape_with_halo == u0._shape_with_inhalo  # W/o MPI, these two coincide
-        assert u0._size_halo == u0._size_owned == u0._size_padding ==\
-            ((0, 0), (0, 0), (0, 0))
-        assert u0._offset_domain == (0, 0, 0)
-        assert u0._offset_halo == u0._offset_owned == ((0, 4), (0, 4), (0, 4))
-
-        # With halo but without padding
-        u1 = Function(name='u1', grid=grid, space_order=2)
-        assert len(u1.shape) == len(u1._size_halo.left)
-        assert u1._size_halo == u1._size_owned == ((2, 2), (2, 2), (2, 2))
-        assert u1._offset_domain == (2, 2, 2)
-        assert u1._offset_halo == ((0, 6), (0, 6), (0, 6))
-        assert u1._offset_owned == ((2, 4), (2, 4), (2, 4))
-        assert tuple(i + j*2 for i, j in zip(u1.shape, u1._size_halo.left)) ==\
-            u1.shape_with_halo
-
-        # Without halo but with padding
-        u2 = Function(name='u2', grid=grid, space_order=2,
-                      padding=((1, 1), (3, 3), (4, 4)))
-        assert len(u2.shape_allocated) == len(u1._size_padding.left)
-        assert tuple(i + j + k for i, (j, k) in zip(u2.shape_with_halo, u2._padding)) ==\
-            u2.shape_allocated
-        assert u2._halo == ((2, 2), (2, 2), (2, 2))
-        assert u2._size_padding == ((1, 1), (3, 3), (4, 4))
-        assert u2._size_padding.left == u2._size_padding.right == (1, 3, 4)
-        assert u2._size_nodomain == ((3, 3), (5, 5), (6, 6))
-        assert u2._size_nodomain.left == u2._size_nodomain.right == (3, 5, 6)
-        assert u2._size_nopad == (8, 8, 8)
-        assert u2._offset_domain == (3, 5, 6)
-        assert u2._offset_halo == ((1, 7), (3, 9), (4, 10))
-        assert u2._offset_halo.left == (1, 3, 4)
-        assert u2._offset_halo.right == (7, 9, 10)
-        assert u2._offset_owned == ((3, 5), (5, 7), (6, 8))
-
-        # With halo and with padding
-        u3 = Function(name='u3', grid=grid, space_order=(2, 1, 4),
-                      padding=((1, 1), (2, 2), (3, 3)))
-        assert u3._size_halo == ((1, 4), (1, 4), (1, 4))
-        assert u3._size_owned == ((4, 1), (4, 1), (4, 1))
-        assert u3._size_nodomain == ((2, 5), (3, 6), (4, 7))
-        assert u3._size_nodomain.left == (2, 3, 4)
-        assert u3._size_nodomain.right == (5, 6, 7)
-        assert u3._size_nopad == (9, 9, 9)
-        assert u3._offset_domain == (2, 3, 4)
-        assert u3._offset_halo == ((1, 6), (2, 7), (3, 8))
-        assert u3._offset_owned == ((2, 5), (3, 6), (4, 7))
-
     def test_indexing_into_sparse(self):
         """
         Test indexing into SparseFunctions.
@@ -245,6 +187,89 @@ class TestDataBasic(object):
 
         sf.data[1:-1, 0] = np.arange(8)
         assert np.all(sf.data[1:-1, 0] == np.arange(8))
+
+
+class TestMetaData(object):
+
+    """
+    Test correctness of metadata describing size and offset of the various
+    data regions, such as DOMAIN, HALO, etc.
+    """
+
+    def test_wo_halo_wo_padding(self):
+        grid = Grid(shape=(4, 4, 4))
+        u = Function(name='u', grid=grid, space_order=0, padding=0)
+
+        assert u.shape == u._shape_with_inhalo == u.shape_allocated
+        assert u.shape_with_halo == u._shape_with_inhalo  # W/o MPI, these two coincide
+        assert u._size_halo == u._size_owned == u._size_padding ==\
+            ((0, 0), (0, 0), (0, 0))
+        assert u._offset_domain == (0, 0, 0)
+        assert u._offset_halo == u._offset_owned == ((0, 4), (0, 4), (0, 4))
+
+    def test_w_halo_wo_padding(self):
+        grid = Grid(shape=(4, 4, 4))
+        u = Function(name='u', grid=grid, space_order=2, padding=0)
+
+        assert len(u.shape) == len(u._size_halo.left)
+        assert u._size_halo == u._size_owned == ((2, 2), (2, 2), (2, 2))
+        assert u._offset_domain == (2, 2, 2)
+        assert u._offset_halo == ((0, 6), (0, 6), (0, 6))
+        assert u._offset_owned == ((2, 4), (2, 4), (2, 4))
+        assert tuple(i + j*2 for i, j in zip(u.shape, u._size_halo.left)) ==\
+            u.shape_with_halo
+
+    @skipif('yask')
+    def test_wo_halo_w_padding(self):
+        grid = Grid(shape=(4, 4, 4))
+        u = Function(name='u', grid=grid, space_order=2, padding=((1, 1), (3, 3), (4, 4)))
+
+        assert tuple(i + j + k for i, (j, k) in zip(u.shape_with_halo, u._padding)) ==\
+            u.shape_allocated
+        assert u._halo == ((2, 2), (2, 2), (2, 2))
+        assert u._size_padding == ((1, 1), (3, 3), (4, 4))
+        assert u._size_padding.left == u._size_padding.right == (1, 3, 4)
+        assert u._size_nodomain == ((3, 3), (5, 5), (6, 6))
+        assert u._size_nodomain.left == u._size_nodomain.right == (3, 5, 6)
+        assert u._size_nopad == (8, 8, 8)
+        assert u._offset_domain == (3, 5, 6)
+        assert u._offset_halo == ((1, 7), (3, 9), (4, 10))
+        assert u._offset_halo.left == (1, 3, 4)
+        assert u._offset_halo.right == (7, 9, 10)
+        assert u._offset_owned == ((3, 5), (5, 7), (6, 8))
+
+    @skipif('yask')
+    def test_w_halo_w_padding(self):
+        grid = Grid(shape=(4, 4, 4))
+        u = Function(name='u', grid=grid, space_order=(2, 1, 4),
+                     padding=((1, 1), (2, 2), (3, 3)))
+
+        assert u._size_halo == ((1, 4), (1, 4), (1, 4))
+        assert u._size_owned == ((4, 1), (4, 1), (4, 1))
+        assert u._size_nodomain == ((2, 5), (3, 6), (4, 7))
+        assert u._size_nodomain.left == (2, 3, 4)
+        assert u._size_nodomain.right == (5, 6, 7)
+        assert u._size_nopad == (9, 9, 9)
+        assert u._offset_domain == (2, 3, 4)
+        assert u._offset_halo == ((1, 6), (2, 7), (3, 8))
+        assert u._offset_owned == ((2, 5), (3, 6), (4, 7))
+
+    @skipif('yask')
+    @switchconfig(platform='skx')  # To fix autopadding
+    def test_w_halo_w_autopadding(self):
+        grid = Grid(shape=(4, 4, 4))
+        u0 = Function(name='u0', grid=grid, space_order=0)
+        u1 = Function(name='u1', grid=grid, space_order=3)
+
+        assert u0._size_halo == ((0, 0), (0, 0), (0, 0))
+        assert u0._size_padding == ((0, 0), (0, 0), (0, 4))  # no left-halo -> no left-pad
+        assert u0._size_nodomain == u0._size_padding
+        assert u0.shape_allocated == (4, 4, 8)
+
+        assert u1._size_halo == ((3, 3), (3, 3), (3, 3))
+        assert u1._size_padding == ((0, 0), (0, 0), (5, 1))
+        assert u1._size_nodomain == ((3, 3), (3, 3), (8, 4))
+        assert u1.shape_allocated == (10, 10, 16)
 
 
 @skipif('yask')

--- a/tests/test_dle.py
+++ b/tests/test_dle.py
@@ -266,7 +266,7 @@ def test_cache_blocking_hierarchical(blockshape0, blockshape1, exception):
                                        dle=('blocking', {'blockinner': True,
                                                          'blocklevels': 2}))
         assert not exception
-        assert np.all(wo_blocking == w_blocking)
+        assert np.allclose(wo_blocking, w_blocking, rtol=1e-12)
     except InvalidArgument:
         assert exception
     except:

--- a/tests/test_dle.py
+++ b/tests/test_dle.py
@@ -1,18 +1,19 @@
 from functools import reduce
 from operator import mul
 
+from sympy import Add
 import numpy as np
 import pytest
 
 from conftest import EVAL, skipif
 from devito import (Grid, Function, TimeFunction, SparseTimeFunction, SubDimension,
-                    Eq, Operator, solve)
+                    Eq, Operator, solve, switchconfig)
 from devito.dle import BlockDimension, NThreads, transform
 from devito.dle.parallelizer import nhyperthreads
 from devito.exceptions import InvalidArgument
 from devito.ir.equations import DummyEq
 from devito.ir.iet import (Call, Expression, Iteration, Conditional, FindNodes,
-                           iet_analyze, retrieve_iteration_tree)
+                           FindSymbols, iet_analyze, retrieve_iteration_tree)
 from devito.tools import as_tuple
 from unittest.mock import patch
 
@@ -484,6 +485,59 @@ class TestNestedParallelism(object):
         assert trees[1][2].pragmas[0].value ==\
             ('omp parallel for collapse(1) schedule(static,1) num_threads(%d)'
              % nhyperthreads())
+
+
+@switchconfig(autopadding=True, platform='knl7210')  # Platform is to fix pad value
+@patch("devito.dse.rewriters.AdvancedRewriter.MIN_COST_ALIAS", 1)
+def test_minimize_reminders_due_to_autopadding():
+    """
+    Check that the bounds of the Iteration computing the DSE-captured aliasing
+    expressions are relaxed (i.e., slightly larger) so that backend-compiler-generated
+    remainder loops are avoided.
+    """
+    grid = Grid(shape=(3, 3, 3))
+    x, y, z = grid.dimensions  # noqa
+    t = grid.stepping_dim
+
+    f = Function(name='f', grid=grid)
+    f.data_with_halo[:] = 1.
+    u = TimeFunction(name='u', grid=grid, space_order=3)
+    u.data_with_halo[:] = 0.
+
+    # Leads to 3D aliases
+    eqn = Eq(u.forward, ((u[t, x, y, z] + u[t, x+1, y+1, z+1])*3*f +
+                         (u[t, x+2, y+2, z+2] + u[t, x+3, y+3, z+3])*3*f + 1))
+    op0 = Operator(eqn, dse='noop', dle=('advanced', {'openmp': False}))
+    op1 = Operator(eqn, dse='aggressive', dle=('advanced', {'openmp': False}))
+
+    x0_blk_size = op1.parameters[5]
+    y0_blk_size = op1.parameters[9]
+    z_size = op1.parameters[-1]
+
+    # Check Array shape
+    arrays = [i for i in FindSymbols().visit(op1._func_table['bf0'].root) if i.is_Array]
+    assert len(arrays) == 1
+    a = arrays[0]
+    assert len(a.dimensions) == 3
+    assert a.halo == ((1, 1), (1, 1), (1, 1))
+    assert a.padding == ((0, 0), (0, 0), (0, 30))
+    assert Add(*a.symbolic_shape[0].args) == x0_blk_size + 2
+    assert Add(*a.symbolic_shape[1].args) == y0_blk_size + 2
+    assert Add(*a.symbolic_shape[2].args) == z_size + 32
+
+    # Check loop bounds
+    trees = retrieve_iteration_tree(op1._func_table['bf0'].root)
+    assert len(trees) == 2
+    expected_rounded = trees[0].inner
+    assert expected_rounded.symbolic_max ==\
+        z.symbolic_max + (z.symbolic_max - z.symbolic_min + 3) % 16 + 1
+
+    # Check numerical output
+    op0(time_M=1)
+    exp = np.copy(u.data[:])
+    u.data_with_halo[:] = 0.
+    op1(time_M=1)
+    assert np.all(u.data == exp)
 
 
 @pytest.mark.parametrize("shape", [(41,), (20, 33), (45, 31, 45)])

--- a/tests/test_dle.py
+++ b/tests/test_dle.py
@@ -413,7 +413,7 @@ class TestNodeParallelism(object):
 class TestNestedParallelism(object):
 
     @patch("devito.dle.parallelizer.Ompizer.NESTED", 0)
-    @patch("devito.dle.parallelizer.Ompizer.COLLAPSE", 10000)
+    @patch("devito.dle.parallelizer.Ompizer.COLLAPSE_NCORES", 10000)
     def test_basic(self):
         grid = Grid(shape=(3, 3, 3))
 
@@ -459,7 +459,7 @@ class TestNestedParallelism(object):
 
     @patch("devito.dse.rewriters.AdvancedRewriter.MIN_COST_ALIAS", 1)
     @patch("devito.dle.parallelizer.Ompizer.NESTED", 0)
-    @patch("devito.dle.parallelizer.Ompizer.COLLAPSE", 10000)
+    @patch("devito.dle.parallelizer.Ompizer.COLLAPSE_NCORES", 10000)
     def test_multiple_subnests(self):
         grid = Grid(shape=(3, 3, 3))
         x, y, z = grid.dimensions

--- a/tests/test_dse.py
+++ b/tests/test_dse.py
@@ -261,6 +261,7 @@ def test_time_dependent_split(dse, dle):
     assert np.allclose(v.data[1, 1:-1, 1:-1], 1.0)
 
 
+@switchconfig(autopadding=False)
 @patch("devito.dse.rewriters.AdvancedRewriter.MIN_COST_ALIAS", 1)
 def test_full_alias_shape_after_blocking():
     """
@@ -292,7 +293,7 @@ def test_full_alias_shape_after_blocking():
     assert len(arrays) == 1
     a = arrays[0]
     assert len(a.dimensions) == 3
-    assert a.halo == [(1, 1), (1, 1), (1, 1)]
+    assert a.halo == ((1, 1), (1, 1), (1, 1))
     assert Add(*a.symbolic_shape[0].args) == x0_blk_size + 2
     assert Add(*a.symbolic_shape[1].args) == y0_blk_size + 2
     assert Add(*a.symbolic_shape[2].args) == z_size + 2
@@ -304,6 +305,7 @@ def test_full_alias_shape_after_blocking():
     assert np.all(u.data == exp)
 
 
+@switchconfig(autopadding=False)
 @patch("devito.dse.rewriters.AdvancedRewriter.MIN_COST_ALIAS", 1)
 def test_contracted_alias_shape_after_blocking():
     """
@@ -332,7 +334,7 @@ def test_contracted_alias_shape_after_blocking():
     assert len(arrays) == 1
     a = arrays[0]
     assert len(a.dimensions) == 2
-    assert a.halo == [(1, 1), (1, 1)]
+    assert a.halo == ((1, 1), (1, 1))
     assert Add(*a.symbolic_shape[0].args) == y0_blk_size + 2
     assert Add(*a.symbolic_shape[1].args) == z_size + 2
     # Check numerical output
@@ -375,7 +377,7 @@ def test_full_alias_shape_with_subdims():
     assert len(arrays) == 1
     a = arrays[0]
     assert len(a.dimensions) == 3
-    assert a.halo == [(1, 1), (1, 1), (1, 1)]
+    assert a.halo == ((1, 1), (1, 1), (1, 1))
     assert Add(*a.symbolic_shape[0].args) == xi0_blk_size + 2
     assert Add(*a.symbolic_shape[1].args) == yi0_blk_size + 2
     assert Add(*a.symbolic_shape[2].args) == z_size + 2

--- a/tests/test_dse.py
+++ b/tests/test_dse.py
@@ -261,7 +261,6 @@ def test_time_dependent_split(dse, dle):
     assert np.allclose(v.data[1, 1:-1, 1:-1], 1.0)
 
 
-@switchconfig(autopadding=False)
 @patch("devito.dse.rewriters.AdvancedRewriter.MIN_COST_ALIAS", 1)
 def test_full_alias_shape_after_blocking():
     """
@@ -305,7 +304,6 @@ def test_full_alias_shape_after_blocking():
     assert np.all(u.data == exp)
 
 
-@switchconfig(autopadding=False)
 @patch("devito.dse.rewriters.AdvancedRewriter.MIN_COST_ALIAS", 1)
 def test_contracted_alias_shape_after_blocking():
     """

--- a/tests/test_dse.py
+++ b/tests/test_dse.py
@@ -389,6 +389,54 @@ def test_full_alias_shape_with_subdims():
     assert np.all(u.data == exp)
 
 
+@switchconfig(platform='knl7210')  # Fix a platform so that autopadding is fixed
+@patch("devito.dse.rewriters.AdvancedRewriter.MIN_COST_ALIAS", 1)
+def test_full_alias_induced_iteration_bounds():
+    """
+    Check that the bounds of the Iteration computing the DSE-captured aliasing
+    expressions are relaxed (i.e., slightly larger) so that backend-compiler-generated
+    remainder loops are avoided.
+    """
+    grid = Grid(shape=(3, 3, 3))
+    x, y, z = grid.dimensions  # noqa
+    t = grid.stepping_dim
+
+    f = Function(name='f', grid=grid)
+    f.data_with_halo[:] = 1.
+    u = TimeFunction(name='u', grid=grid, space_order=3)
+    u.data_with_halo[:] = 0.
+
+    # Leads to 3D aliases
+    eqn = Eq(u.forward, ((u[t, x, y, z] + u[t, x+1, y+1, z+1])*3*f +
+                         (u[t, x+2, y+2, z+2] + u[t, x+3, y+3, z+3])*3*f + 1))
+    op0 = Operator(eqn, dse='noop', dle=('advanced', {'openmp': True}))
+    op1 = Operator(eqn, dse='aggressive', dle=('advanced', {'openmp': True}))
+
+    x0_blk_size = op1.parameters[6]
+    y0_blk_size = op1.parameters[10]
+    z_size = op1.parameters[-1]
+
+    # Check Array shape
+    arrays = [i for i in FindSymbols().visit(op1._func_table['bf0'].root) if i.is_Array]
+    assert len(arrays) == 1
+    a = arrays[0]
+    assert len(a.dimensions) == 3
+    assert a.halo == ((1, 1), (1, 1), (1, 1))
+    assert a.padding == ((0, 0), (0, 0), (0, 14))
+    assert Add(*a.symbolic_shape[0].args) == x0_blk_size + 2
+    assert Add(*a.symbolic_shape[1].args) == y0_blk_size + 2
+    assert Add(*a.symbolic_shape[2].args) == z_size + 16
+
+    # Check loop bounds
+
+    # Check numerical output
+    op0(time_M=1)
+    exp = np.copy(u.data[:])
+    u.data_with_halo[:] = 0.
+    op1(time_M=1)
+    assert np.all(u.data == exp)
+
+
 def test_alias_composite():
     """
     Check that composite alias are optimized away through "smaller" aliases.

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -38,7 +38,7 @@ class TestCodeGen(object):
     def test_parameters(self):
         """Tests code generation for Operator parameters."""
         grid = Grid(shape=(3,))
-        a_dense = Function(name='a_dense', grid=grid, padding=0)
+        a_dense = Function(name='a_dense', grid=grid)
         const = Constant(name='constant')
         eqn = Eq(a_dense, a_dense + 2.*const)
         op = Operator(eqn, dle=('advanced', {'openmp': False}))
@@ -68,8 +68,8 @@ class TestCodeGen(object):
         grid = Grid(shape=(4, 4, 4))
         x, y, z = grid.dimensions
         t = grid.stepping_dim  # noqa
-        u = TimeFunction(name='u', grid=grid, space_order=so, time_order=to, padding=0)  # noqa
-        m = Function(name='m', grid=grid, space_order=0, padding=0)  # noqa
+        u = TimeFunction(name='u', grid=grid, space_order=so, time_order=to)  # noqa
+        m = Function(name='m', grid=grid, space_order=0)  # noqa
         expr = eval(expr)
         expr = Operator(expr)._specialize_exprs([indexify(expr)])[0]
         assert str(expr).replace(' ', '') == expected
@@ -419,11 +419,11 @@ class TestAllocation(object):
         Test the "deformed" allocation for staggered functions
         """
         grid = Grid(shape=tuple([11]*ndim))
-        f = Function(name='f', grid=grid, staggered=stagg, padding=0)
+        f = Function(name='f', grid=grid, staggered=stagg)
         assert f.data.shape == tuple(11-i for i in f.staggered)
         # Add a non-staggered field to ensure that the auto-derived
         # dimension size arguments are at maximum
-        g = Function(name='g', grid=grid, padding=0)
+        g = Function(name='g', grid=grid)
         # Test insertion into a central point
         index = tuple(5 for _ in f.staggered)
         set_f = Eq(f[index], 2.)
@@ -442,11 +442,11 @@ class TestAllocation(object):
         Test the "deformed" allocation for staggered functions
         """
         grid = Grid(shape=tuple([11]*ndim))
-        f = TimeFunction(name='f', grid=grid, staggered=stagg, padding=0)
+        f = TimeFunction(name='f', grid=grid, staggered=stagg)
         assert f.data.shape[1:] == tuple(11-i for i in f.staggered[1:])
         # Add a non-staggered field to ensure that the auto-derived
         # dimension size arguments are at maximum
-        g = TimeFunction(name='g', grid=grid, padding=0)
+        g = TimeFunction(name='g', grid=grid)
         # Test insertion into a central point
         index = tuple([0] + [5 for _ in f.staggered[1:]])
         set_f = Eq(f[index], 2.)

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -1099,7 +1099,7 @@ class TestDeclarator(object):
   return 0;""" in str(operator.ccode)
 
 
-class TestLoopScheduler(object):
+class TestLoopScheduling(object):
 
     def test_consistency_coupled_wo_ofs(self, tu, tv, ti0, t0, t1):
         """
@@ -1155,65 +1155,108 @@ class TestLoopScheduler(object):
             exprs = FindNodes(Expression).visit(tree[-1])
             assert len(exprs) == 3
 
+    def test_fission_for_parallelism(self):
+        """
+        Test that expressions are scheduled to separate loops if this can
+        turn one sequential loop into two parallel loops ("loop fission").
+        """
+        grid = Grid(shape=(3, 3))
+        x, y = grid.dimensions
+
+        u = TimeFunction(name='u', grid=grid)
+        v = TimeFunction(name='v', grid=grid)
+
+        # Fission as an optimization to increase parallelism
+        eqns = [Eq(u, 1), Eq(v, u.dxl)]
+        op = Operator(eqns)
+        trees = retrieve_iteration_tree(op)
+        assert len(trees) == 2
+        assert trees[0][1].dim is x
+        assert trees[1][1].dim is x
+
+        # Same story as above, but now with a WAR
+        eqns = [Eq(u, 1), Eq(v, u.dxr)]
+        op = Operator(eqns)
+        trees = retrieve_iteration_tree(op)
+        assert len(trees) == 2
+        assert trees[0][1].dim is x
+        assert trees[1][1].dim is x
+
+        # Again pretty similar, but with a WAR on `v` -- fission is still
+        # the result of optimization
+        eqns = [Eq(u, v), Eq(v, u.dxl)]
+        op = Operator(eqns)
+        trees = retrieve_iteration_tree(op)
+        assert len(trees) == 2
+        assert trees[0][1].dim is x
+        assert trees[1][1].dim is x
+
+        # No fission expected
+        eqns = [Eq(u.forward, v), Eq(v, u.dxl)]
+        op = Operator(eqns)
+        trees = retrieve_iteration_tree(op)
+        assert len(trees) == 1
+
     @pytest.mark.parametrize('exprs,directions,expected,visit', [
-        # WAR 2->3; expected=2
+        # WAR 2->3
         (('Eq(ti0[x,y,z], ti0[x,y,z] + ti1[x,y,z])',
           'Eq(ti1[x,y,z], ti3[x,y,z])',
           'Eq(ti3[x,y,z], ti1[x,y,z+1] + 1.)'),
-         '++-', ['xyz'], 'xyz'),
-        # WAR 1->2, 2->3; expected=2
-        # The second WAR forces a change of iteration direction along z
+         '++++', ['xyz', 'xyz'], 'xyzz'),
+        # WAR 1->2, 2->3
         (('Eq(ti0[x,y,z], ti0[x,y,z] + ti1[x,y,z])',
           'Eq(ti1[x,y,z], ti0[x,y,z+1])',
           'Eq(ti3[x,y,z], ti1[x,y,z-2] + 1.)'),
-         '++-+', ['xyz', 'xyz'], 'xyzz'),
+         '+++++', ['xyz', 'xyz', 'xyz'], 'xyzzz'),
         # WAR 1->2, 2->3, RAW 2->3
-        # In 2->3 there are both a RAW and a WAR, so the compiler enforces a
-        # change of iteration direction. 1->2 caused --, so 2->3 gets ++
         (('Eq(ti0[x,y,z], ti0[x,y,z] + ti1[x,y,z])',
           'Eq(ti1[x,y,z], ti0[x,y,z+1])',
           'Eq(ti3[x,y,z], ti1[x,y,z-2] + ti1[x,y,z+2])'),
-         '++-+', ['xyz', 'xyz'], 'xyzz'),
-        # WAR 1->3; expected=1
+         '+++++', ['xyz', 'xyz', 'xyz'], 'xyzzz'),
+        # WAR 1->3
         (('Eq(ti0[x,y,z], ti0[x,y,z] + ti1[x,y,z])',
           'Eq(ti1[x,y,z], ti3[x,y,z])',
           'Eq(ti3[x,y,z], ti0[x,y,z+1] + 1.)'),
-         '++-', ['xyz'], 'xyz'),
-        # WAR 1->2, 2->3; WAW 1->3; expected=2
-        # ti0 is an Array, so the observation made above still holds (expected=2
-        # rather than 3)
+         '++++', ['xyz', 'xyz'], 'xyzz'),
+        # WAR 1->3
+        # Like before, but the WAR is along `y`, an inner Dimension
         (('Eq(ti0[x,y,z], ti0[x,y,z] + ti1[x,y,z])',
-          'Eq(ti1[x,y,z], 3*ti0[x,y,z+2])',
+          'Eq(ti1[x,y,z], ti3[x,y,z])',
+          'Eq(ti3[x,y,z], ti0[x,y+1,z] + 1.)'),
+         '+++++', ['xyz', 'xyz'], 'xyzyz'),
+        # WAR 1->2, 2->3; WAW 1->3
+        # Similar to the cases above, but the last equation does not iterate over `z`
+        (('Eq(ti0[x,y,z], ti0[x,y,z] + ti1[x,y,z])',
+          'Eq(ti1[x,y,z], ti0[x,y,z+2])',
           'Eq(ti0[x,y,0], ti0[x,y,0] + 1.)'),
-         '++-', ['xyz', 'xy'], 'xyz'),
-        # WAR 1->2; WAW 1->3; expected=2
-        # Now tu, tv, tw are not Arrays, so they must end up in separate loops
+         '++++', ['xyz', 'xyz', 'xy'], 'xyzz'),
+        # WAR 1->2; WAW 1->3
+        # Basically like above, but with the time dimension. This should have no impact
         (('Eq(tu[t,x,y,z], tu[t,x,y,z] + tv[t,x,y,z])',
           'Eq(tv[t,x,y,z], tu[t,x,y,z+2])',
           'Eq(tu[t,x,y,0], tu[t,x,y,0] + 1.)'),
-         '+++-', ['txyz', 'txy'], 'txyz'),
-        # WAR 1->2, 2->3; expected=2
-        # The second WAR forces a change of iteration direction along z
+         '+++++', ['txyz', 'txyz', 'txy'], 'txyzz'),
+        # WAR 1->2, 2->3
         (('Eq(tu[t,x,y,z], tu[t,x,y,z] + tv[t,x,y,z])',
           'Eq(tv[t,x,y,z], tu[t,x,y,z+2])',
           'Eq(tw[t,x,y,z], tv[t,x,y,z-1] + 1.)'),
-         '+++-+', ['txyz', 'txyz'], 'txyzz'),
-        # WAR 1->2; WAW 1->3; expected=2
+         '++++++', ['txyz', 'txyz', 'txyz'], 'txyzzz'),
+        # WAR 1->2; WAW 1->3
         (('Eq(tu[t,x,y,z], tu[t,x,y,z] + tv[t,x,y,z])',
           'Eq(tv[t,x,y,z], tu[t,x+2,y,z])',
           'Eq(tu[t,3,y,0], tu[t,3,y,0] + 1.)'),
-         '+-+++', ['txyz', 'ty'], 'txyzy'),
-        # RAW 1->2, WAR 2->3; expected=1
+         '++++++++', ['txyz', 'txyz', 'ty'], 'txyzxyzy'),
+        # RAW 1->2, WAR 2->3
         (('Eq(tu[t,x,y,z], tu[t,x,y,z] + tv[t,x,y,z])',
           'Eq(tv[t,x,y,z], tu[t,x,y,z-2])',
           'Eq(tw[t,x,y,z], tv[t,x,y+1,z] + 1.)'),
-         '++-+', ['txyz'], 'txyz'),
-        # WAR 1->2; WAW 1->3; expected=2
+         '+++++++', ['txyz', 'txyz', 'txyz'], 'txyzzyz'),
+        # WAR 1->2; WAW 1->3
         (('Eq(tu[t-1,x,y,z], tu[t,x,y,z] + tv[t,x,y,z])',
           'Eq(tv[t,x,y,z], tu[t,x,y,z+2])',
           'Eq(tu[t-1,x,y,0], tu[t,x,y,0] + 1.)'),
          '-+++', ['txyz', 'txy'], 'txyz'),
-        # WAR 1->2; expected=1
+        # WAR 1->2
         (('Eq(tu[t-1,x,y,z], tu[t,x,y,z] + tv[t,x,y,z])',
           'Eq(tv[t,x,y,z], tu[t,x,y,z+2] + tu[t,x,y,z-2])',
           'Eq(tw[t,x,y,z], tv[t,x,y,z] + 2)'),
@@ -1234,7 +1277,7 @@ class TestLoopScheduler(object):
           'Eq(tu[t-1,x,y,z], tu[t,x+3,y,z] + tv[t,x,y,z])',
           'Eq(tw[t-1,x,y,z], tu[t,x,y+1,z] + ti0[x,y-1,z])'),
          '+++-+++', ['xyz', 'txyz'], 'xyztxyz'),
-        # War 2->1; expected=2
+        # WAR 2->1
         # Here the difference is that we're using SubDimensions
         (('Eq(tv[t,xi,yi,zi], tu[t,xi-1,yi,zi] + tu[t,xi+1,yi,zi])',
           'Eq(tu[t+1,xi,yi,zi], tu[t,xi,yi,zi] + tv[t,xi-1,yi,zi] + tv[t,xi+1,yi,zi])'),
@@ -1372,8 +1415,8 @@ class TestLoopScheduler(object):
         Test that equations using a mixture of Function and TimeFunction objects
         are embedded within the same time loop.
         """
-        grid = Grid(shape=shape, dimensions=dimensions, time_dimension=time,
-                    dtype=np.float64)
+        grid = Grid(shape=shape, dimensions=dimensions, dtype=np.float64)
+        time = grid.time_dim
         a = TimeFunction(name='a', grid=grid, time_order=2, space_order=2)
         p_aux = Dimension(name='p_aux')
         b = Function(name='b', shape=shape + (10,), dimensions=dimensions + (p_aux,),

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -512,7 +512,7 @@ class TestArguments(object):
         }
         self.verify_arguments(op.arguments(time=4), expected)
         exp_parameters = ['f', 'g', 'x_m', 'x_M', 'y_m', 'y_M', 'z_m', 'z_M',
-                          'x0_blk_size', 'y0_blk_size', 'time_m', 'time_M']
+                          'x0_blk0_size', 'y0_blk0_size', 'time_m', 'time_M']
         self.verify_parameters(op.parameters, exp_parameters)
 
     def test_default_sparse_functions(self):


### PR DESCRIPTION
The following new optimizations are disabled by default -- until I'll have benchmarked them properly

* Autopadding of Function/TimeFunction
* Hierarchical loop blocking
* Loop rounding (see docstrings for explanation of what this is)

Also, ``omp collapse`` is now applied more aggressively than before (based on my experiments, it generally produces faster code)

This PR also ships a jupyter notebook describing ``op.apply``

fixes #520 
