### PR TITLE
Created OPSDeclarator class

### DIFF
--- a/devito/ops/types.py
+++ b/devito/ops/types.py
@@ -109,13 +109,14 @@ class OpsAccess(basic.Basic, sympy.Basic):
 
 class OPSDeclarator(basic.LocalObject):
     """
-    OPS declarator
+    OPS declarator is used for any declarations that need to pass a type defined in OPS.
 
     Parameters
     ----------
     name : str
-        Symbol to access
-    dtype : data-type
+        Variable name that will be created in C code.
+    dtype : str
+        The data type of the raw data.
     """
 
     def __init__(self, name, dtype, *args, **kwargs):

--- a/devito/ops/types.py
+++ b/devito/ops/types.py
@@ -1,3 +1,4 @@
+import numpy as np
 import sympy
 
 import devito.types.basic as basic
@@ -104,3 +105,23 @@ class OpsAccess(basic.Basic, sympy.Basic):
         return sympy.S.Zero, self
 
     __repr__ = __str__
+
+
+class OPSDeclarator(basic.LocalObject):
+    """
+    OPS declarator
+
+    Parameters
+    ----------
+    name : str
+        Symbol to access
+    dtype : data-type
+    """
+
+    def __init__(self, name, dtype, *args, **kwargs):
+        super().__init__(name, np.void, *args, **kwargs)
+        self.dtype = dtype
+
+    @property
+    def _C_typename(self):
+        return self.dtype


### PR DESCRIPTION
This is a generic class for OPS declarations.

Example:
Pass `name` and `type` args.
stencil = OPSDeclarator('stencil_n', 'ops_stencil')
block = OPSDeclarator('block', 'ops_block')
