### PR TITLE
 topology fix

### DIFF
--- a/devito/dse/manipulation.py
+++ b/devito/dse/manipulation.py
@@ -192,7 +192,11 @@ def topological_sort(exprs):
                 # Eq(f, f + 1)
                 continue
             elif r.is_Indexed and r not in mapper.keys():
-                # Only scalars enforce an ordering
+                # Only scalars or indexed that not lhs of equations
+                continue
+            elif not e.lhs.is_Indexed:
+                # Skip dependency if lhs is a temporary that automatically caries
+                # dependency
                 continue
             else:
                 dag.add_edge(mapper[r], e, force_add=True)

--- a/devito/dse/manipulation.py
+++ b/devito/dse/manipulation.py
@@ -191,7 +191,7 @@ def topological_sort(exprs):
                 # Avoid cyclic dependences, such as
                 # Eq(f, f + 1)
                 continue
-            elif r.is_Indexed:
+            elif r.is_Indexed and r not in mapper.keys():
                 # Only scalars enforce an ordering
                 continue
             else:

--- a/devito/dse/manipulation.py
+++ b/devito/dse/manipulation.py
@@ -194,7 +194,7 @@ def topological_sort(exprs):
             elif r.is_Indexed and r not in mapper.keys():
                 # Only scalars or indexed that not lhs of equations
                 continue
-            elif not e.lhs.is_Indexed:
+            elif r.is_Indexed and not e.lhs.is_Indexed:
                 # Skip dependency if lhs is a temporary that automatically caries
                 # dependency
                 continue

--- a/devito/dse/manipulation.py
+++ b/devito/dse/manipulation.py
@@ -5,7 +5,7 @@ from sympy import Add, Mul, collect, collect_const
 from devito.dse.flowgraph import FlowGraph
 from devito.symbolics import (Eq, count, estimate_cost, q_xop, q_leaf,
                               retrieve_terminals, xreplace_constrained)
-from devito.tools import DAG, ReducerMap
+from devito.tools import DAG, ReducerMap, split
 
 __all__ = ['collect_nested', 'common_subexprs_elimination', 'compact_temporaries']
 
@@ -182,10 +182,10 @@ def topological_sort(exprs):
     mapper = {e.lhs: e for e in exprs}
     assert len(mapper) == len(exprs)  # Expect SSA
 
-    # Only sort temporaries
-    r_exprs = [e for e in exprs if not e.lhs.is_Indexed]
-    dag = DAG(nodes=r_exprs)
-    for e in r_exprs:
+    # Build DAG and topologically-sort temporaries
+    temporaries, tensors = split(exprs, lambda e: not e.lhs.is_Indexed)
+    dag = DAG(nodes=temporaries)
+    for e in temporaries:
         for r in retrieve_terminals(e.rhs):
             if r not in mapper:
                 continue
@@ -198,9 +198,9 @@ def topological_sort(exprs):
                 continue
             else:
                 dag.add_edge(mapper[r], e, force_add=True)
-
     processed = dag.topological_sort()
-    # Append indexed eqaution at the  end in the user-provided order
-    processed.extend(e for e in exprs if e not in r_exprs)
+
+    # Append tensor equations at the end in user-provided order
+    processed.extend(tensors)
 
     return processed

--- a/tests/test_dse.py
+++ b/tests/test_dse.py
@@ -76,7 +76,7 @@ def test_xreplace_constrained_time_invariants(tu, tv, tw, ti0, ti1, t0, t1,
       'r0*(t0 + t1) + r0*(tv[t, x, y, z] + tw[t, x, y, z] + 5.0)']),
     # across expressions
     (['Eq(tu, tv*4 + tw*5 + tw*5*t0)', 'Eq(tv, tw*5)'],
-     ['5*tw[t, x, y, z]', 'r0', 'r0 + 5*t0*tw[t, x, y, z] + 4*tv[t, x, y, z]']),
+     ['5*tw[t, x, y, z]', 'r0 + 5*t0*tw[t, x, y, z] + 4*tv[t, x, y, z]', 'r0']),
     # intersecting
     pytest.param(['Eq(tu, ti0*ti1 + ti0*ti1*t0 + ti0*ti1*t0*t1)'],
                  ['ti0*ti1', 'r0', 'r0*t0', 'r0*t0*t1'],
@@ -90,7 +90,6 @@ def test_common_subexprs_elimination(tu, tv, tw, ti0, ti1, t0, t1, exprs, expect
     make = lambda: Scalar(name='r%d' % counter()).indexify()
     processed = common_subexprs_elimination(EVAL(exprs, tu, tv, tw, ti0, ti1, t0, t1),
                                             make)
-
     assert len(processed) == len(expected)
     assert all(str(i.rhs) == j for i, j in zip(processed, expected))
 

--- a/tests/test_dse.py
+++ b/tests/test_dse.py
@@ -76,7 +76,7 @@ def test_xreplace_constrained_time_invariants(tu, tv, tw, ti0, ti1, t0, t1,
       'r0*(t0 + t1) + r0*(tv[t, x, y, z] + tw[t, x, y, z] + 5.0)']),
     # across expressions
     (['Eq(tu, tv*4 + tw*5 + tw*5*t0)', 'Eq(tv, tw*5)'],
-     ['5*tw[t, x, y, z]', 'r0 + 5*t0*tw[t, x, y, z] + 4*tv[t, x, y, z]', 'r0']),
+     ['5*tw[t, x, y, z]', 'r0', 'r0 + 5*t0*tw[t, x, y, z] + 4*tv[t, x, y, z]']),
     # intersecting
     pytest.param(['Eq(tu, ti0*ti1 + ti0*ti1*t0 + ti0*ti1*t0*t1)'],
                  ['ti0*ti1', 'r0', 'r0*t0', 'r0*t0*t1'],
@@ -90,6 +90,7 @@ def test_common_subexprs_elimination(tu, tv, tw, ti0, ti1, t0, t1, exprs, expect
     make = lambda: Scalar(name='r%d' % counter()).indexify()
     processed = common_subexprs_elimination(EVAL(exprs, tu, tv, tw, ti0, ti1, t0, t1),
                                             make)
+
     assert len(processed) == len(expected)
     assert all(str(i.rhs) == j for i, j in zip(processed, expected))
 


### PR DESCRIPTION
Tiny fix to DAG setup.

Mainly, the `Indexed` have to be added to depency list if the yare lhs of one of the eq of the cluster of equations. Currently was assuming all indexed in rhs are not lhs.

Now 

```
from devito import *
from devito.types import *

from sympy import pprint
grid = Grid((10, 10, 10))
t = TimeFunction(name="t", grid=grid, space_order=4)
r = TimeFunction(name="r", grid=grid, space_order=4)

eq_t = Eq(t.forward, r.forward)
eq_r = Eq(r.forward, 2*r)

op = Operator([eq_t, eq_r])
```

produces

```
            #pragma ivdep
            #pragma omp simd aligned(r,t:32)
            for (int z = z_m; z <= z_M; z += 1)
            {
              r[t1][x + 4][y + 4][z + 4] = 2*r[t0][x + 4][y + 4][z + 4] + 2;
              t[t1][x + 4][y + 4][z + 4] = r[t1][x + 4][y + 4][z + 4] + t[t0][x + 4][y + 4][z + 4];
            }
```

that has the correct dependency