### PR TITLE
Allowing calls to be nested

### DIFF
--- a/devito/ir/iet/nodes.py
+++ b/devito/ir/iet/nodes.py
@@ -201,8 +201,9 @@ class Call(Simple, Node):
 
     is_Call = True
 
-    def __init__(self, name, arguments=None):
+    def __init__(self, name, arguments=None, statement=None):
         self.name = name
+        self.statement = statement if statement is not None else True
         self.arguments = as_tuple(arguments)
 
     def __repr__(self):
@@ -227,6 +228,10 @@ class Call(Simple, Node):
     @property
     def defines(self):
         return ()
+
+    @property
+    def children(self):
+        return tuple(i for i in self.arguments if isinstance(i, Call))
 
 
 class Expression(Simple, Node):

--- a/devito/ir/iet/nodes.py
+++ b/devito/ir/iet/nodes.py
@@ -203,7 +203,7 @@ class Call(Simple, Node):
 
     def __init__(self, name, arguments=None, statement=None):
         self.name = name
-        self.statement = statement if statement is not None else True
+        self.statement = statement or True
         self.arguments = as_tuple(arguments)
 
     def __repr__(self):

--- a/devito/ir/iet/nodes.py
+++ b/devito/ir/iet/nodes.py
@@ -201,8 +201,6 @@ class Call(Simple, Node):
 
     is_Call = True
 
-    _traversable = ['arguments']
-
     def __init__(self, name, arguments=None):
         self.name = name
         self.arguments = as_tuple(arguments)
@@ -213,6 +211,10 @@ class Call(Simple, Node):
     @property
     def functions(self):
         return tuple(i for i in self.arguments if isinstance(i, AbstractFunction))
+
+    @property
+    def children(self):
+        return tuple(i for i in self.arguments if isinstance(i, Call))
 
     @cached_property
     def free_symbols(self):

--- a/devito/ir/iet/nodes.py
+++ b/devito/ir/iet/nodes.py
@@ -201,9 +201,10 @@ class Call(Simple, Node):
 
     is_Call = True
 
-    def __init__(self, name, arguments=None, statement=None):
+    _traversable = ['arguments']
+
+    def __init__(self, name, arguments=None):
         self.name = name
-        self.statement = statement or True
         self.arguments = as_tuple(arguments)
 
     def __repr__(self):
@@ -228,10 +229,6 @@ class Call(Simple, Node):
     @property
     def defines(self):
         return ()
-
-    @property
-    def children(self):
-        return tuple(i for i in self.arguments if isinstance(i, Call))
 
 
 class Expression(Simple, Node):

--- a/devito/ir/iet/visitors.py
+++ b/devito/ir/iet/visitors.py
@@ -232,9 +232,7 @@ class CGen(Visitor):
     def visit_Call(self, o):
         arguments = self._args_call(o.arguments)
         code = '%s(%s)' % (o.name, ','.join(arguments))
-        if o.statement:
-            return c.Statement(code)
-        return c.Line(code)
+        return c.Statement(code)
 
     def visit_Conditional(self, o):
         then_body = c.Block(self._visit(o.then_body))

--- a/devito/ir/iet/visitors.py
+++ b/devito/ir/iet/visitors.py
@@ -167,8 +167,7 @@ class CGen(Visitor):
         for i in args:
             try:
                 if isinstance(i, Call):
-                    res = self.visit(i)
-                    ret.append(res.text)
+                    ret.append(self.visit(i).text)
                 elif i.is_LocalObject:
                     ret.append('&%s' % i._C_name)
                 elif i.is_Array:
@@ -532,7 +531,7 @@ class FindSymbols(Visitor):
 
     def visit_Call(self, o):
         symbols = self._visit(o.children)
-        symbols += [f for f in self.rule(o)]
+        symbols.extend([f for f in self.rule(o)])
         return filter_sorted(symbols, key=attrgetter('name'))
 
     visit_ArrayCast = visit_Expression

