### PR TITLE
removing :class: from comments

### DIFF
--- a/devito/ir/iet/utils.py
+++ b/devito/ir/iet/utils.py
@@ -12,7 +12,7 @@ __all__ = ['filter_iterations', 'retrieve_iteration_tree',
 
 def retrieve_iteration_tree(node, mode='normal'):
     """
-    A list with all :class:`Iteration` sub-trees within an IET.
+    A list with all Iteration sub-trees within an IET.
 
     Examples
     --------

--- a/devito/ir/iet/visitors.py
+++ b/devito/ir/iet/visitors.py
@@ -503,7 +503,7 @@ class FindSymbols(Visitor):
     ----------
     mode : str, optional
         Drive the search. Accepted:
-        - ``symbolics``: Collect :class:`AbstractSymbol` objects, default.
+        - ``symbolics``: Collect AbstractSymbol objects, default.
         - ``free-symbols``: Collect all free symbols.
         - ``defines``: Collect all defined (bound) objects.
     """
@@ -648,7 +648,7 @@ class FindAdjacent(Visitor):
 class IsPerfectIteration(Visitor):
 
     """
-    Return True if an :class:`Iteration` defines a perfect loop nest, False otherwise.
+    Return True if an Iteration defines a perfect loop nest, False otherwise.
     """
 
     def visit_object(self, o, **kwargs):
@@ -734,7 +734,7 @@ class Transformer(Visitor):
 
 class XSubs(Transformer):
     """
-    :class:`Transformer` that performs substitutions on :class:`Expression`s
+    Transformer that performs substitutions on Expressions
     in a given tree, akin to SymPy's ``subs``.
 
     Parameters

--- a/devito/logger.py
+++ b/devito/logger.py
@@ -84,7 +84,7 @@ def set_log_level(level, comm=None):
     comm : MPI communicator, optional
         An MPI communicator the logger should be collective over. If provided, only
         rank-0 on that communicator will write to the registered handlers, other
-        ranks will use a :class:`logging.NullHandler`.  By default, ``comm`` is set
+        ranks will use a `logging.NullHandler`.  By default, ``comm`` is set
         to ``None``, so all ranks will use the default handlers.  This could be
         used, for example, if one wants to log to one file per rank.
     """

--- a/devito/ops/types.py
+++ b/devito/ops/types.py
@@ -64,7 +64,7 @@ class OpsAccess(basic.Basic, sympy.Basic):
     ----------
     base : OpsAccessible
         Symbol to access
-    indices: [int]
+    indices: list of tuples of int
         Indices to access
     """
 

--- a/devito/profiling.py
+++ b/devito/profiling.py
@@ -34,8 +34,8 @@ class Profiler(object):
     def instrument(self, iet):
         """
         Enrich the Iteration/Expression tree ``iet`` adding nodes for C-level
-        performance profiling. In particular, turn all :class:`Section`s within ``iet``
-        into :class:`TimedList`s.
+        performance profiling. In particular, turn all Sections within ``iet``
+        into TimedLists.
         """
         sections = FindNodes(Section).visit(iet)
         for section in sections:
@@ -76,7 +76,7 @@ class Profiler(object):
 
     def summary(self, arguments, dtype):
         """
-        Return a :class:`PerformanceSummary` of the profiled sections. See
+        Return a PerformanceSummary of the profiled sections. See
         summary under the class AdvancedProfiler below for further details.
         """
         summary = PerformanceSummary()
@@ -100,7 +100,7 @@ class AdvancedProfiler(Profiler):
     # Override basic summary so that arguments other than runtime are computed.
     def summary(self, arguments, dtype):
         """
-        Return a :class:`PerformanceSummary` of the profiled sections.
+        Return a PerformanceSummary of the profiled sections.
 
         Parameters
         ----------
@@ -234,11 +234,11 @@ SectionData = namedtuple('SectionData', 'ops sops points traffic itershapes')
 
 
 PerfEntry = namedtuple('PerfEntry', 'time gflopss gpointss oi ops itershapes')
-"""Runtime profiling data for a :class:`Section`."""
+"""Runtime profiling data for a Section."""
 
 
 def create_profile(name):
-    """Create a new :class:`Profiler`."""
+    """Create a new Profiler."""
     if configuration['log-level'] == 'DEBUG':
         # Enforce performance profiling in DEBUG mode
         level = 'advanced'

--- a/devito/profiling.py
+++ b/devito/profiling.py
@@ -76,8 +76,16 @@ class Profiler(object):
 
     def summary(self, arguments, dtype):
         """
-        Return a PerformanceSummary of the profiled sections. See
-        summary under the class AdvancedProfiler below for further details.
+        Return a PerformanceSummary of the profiled sections.
+
+        Parameters
+        ----------
+        arguments : dict
+            A mapper from argument names to run-time values from which the Profiler
+            infers iteration space and execution times of a run.
+        dtype : data-type, optional
+            The data type of the objects in the profiled sections. Used to compute
+            the operational intensity.
         """
         summary = PerformanceSummary()
         for section, data in self._sections.items():
@@ -99,18 +107,7 @@ class AdvancedProfiler(Profiler):
 
     # Override basic summary so that arguments other than runtime are computed.
     def summary(self, arguments, dtype):
-        """
-        Return a PerformanceSummary of the profiled sections.
 
-        Parameters
-        ----------
-        arguments : dict
-            A mapper from argument names to run-time values from which the Profiler
-            infers iteration space and execution times of a run.
-        dtype : data-type, optional
-            The data type of the objects in the profiled sections. Used to compute
-            the operational intensity.
-        """
         summary = PerformanceSummary()
         for section, data in self._sections.items():
             # Time to run the section

--- a/devito/tools/visitors.py
+++ b/devito/tools/visitors.py
@@ -97,7 +97,7 @@ class GenericVisitor(object):
 
     def visit(self, o, *args, **kwargs):
         """
-        Apply this :class:`Visitor` to an object.
+        Apply this Visitor to an object.
 
         Parameters
         ----------

--- a/devito/yask/data.py
+++ b/devito/yask/data.py
@@ -274,7 +274,7 @@ class Data(object):
     def view(self, *args):
         """
         View of the YASK var in standard (i.e., Devito) row-major layout,
-        returned as a :class:`numpy.ndarray`.
+        returned as a `numpy.ndarray`.
         """
         return self[:]
 

--- a/devito/yask/transformer.py
+++ b/devito/yask/transformer.py
@@ -10,7 +10,7 @@ __all__ = ['yaskit', 'make_yask_ast']
 
 def yaskit(trees, yc_soln):
     """
-    Populate a YASK compiler solution with the :class:`Expression`s found in an IET.
+    Populate a YASK compiler solution with the Expressions found in an IET.
 
     The necessary YASK vars are instantiated.
 

--- a/devito/yask/types.py
+++ b/devito/yask/types.py
@@ -129,13 +129,13 @@ class Function(dense.Function, Signer):
     @property
     def data(self):
         """
-        The domain data values, as a :class:`Data`.
+        The domain data values, as a Data.
 
-        The returned object, which behaves as a :class:`numpy.ndarray`, provides
+        The returned object, which behaves as a `numpy.ndarray`, provides
         a *view* of the actual data, in row-major format. Internally, the data is
         stored in whatever layout adopted by YASK.
 
-        Any read/write from/to the returned :class:`Data` should be performed
+        Any read/write from/to the returned Data should be performed
         assuming a row-major storage layout; behind the scenes, these accesses
         are automatically translated into whatever YASK expects, in order to pick
         the intended values.

--- a/devito/yask/utils.py
+++ b/devito/yask/utils.py
@@ -23,8 +23,7 @@ def make_sharedptr_funcall(call, params, sharedptr):
 def make_var_accesses(node, yk_var_objs):
     """
     Construct a new Iteration/Expression based on ``node``, in which all
-    :class:`types.Indexed` accesses have been converted into YASK var
-    accesses.
+    Indexed accesses have been converted into YASK var accesses.
     """
 
     def make_var_gets(expr):

--- a/tests/test_dimension.py
+++ b/tests/test_dimension.py
@@ -111,7 +111,7 @@ class TestSubDimension(object):
         """
         Tests application of an Operator consisting of multiple equations
         defined over different sub-regions, explicitly created through the
-        use of :class:`SubDimension`s.
+        use of SubDimensions.
         """
         grid = Grid(shape=(20, 20))
         x, y = grid.dimensions
@@ -147,7 +147,7 @@ class TestSubDimension(object):
     @skipif('yask')
     def test_flow_detection_interior(self):
         """
-        Test detection of flow directions when :class:`SubDimension`s are used
+        Test detection of flow directions when SubDimensions are used
         (in this test they are induced by the ``interior`` subdomain).
 
         Stencil uses values at new timestep as well as those at previous ones
@@ -257,7 +257,7 @@ class TestSubDimension(object):
         """
         Tests application of an Operator consisting of a subdimension
         defined over different sub-regions, explicitly created through the
-        use of :class:`SubDimension`s.
+        use of SubDimensions.
         """
         grid = Grid(shape=(20, 20))
         x, y = grid.dimensions
@@ -297,7 +297,7 @@ class TestSubDimension(object):
         """
         Tests application of an Operator consisting of a subdimension
         defined over different sub-regions, explicitly created through the
-        use of :class:`SubDimension`s.
+        use of SubDimensions.
 
         This tests that flow direction is not being automatically inferred
         from whether the subdimension is on the left or right boundary.
@@ -333,7 +333,7 @@ class TestSubDimension(object):
         """
         Tests application of an Operator consisting of a subdimension
         defined over different sub-regions, explicitly created through the
-        use of :class:`SubDimension`s.
+        use of SubDimensions.
 
         Different from ``test_subdimmiddle_parallel`` because an interior
         dimension cannot be evaluated in parallel.
@@ -374,7 +374,7 @@ class TestSubDimension(object):
         """
         Tests application of an Operator consisting of a subdimension
         defined over different sub-regions, explicitly created through the
-        use of :class:`SubDimension`s.
+        use of SubDimensions.
 
         This tests that flow direction is not being automatically inferred
         from whether the subdimension is on the left or right boundary.
@@ -456,7 +456,7 @@ class TestSubDimension(object):
 class TestConditionalDimension(object):
 
     """A collection of tests to check the correct functioning of
-    :class:`ConditionalDimension`s."""
+    ConditionalDimensions."""
 
     def test_basic(self):
         nt = 19

--- a/tests/test_ir.py
+++ b/tests/test_ir.py
@@ -802,7 +802,7 @@ class TestEquationAlgorithms(object):
     ])
     def test_dimension_sort(self, expr, expected):
         """
-        Tests that ``dimension_sort()`` provides meaningful :class:`Dimension` orderings.
+        Tests that ``dimension_sort()`` provides meaningful Dimension orderings.
         """
         grid = Grid(shape=(10, 10))
         p = Dimension('p')

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -223,7 +223,7 @@ class TestArithmetic(object):
         assert np.allclose(fa.data[1, 1:-1, 1:-1], result[1:-1, 1:-1], rtol=1e-12)
 
     def test_indexed_w_indirections(self):
