### PR TITLE
 index_dist_to_repl fix

### DIFF
--- a/devito/data/utils.py
+++ b/devito/data/utils.py
@@ -65,6 +65,9 @@ def index_dist_to_repl(idx, decomposition):
     elif not is_integer(value):
         raise ValueError("Cannot derive shift value from type `%s`" % type(value))
 
+    if value < 0:
+        value += decomposition.glb_max + 1
+
     # Convert into absolute local index
     idx = decomposition.index_glb_to_loc(idx, rel=False)
 

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -75,6 +75,16 @@ class TestDataBasic(object):
         assert (np.array(u.data[0, 3::-1, 0, 0]) == dat[3::-1]).all()
         assert (np.array(u.data[0, 5:1:-1, 0, 0]) == dat[5:1:-1]).all()
 
+    @skipif('yask')
+    def test_negative_start(self):
+        """Test slicing with a negative start."""
+        grid = Grid(shape=(13,))
+        f = Function(name='f', grid=grid)
+        idx = slice(-4, None, 1)
+        dat = np.array([1, 2, 3, 4])
+        f.data[idx] = dat
+        assert np.all(np.array(f.data[9:]) == dat)
+
     def test_halo_indexing(self):
         """Test data packing/unpacking in presence of a halo region."""
         domain_shape = (16, 16, 16)


### PR DESCRIPTION
This PR fixes a problem for data slicing when `slice.start` is negative.