### PR TITLE
Ops/including headers

### DIFF
--- a/devito/ops/node_factory.py
+++ b/devito/ops/node_factory.py
@@ -4,6 +4,7 @@ from devito import Dimension, TimeFunction
 from devito.ops.utils import namespace
 from devito.symbolics import Macro, split_affine
 from devito.types import Indexed, Array
+from devito.types.dimension import SpaceDimension
 
 
 class OPSNodeFactory(object):
@@ -19,16 +20,16 @@ class OPSNodeFactory(object):
 
     def new_ops_arg(self, indexed):
         """
-        Create an :class:`Indexed` node using OPS representation.
+        Create an Indexed node using OPS representation.
 
         Parameters
         ----------
-        indexed : :class:`Indexed`
+        indexed : Indexed
             Indexed object using devito representation.
 
         Returns
         -------
-        :class:`Indexed`
+        Indexed
             Indexed node using OPS representation.
         """
 
@@ -47,8 +48,8 @@ class OPSNodeFactory(object):
             ops_arg = self.ops_args[ops_arg_id]
 
         # Get the space indices
-        space_indices = [e for i, e in enumerate(
-            indexed.indices) if i != TimeFunction._time_position]
+        space_indices = [i for i in indexed.indices if isinstance(
+            split_affine(i).var, SpaceDimension)]
 
         # Define the Macro used in OPS arg index
         access_macro = Macro('OPS_ACC%d(%s)' % (list(self.ops_args).index(ops_arg_id),

--- a/devito/ops/operator.py
+++ b/devito/ops/operator.py
@@ -1,7 +1,6 @@
 from devito.ir.iet import Call, List, find_affine_trees
 from devito.logger import warning
 from devito.operator import Operator
-from devito.types.basic import FunctionPointer
 
 from devito.ops.utils import namespace
 
@@ -23,7 +22,6 @@ class OperatorOPS(Operator):
         warning("The OPS backend is still work-in-progress")
 
         ops_init = Call(namespace['ops_init'], [0, 0, 2])
-        ops_timing = Call(namespace['ops_timing_output'], [FunctionPointer("stdout")])
         ops_exit = Call(namespace['ops_exit'])
 
         dims = []
@@ -35,6 +33,6 @@ class OperatorOPS(Operator):
         self._headers.append(namespace['ops-define-dimension'](dims[0]))
         self._includes.append('stdio.h')
 
-        body = [ops_init, iet, ops_timing, ops_exit]
+        body = [ops_init, iet, ops_exit]
 
         return List(body=body)

--- a/devito/ops/operator.py
+++ b/devito/ops/operator.py
@@ -1,5 +1,9 @@
+from devito.ir.iet import Call, List, find_affine_trees
 from devito.logger import warning
 from devito.operator import Operator
+from devito.types.basic import FunctionPointer
+
+from devito.ops.utils import namespace
 
 __all__ = ['OperatorOPS']
 
@@ -10,8 +14,27 @@ class OperatorOPS(Operator):
     A special Operator generating and executing OPS code.
     """
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+
     def _specialize_iet(self, iet, **kwargs):
 
         warning("The OPS backend is still work-in-progress")
 
-        return iet
+        ops_init = Call(namespace['ops_init'], [0, 0, 2])
+        ops_timing = Call(namespace['ops_timing_output'], [FunctionPointer("stdout")])
+        ops_exit = Call(namespace['ops_exit'])
+
+        dims = []
+        for n, (section, trees) in enumerate(find_affine_trees(iet).items()):
+            dims.append(len(trees[n].dimensions))
+
+        assert (d == dims[0] for d in dims), "The OPS backend currently assumes that all kernels have the same number of dimension"
+
+        self._headers.append(namespace['ops-define-dimension'](dims[0]))
+        self._includes.append('stdio.h')
+
+        body = [ops_init, iet, ops_timing, ops_exit]
+
+        return List(body=body)

--- a/devito/ops/operator.py
+++ b/devito/ops/operator.py
@@ -16,7 +16,6 @@ class OperatorOPS(Operator):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
-
     def _specialize_iet(self, iet, **kwargs):
 
         warning("The OPS backend is still work-in-progress")
@@ -28,7 +27,9 @@ class OperatorOPS(Operator):
         for n, (section, trees) in enumerate(find_affine_trees(iet).items()):
             dims.append(len(trees[n].dimensions))
 
-        assert (d == dims[0] for d in dims), "The OPS backend currently assumes that all kernels have the same number of dimension"
+        assert (d == dims[0] for d in dims), \
+            "The OPS backend currently assumes that all kernels \
+            have the same number of dimensions"
 
         self._headers.append(namespace['ops-define-dimension'](dims[0]))
         self._includes.append('stdio.h')

--- a/devito/ops/transformer.py
+++ b/devito/ops/transformer.py
@@ -5,14 +5,14 @@ def make_ops_ast(expr, nfops):
 
     Parameters
     ----------
-    expr : :class:`Node`
+    expr : Node
         Initial tree node.
-    nfops : :class:`OPSNodeFactory`
+    nfops : OPSNodeFactory
         Generate OPS specific nodes.
 
     Returns
     -------
-    :class:`Node`
+    Node
         Expression alredy translated to OPS syntax.
     """
 

--- a/devito/ops/utils.py
+++ b/devito/ops/utils.py
@@ -6,3 +6,7 @@ namespace = OrderedDict()
 
 # OPS Kernel strings.
 namespace['ops_acc'] = 'OPS_ACC'
+namespace['ops_init'] = 'ops_init'
+namespace['ops_timing_output'] = 'ops_timing_output'
+namespace['ops_exit'] = 'ops_exit'
+namespace['ops-define-dimension'] = lambda i: '#define OPS_%sD' % i


### PR DESCRIPTION
This PR is for updating the ops backend with must-have calls.
The namespace dict in utils.py is updated.

Documentation is updated.

It also changes how `space_indices` are obtained in
`ops/node_factory.py`