-        """Test point-wise arithmetic with indirectly indexed :class:`Function`s."""
+        """Test point-wise arithmetic with indirectly indexed Functions."""
         grid = Grid(shape=(10, 10))
         x, y = grid.dimensions
 
@@ -532,7 +532,7 @@ class TestArguments(object):
 
     def test_override_function_size(self):
         """
-        Test runtime size overrides for :class:`Function` dimensions.
+        Test runtime size overrides for Function dimensions.
 
         Note: The current behaviour for size-only arguments seems
         ambiguous (eg. op(x=3, y=4), as it sets `dim_size` as well as
@@ -541,7 +541,7 @@ class TestArguments(object):
         provided data. This should error out, or potentially we could
         set the corresponding size, while aliasing `dim` to `dim_e`?
 
-        The same should be tested for :class:`TimeFunction` once fixed.
+        The same should be tested for TimeFunction once fixed.
         """
         grid = Grid(shape=(5, 6, 7))
         g = Function(name='g', grid=grid)
@@ -565,7 +565,7 @@ class TestArguments(object):
 
     def test_override_function_subrange(self):
         """
-        Test runtime start/end override for :class:`Function` dimensions.
+        Test runtime start/end override for Function dimensions.
         """
         grid = Grid(shape=(5, 6, 7))
         g = Function(name='g', grid=grid)