--- a/devito/ir/iet/visitors.py
+++ b/devito/ir/iet/visitors.py
@@ -166,7 +166,10 @@ class CGen(Visitor):
         ret = []
         for i in args:
             try:
-                if i.is_LocalObject:
+                if isinstance(i, Call):
+                    res = self.visit(i)
+                    ret.append(res.text)
+                elif i.is_LocalObject:
                     ret.append('&%s' % i._C_name)
                 elif i.is_Array:
                     ret.append("(%s)%s" % (i._C_typename, i.name))
@@ -229,7 +232,10 @@ class CGen(Visitor):
 
     def visit_Call(self, o):
         arguments = self._args_call(o.arguments)
-        return c.Statement('%s(%s)' % (o.name, ','.join(arguments)))
+        code = '%s(%s)' % (o.name, ','.join(arguments))
+        if o.statement:
+            return c.Statement(code)
+        return c.Line(code)
 
     def visit_Conditional(self, o):
         then_body = c.Block(self._visit(o.then_body))
@@ -524,8 +530,12 @@ class FindSymbols(Visitor):
     def visit_Expression(self, o):
         return filter_sorted([f for f in self.rule(o)], key=attrgetter('name'))
 
+    def visit_Call(self, o):
+        symbols = self._visit(o.children)
+        symbols += [f for f in self.rule(o)]
+        return filter_sorted(symbols, key=attrgetter('name'))
+
     visit_ArrayCast = visit_Expression
-    visit_Call = visit_Expression
 
 
 class FindNodes(Visitor):

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -800,7 +800,7 @@ class TestNestedCalls(object):
 
     def test_nested_calls_cgen(self):
         call = Call('foo', [
-            Call('bar', [], False)
+            Call('bar', [])
         ])
 
         code = CGen().visit(call)

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -6,13 +6,14 @@ from devito import (Eq, Inc, Grid, Constant, Function, TimeFunction, # noqa
                     Operator, Dimension, SubDimension, switchconfig)
 from devito.ir.equations import DummyEq, LoweredEq
 from devito.ir.equations.algorithms import dimension_sort
-from devito.ir.iet import (Conditional, Expression, Iteration, FindNodes, FindSymbols,
-                           retrieve_iteration_tree, filter_iterations, make_efunc)
+from devito.ir.iet import (Call, Conditional, Expression, Iteration, CGen, FindNodes,
+                           FindSymbols, retrieve_iteration_tree, filter_iterations,
+                           make_efunc)
 from devito.ir.support.basic import (IterationInstance, TimedAccess, Scope,
                                      Vector, AFFINE, IRREGULAR)
 from devito.ir.support.space import (NullInterval, Interval, IntervalGroup, Forward,
                                      Backward, IterationSpace)
-from devito.types import Scalar
+from devito.types import Scalar, Symbol
 from devito.tools import as_tuple
 
 pytestmark = skipif(['yask', 'ops'])
@@ -793,3 +794,32 @@ class TestEquationAlgorithms(object):
         expr = eval(expr)
 
         assert list(dimension_sort(expr)) == eval(expected)
+
+
+class TestNestedCalls(object):
+
+    def test_nested_calls_cgen(self):
+        call = Call('foo', [
+            Call('bar', [], False)
+        ])
+
+        code = CGen().visit(call)
+
+        assert str(code) == 'foo(bar());'
+
+    @pytest.mark.parametrize('mode,expected', [
+        ('free-symbols', '["f", "x"]'),
+        ('symbolics', '["f"]')
+    ])
+    def test_find_symbols_nested(self, mode, expected):
+        grid = Grid(shape=(4, 4, 4))
+        call = Call('foo', [
+            Call('bar', [
+                Symbol(name='x'),
+                Call('baz', [Function(name='f', grid=grid)])
+            ])
+        ])
+
+        found = FindSymbols(mode).visit(call)
+
+        assert [f.name for f in found] == eval(expected)


### PR DESCRIPTION
eg: `foo(bar(baz()))`

This will be used when nesting `ops_arg` calls within `ops_par_loop`