### PR TITLE
Fixed OPS code gen bug

### DIFF
--- a/devito/ops/types.py
+++ b/devito/ops/types.py
@@ -74,7 +74,7 @@ class OpsAccess(basic.Basic, sympy.Basic):
         super().__init__(*args, **kwargs)
 
     def _hashable_content(self):
-        return (self.base,)
+        return (self.base, ','.join([str(i) for i in self.indices]))
 
     @property
     def function(self):

--- a/example.py
+++ b/example.py
@@ -1,0 +1,6 @@
+from devito import TimeFunction, Grid, Operator, Eq
+
+grid = Grid((4, 4))
+v = TimeFunction(name='v', grid=grid, space_order=2)
+
+op = Operator(Eq(v, v.dxl + v.dxr - v.dyr - v.dyl))

--- a/example.py
+++ b/example.py
@@ -1,6 +1,0 @@
-from devito import TimeFunction, Grid, Operator, Eq
-
-grid = Grid((4, 4))
-v = TimeFunction(name='v', grid=grid, space_order=2)
-
-op = Operator(Eq(v, v.dxl + v.dxr - v.dyr - v.dyl))

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -34,8 +34,8 @@ class TestOPSExpression(object):
          'void OPS_Kernel_0(ACC<float> & vt0, const float *h_x, const float *h_y)\n'
          '{\n  r1 = 1.0/*h_y;\n  r0 = 1.0/*h_x;\n  '
          'vt0(0, 0) = 5.0e-1F*(-vt0(2, 0)*r0 + vt0(-2, 0)*r0 - '
-         'vt0(0, -2)*r1 + vt0(0, 2)*r1) + 2.0F*(-vt0(2, 0)*r0 + '
-         'vt0(-2, 0)*r0 - vt0(0, -2)*r1 + vt0(0, 2)*r1);\n}'),
+         'vt0(0, -2)*r1 + vt0(0, 2)*r1) + 2.0F*(-vt0(-1, 0)*r0 + '
+         'vt0(1, 0)*r0 - vt0(0, 1)*r1 + vt0(0, -1)*r1);\n}'),
         ('Eq(v,v**2 - 3*v)',
          'void OPS_Kernel_0(ACC<float> & vt0)\n'
          '{\n  vt0(0, 0) = -3*vt0(0, 0) + vt0(0, 0)*vt0(0, 0);\n}'),


### PR DESCRIPTION
See #893.

The problem was that `hashable_content` in `OpsAccess` only used `self.base`, meaning that sympy would cache them incorrectly