@@ -589,7 +589,7 @@ class TestArguments(object):
 
     def test_override_timefunction_subrange(self):
         """
-        Test runtime start/end overrides for :class:`TimeFunction` dimensions.
+        Test runtime start/end overrides for TimeFunction dimensions.
         """
         grid = Grid(shape=(5, 6, 7))
         f = TimeFunction(name='f', grid=grid, time_order=0)
@@ -620,7 +620,7 @@ class TestArguments(object):
 
     def test_override_function_data(self):
         """
-        Test runtime data overrides for :class:`Function` symbols.
+        Test runtime data overrides for Function symbols.
         """
         grid = Grid(shape=(5, 6, 7))
         a = Function(name='a', grid=grid)
@@ -651,7 +651,7 @@ class TestArguments(object):
 
     def test_override_timefunction_data(self):
         """
-        Test runtime data overrides for :class:`TimeFunction` symbols.
+        Test runtime data overrides for TimeFunction symbols.
         """
         grid = Grid(shape=(5, 6, 7))
         a = TimeFunction(name='a', grid=grid, save=2)
@@ -815,7 +815,7 @@ class TestArguments(object):
         assert(op_arguments[time.max_name] == nt - 2)
 
     def test_derive_constant_value(self):
-        """Ensure that values for :class:`Constant` symbols are derived correctly."""
+        """Ensure that values for Constant symbols are derived correctly."""
         grid = Grid(shape=(5, 6))
         f = Function(name='f', grid=grid)
         a = Constant(name='a', value=3.)

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -58,7 +58,7 @@ class TestOPSExpression(object):
         Parameters
         ----------
         equation : str
-            A string with a :class:`Eq`to be evaluated.
+            A string with a Eq to be evaluated.
         expected : str
             Expected expression to be generated from devito.
         """

--- a/tests/test_yask.py
+++ b/tests/test_yask.py
@@ -272,7 +272,7 @@ class TestOperatorSimple(object):
 
     def test_constants(self):
         """
-        Check that :class:`Constant` objects are treated correctly.
+        Check that Constant objects are treated correctly.
         """
         grid = Grid(shape=(4, 4, 4))
         c = Constant(name='c', value=2., dtype=grid.dtype)
@@ -296,7 +296,7 @@ class TestOperatorSimple(object):
 
     def test_partial_offloading(self):
         """
-        Check that :class:`Function` objects not using any :class:`SpaceDimension`
+        Check that Function objects not using any SpaceDimension
         are computed in Devito-land, rather than via YASK.
         """
         shape = (4, 4, 4)
@@ -366,8 +366,7 @@ class TestOperatorAdvanced(object):
 
     def test_misc_dims(self):
         """
-        Tests grid-independent :class:`Function`s, which require YASK's "misc"
-        dimensions.
+        Tests grid-independent Functions, which require YASK's "misc" dimensions.
         """
         dx = Dimension(name='dx')
         grid = Grid(shape=(10, 10))


### PR DESCRIPTION
This PR is for removing obsolete `:class:` from commentaries. 