### PR TITLE
Revamp profiling and support for MPI timing

### DIFF
--- a/benchmarks/user/benchmark.py
+++ b/benchmarks/user/benchmark.py
@@ -431,9 +431,9 @@ def get_ob_exec(func):
             gflopss, oi, timings, _ = self.func(*args, **kwargs)
 
             for key in timings.keys():
-                self.register(gflopss[key], measure="gflopss", event=key)
-                self.register(oi[key], measure="oi", event=key)
-                self.register(timings[key], measure="timings", event=key)
+                self.register(gflopss[key], measure="gflopss", event=key.name)
+                self.register(oi[key], measure="oi", event=key.name)
+                self.register(timings[key], measure="timings", event=key.name)
 
     return DevitoExecutor(func)
 

--- a/benchmarks/user/make-pbs.py
+++ b/benchmarks/user/make-pbs.py
@@ -38,6 +38,8 @@ def generate(**kwargs):
 #PBS -lselect=%(nn)s:ncpus=%(ncpus)s:mem=120gb:mpiprocs=%(np)s:ompthreads=%(nt)s:cpumodel=%(ncpus)s
 #PBS -lwalltime=02:00:00
 
+lscpu
+
 %(load)s
 
 cd %(home)s

--- a/benchmarks/user/make-pbs.py
+++ b/benchmarks/user/make-pbs.py
@@ -35,7 +35,7 @@ def generate(**kwargs):
     template = """\
 #!/bin/bash
 
-#PBS -lselect=%(nn)s:ncpus=%(ncpus)s:mem=120gb:mpiprocs=%(np)s:ompthreads=%(nt)s:cpumodel=%(ncpus)s
+#PBS -lselect=%(nn)s:ncpus=%(ncpus)s:mem=120gb:mpiprocs=%(np)s:ompthreads=%(nt)s
 #PBS -lwalltime=02:00:00
 
 lscpu

--- a/devito/ir/clusters/cluster.py
+++ b/devito/ir/clusters/cluster.py
@@ -76,10 +76,6 @@ class Cluster(object):
         return self.ispace.itintervals
 
     @property
-    def shape(self):
-        return self.ispace.shape
-
-    @property
     def dspace(self):
         return self._dspace
 

--- a/devito/ir/iet/nodes.py
+++ b/devito/ir/iet/nodes.py
@@ -777,9 +777,9 @@ class ExpressionBundle(List):
 
     is_ExpressionBundle = True
 
-    def __init__(self, shape, ops, traffic, body=None):
+    def __init__(self, ispace, ops, traffic, body=None):
         super(ExpressionBundle, self).__init__(body=body)
-        self.shape = shape
+        self.ispace = ispace
         self.ops = ops
         self.traffic = traffic
 
@@ -789,6 +789,10 @@ class ExpressionBundle(List):
     @property
     def exprs(self):
         return self.body
+
+    @property
+    def shape(self):
+        return tuple(self.ispace.dimension_map.values())
 
 
 class Prodder(Call):

--- a/devito/ir/iet/scheduler.py
+++ b/devito/ir/iet/scheduler.py
@@ -43,7 +43,7 @@ def iet_make(stree):
 
         elif i.is_Exprs:
             exprs = [Increment(e) if e.is_Increment else Expression(e) for e in i.exprs]
-            body = ExpressionBundle(i.shape, i.ops, i.traffic, body=exprs)
+            body = ExpressionBundle(i.ispace, i.ops, i.traffic, body=exprs)
 
         elif i.is_Conditional:
             body = Conditional(i.guard, queues.pop(i))

--- a/devito/ir/stree/algorithms.py
+++ b/devito/ir/stree/algorithms.py
@@ -63,7 +63,7 @@ def st_schedule(clusters):
             mapper[i] = root
 
         # Add in Expressions
-        NodeExprs(c.exprs, c.ispace, c.dspace, c.shape, c.ops, c.traffic, root)
+        NodeExprs(c.exprs, c.ispace, c.dspace, c.ops, c.traffic, root)
 
         # Add in Conditionals
         for k, v in mapper.items():

--- a/devito/ir/stree/tree.py
+++ b/devito/ir/stree/tree.py
@@ -90,12 +90,11 @@ class NodeExprs(ScheduleTree):
 
     is_Exprs = True
 
-    def __init__(self, exprs, ispace, dspace, shape, ops, traffic, parent=None):
+    def __init__(self, exprs, ispace, dspace, ops, traffic, parent=None):
         super(NodeExprs, self).__init__(parent)
         self.exprs = exprs
         self.ispace = ispace
         self.dspace = dspace
-        self.shape = shape
         self.ops = ops
         self.traffic = traffic
 

--- a/devito/ir/support/space.py
+++ b/devito/ir/support/space.py
@@ -226,8 +226,9 @@ class IntervalGroup(PartialOrderTuple):
         return reduce(mul, [i.size for i in self]) if self else 0
 
     @property
-    def shape(self):
-        return tuple(i.size for i in self)
+    def dimension_map(self):
+        """Map between Dimensions and their symbolic size."""
+        return OrderedDict([(i.dim, i.size) for i in self])
 
     @cached_property
     def is_well_defined(self):
@@ -432,8 +433,8 @@ class Space(object):
         return self.intervals.size
 
     @property
-    def shape(self):
-        return self.intervals.shape
+    def dimension_map(self):
+        return self.intervals.dimension_map
 
 
 class DataSpace(Space):

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -524,8 +524,9 @@ class Operator(Callable):
         # Invoke kernel function with args
         arg_values = [args[p.name] for p in self.parameters]
         try:
+            cfunction = self.cfunction
             with self._profiler.timer_on('apply', comm=args.comm):
-                self.cfunction(*arg_values)
+                cfunction(*arg_values)
         except ctypes.ArgumentError as e:
             if e.args[0].startswith("argument "):
                 argnum = int(e.args[0][9:].split(':')[0]) - 1

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -16,6 +16,7 @@ from devito.ir.clusters import clusterize
 from devito.ir.iet import (Callable, MetaCall, iet_build, iet_insert_decls,
                            iet_insert_casts, derive_parameters)
 from devito.ir.stree import st_build
+from devito.mpi import MPI
 from devito.parameters import configuration
 from devito.profiling import create_profile
 from devito.symbolics import indexify
@@ -684,7 +685,7 @@ class ArgumentsMap(dict):
     @property
     def comm(self):
         """The MPI communicator the arguments are collective over."""
-        return self.grid.comm if self.grid is not None else None
+        return self.grid.comm if self.grid is not None else MPI.COMM_NULL
 
 
 def set_dse_mode(mode):

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -338,7 +338,7 @@ class Operator(Callable):
         args = args.reduce_all()
 
         # All DiscreteFunctions should be defined on the same Grid
-        grids = {getattr(p, 'grid', None) for p in self.input} - {None}
+        grids = {getattr(p, 'grid', None) for p in overrides + defaults} - {None}
         if len(grids) > 1 and configuration['mpi']:
             raise ValueError("Multiple Grids found")
         try:

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -522,7 +522,7 @@ class Operator(Callable):
         # Invoke kernel function with args
         arg_values = [args[p.name] for p in self.parameters]
         try:
-            with self._profiler.timer_on('apply', comm=args.grid.comm):
+            with self._profiler.timer_on('apply', comm=args.comm):
                 self.cfunction(*arg_values)
         except ctypes.ArgumentError as e:
             if e.args[0].startswith("argument "):
@@ -654,6 +654,11 @@ class ArgumentsMap(dict):
     def __init__(self, grid, *args, **kwargs):
         super(ArgumentsMap, self).__init__(*args, **kwargs)
         self.grid = grid
+
+    @property
+    def comm(self):
+        """The MPI communicator the arguments are collective over."""
+        return self.grid.comm if self.grid is not None else None
 
 
 def set_dse_mode(mode):

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -391,6 +391,9 @@ class Operator(Callable):
                 if k not in self._known_arguments:
                     raise ValueError("Unrecognized argument %s=%s" % (k, v))
 
+        # Attach `grid` to the arguments map
+        args = ArgumentsMap(grid, **args)
+
         return args
 
     def _postprocess_arguments(self, args, **kwargs):
@@ -638,6 +641,13 @@ class Operator(Callable):
 
 
 # Misc helpers
+
+
+class ArgumentsMap(dict):
+
+    def __init__(self, grid, *args, **kwargs):
+        super(ArgumentsMap, self).__init__(*args, **kwargs)
+        self.grid = grid
 
 
 def set_dse_mode(mode):

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -562,8 +562,7 @@ class Operator(Callable):
                 name = k
                 perf("* %s computed in %.2f s" % (name, v.time))
 
-        perf("`%s` configuration:  %s " %
-             (self.name, self._state['optimizations']))
+        perf("Configuration:  %s" % self._state['optimizations'])
 
         return summary
 

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -194,6 +194,9 @@ class Operator(Callable):
 
     # Read-only fields exposed to the outside world
 
+    def __call__(self, **kwargs):
+        self.apply(**kwargs)
+
     @cached_property
     def output(self):
         return tuple(self._output)
@@ -211,11 +214,11 @@ class Operator(Callable):
     def objects(self):
         return tuple(i for i in self.parameters if i.is_Object)
 
+    # Compilation
+
     def _initialize_state(self, **kwargs):
         return {'optimizations': {k: kwargs.get(k, configuration[k])
                                   for k in ('dse', 'dle')}}
-
-    # Compilation
 
     def _add_implicit(self, expressions):
         """
@@ -555,6 +558,8 @@ class Operator(Callable):
 
         return summary
 
+    # Misc properties
+
     @cached_property
     def _mem_summary(self):
         """
@@ -582,9 +587,6 @@ class Operator(Callable):
         summary['total'] = external + heap + stack
 
         return summary
-
-    def __call__(self, **kwargs):
-        self.apply(**kwargs)
 
     # Pickling support
 

--- a/devito/profiling.py
+++ b/devito/profiling.py
@@ -191,16 +191,10 @@ class AdvancedProfiler(Profiler):
                 traffics = comm.allgather(traffic)
                 sops = [data.sops]*comm.size
                 itershapess = comm.allgather(itershapes)
-                # Do not show unexecuted Sections (i.e., loop trip count was 0)
-                if all(i == 0 for i in opss) or all(i == 0 for i in traffics):
-                    continue
                 items = list(zip(times, opss, pointss, traffics, sops, itershapess))
                 for rank in range(comm.size):
                     summary.add(name, rank, *items[rank])
             else:
-                # Do not show unexecuted Sections (i.e., loop trip count was 0)
-                if ops == 0 or traffic == 0:
-                    continue
                 summary.add(name, None, time, ops, points, traffic, data.sops, itershapes)
 
         if mpi_enabled and reduce_over is not None:
@@ -287,6 +281,10 @@ class PerformanceSummary(OrderedDict):
         Add performance data for a given code section. With MPI enabled, the
         performance data is local, that is "per-rank".
         """
+        # Do not show unexecuted Sections (i.e., loop trip count was 0)
+        if ops == 0 or traffic == 0:
+            return
+
         k = self.PerfKey(name, rank)
 
         if ops is None:

--- a/devito/profiling.py
+++ b/devito/profiling.py
@@ -28,6 +28,9 @@ class Profiler(object):
     _default_libs = []
     _ext_calls = []
 
+    SectionData = namedtuple('SectionData', 'ops sops points traffic itermaps')
+    """Metadata for a profiled code section."""
+
     def __init__(self, name):
         self.name = name
 
@@ -64,7 +67,7 @@ class Profiler(object):
             traffic = sum(i.size for i in traffic)
 
             # Each ExpressionBundle lives in its own iteration space
-            itershapes = [i.shape for i in bundles]
+            itermaps = [i.ispace.dimension_map for i in bundles]
 
             # Track how many grid points are written within `section`
             points = []
@@ -74,7 +77,8 @@ class Profiler(object):
                 points.append(reduce(mul, i.shape)*len(writes))
             points = sum(points)
 
-            self._sections[section] = SectionData(ops, sops, points, traffic, itershapes)
+            self._sections[section] = self.SectionData(ops, sops, points,
+                                                       traffic, itermaps)
 
         # Transform the Iteration/Expression tree introducing the C-level timers
         mapper = {i: TimedList(timer=self.timer, lname=i.name, body=i) for i in sections}
@@ -107,7 +111,7 @@ class Profiler(object):
             toc = seq_time()
         self.py_timers[name] = toc - tic
 
-    def summary(self, arguments, dtype):
+    def summary(self, arguments, dtype, reduce_over=None):
         """
         Return a PerformanceSummary of the profiled sections.
 
@@ -116,18 +120,30 @@ class Profiler(object):
         arguments : dict
             A mapper from argument names to run-time values from which the Profiler
             infers iteration space and execution times of a run.
-        dtype : data-type, optional
+        dtype : data-type
             The data type of the objects in the profiled sections. Used to compute
             the operational intensity.
         """
+        comm = arguments.comm
+
+        mpi_enabled = MPI.Is_initialized() and comm is not None
+
         summary = PerformanceSummary()
         for section, data in self._sections.items():
-            # Time to run the section
-            time = max(getattr(arguments[self.name]._obj, section.name), 10e-7)
+            name = section.name
 
-            # In basic mode only return runtime. Other arguments are filled with
-            # dummy values.
-            summary.add(section.name, time, float(), float(), float(), int(), [])
+            # Time to run the section
+            time = max(getattr(arguments[self.name]._obj, name), 10e-7)
+
+            # Add performance data
+            if mpi_enabled:
+                # With MPI enabled, we add one entry per section per rank
+                times = comm.allgather(time)
+                assert comm.size == len(times)
+                for rank in range(comm.size):
+                    summary.add(name, rank, times[rank])
+            else:
+                summary.add(name, None, time)
 
         return summary
 
@@ -139,11 +155,17 @@ class Profiler(object):
 class AdvancedProfiler(Profiler):
 
     # Override basic summary so that arguments other than runtime are computed.
-    def summary(self, arguments, dtype):
+    def summary(self, arguments, dtype, reduce_over=None):
+        comm = arguments.comm
+
+        mpi_enabled = MPI.Is_initialized() and comm is not None
+
         summary = PerformanceSummary()
         for section, data in self._sections.items():
+            name = section.name
+
             # Time to run the section
-            time = max(getattr(arguments[self.name]._obj, section.name), 10e-7)
+            time = max(getattr(arguments[self.name]._obj, name), 10e-7)
 
             # Number of FLOPs performed
             ops = data.ops.subs(arguments)
@@ -154,23 +176,35 @@ class AdvancedProfiler(Profiler):
             # Compulsory traffic
             traffic = float(data.traffic.subs(arguments)*dtype().itemsize)
 
-            # Runtime itershapes
-            itershapes = [tuple(i.subs(arguments) for i in j) for j in data.itershapes]
+            # Runtime itermaps/itershapes
+            itermaps = [OrderedDict([(k, v.subs(arguments)) for k, v in i.items()])
+                        for i in data.itermaps]
+            itershapes = tuple(tuple(i.values()) for i in itermaps)
 
-            # Do not show unexecuted Sections (i.e., because the loop trip count was 0)
-            if ops == 0 or traffic == 0:
-                continue
+            # Add performance data
+            if mpi_enabled:
+                # With MPI enabled, we add one entry per section per rank
+                times = comm.allgather(time)
+                assert comm.size == len(times)
+                opss = comm.allgather(ops)
+                pointss = comm.allgather(points)
+                traffics = comm.allgather(traffic)
+                sops = [data.sops]*comm.size
+                itershapess = comm.allgather(itershapes)
+                # Do not show unexecuted Sections (i.e., loop trip count was 0)
+                if all(i == 0 for i in opss) or all(i == 0 for i in traffics):
+                    continue
+                items = list(zip(times, opss, pointss, traffics, sops, itershapess))
+                for rank in range(comm.size):
+                    summary.add(name, rank, *items[rank])
+            else:
+                # Do not show unexecuted Sections (i.e., loop trip count was 0)
+                if ops == 0 or traffic == 0:
+                    continue
+                summary.add(name, None, time, ops, points, traffic, data.sops, itershapes)
 
-            # Derived metrics
-            # Note: some casts to `float` are simply to turn `sympy.Float` into `float`
-            gflops = float(ops)/10**9
-            gpoints = float(points)/10**9
-            gflopss = gflops/time
-            gpointss = gpoints/time
-            oi = float(ops/traffic)
-
-            # Keep track of performance achieved
-            summary.add(section.name, time, gflopss, gpointss, oi, data.sops, itershapes)
+        if mpi_enabled and reduce_over is not None:
+            summary.reduce(self.py_timers[reduce_over])
 
         return summary
 
@@ -238,12 +272,59 @@ class Timer(CompositeObject):
 
 class PerformanceSummary(OrderedDict):
 
-    """
-    A special dictionary to track and quickly access performance data.
-    """
+    PerfKey = namedtuple('PerfKey', 'name rank')
+    PerfInput = namedtuple('PerfInput', 'time ops points traffic sops itershapes')
+    PerfEntry = namedtuple('PerfEntry', 'time gflopss gpointss oi ops itershapes')
 
-    def add(self, key, time, gflopss, gpointss, oi, ops, itershapes):
-        self[key] = PerfEntry(time, gflopss, gpointss, oi, ops, itershapes)
+    def __init__(self, *args, **kwargs):
+        super(PerformanceSummary, self).__init__(*args, **kwargs)
+        self.input = OrderedDict()
+        self.reduced = None
+
+    def add(self, name, rank, time,
+            ops=None, points=None, traffic=None, sops=None, itershapes=None):
+        """
+        Add performance data for a given code section. With MPI enabled, the
+        performance data is local, that is "per-rank".
+        """
+        k = self.PerfKey(name, rank)
+
+        if ops is None:
+            self[k] = self.PerfEntry(time, 0.0, 0.0, 0.0, 0, [])
+        else:
+            gflops = float(ops)/10**9
+            gpoints = float(points)/10**9
+            gflopss = gflops/time
+            gpointss = gpoints/time
+            oi = float(ops/traffic)
+            self[k] = self.PerfEntry(time, gflopss, gpointss, oi, sops, itershapes)
+
+        self.input[k] = self.PerfInput(time, ops, points, traffic, sops, itershapes)
+
+    def reduce(self, time):
+        """
+        Reduce the following performance data:
+
+            * ops
+            * points
+            * traffic
+
+        over a global "wrapping" timer.
+        """
+        if not self.input:
+            return
+
+        ops = sum(v.ops for v in self.input.values())
+        points = sum(v.points for v in self.input.values())
+        traffic = sum(v.traffic for v in self.input.values())
+
+        gflops = float(ops)/10**9
+        gpoints = float(points)/10**9
+        gflopss = gflops/time
+        gpointss = gpoints/time
+        oi = float(ops/traffic)
+
+        self.reduced = self.PerfEntry(time, gflopss, gpointss, oi, None, None)
 
     @property
     def gflopss(self):
@@ -256,14 +337,6 @@ class PerformanceSummary(OrderedDict):
     @property
     def timings(self):
         return OrderedDict([(k, v.time) for k, v in self.items()])
-
-
-SectionData = namedtuple('SectionData', 'ops sops points traffic itershapes')
-"""Metadata for a profiled code section."""
-
-
-PerfEntry = namedtuple('PerfEntry', 'time gflopss gpointss oi ops itershapes')
-"""Runtime profiling data for a Section."""
 
 
 def create_profile(name):

--- a/devito/types/grid.py
+++ b/devito/types/grid.py
@@ -240,6 +240,11 @@ class Grid(ArgProvider):
         """The Distributor used for domain decomposition."""
         return self._distributor
 
+    @property
+    def comm(self):
+        """The MPI communicator used for domain decomposition."""
+        return self._distributor.comm
+
     def is_distributed(self, dim):
         """True if ``dim`` is a distributed Dimension, False otherwise."""
         return any(dim is d for d in self.distributor.dimensions)

--- a/devito/yask/operator.py
+++ b/devito/yask/operator.py
@@ -149,8 +149,11 @@ class OperatorYASK(Operator):
 
         for i in self.yk_solns.values():
             i.pre_apply(toshare)
+
         arg_values = [args[p.name] for p in self.parameters]
-        self.cfunction(*arg_values)
+        with self._profiler.timer_on('apply', comm=args.grid.comm):
+            self.cfunction(*arg_values)
+
         for i in self.yk_solns.values():
             i.post_apply()
 

--- a/devito/yask/operator.py
+++ b/devito/yask/operator.py
@@ -151,7 +151,7 @@ class OperatorYASK(Operator):
             i.pre_apply(toshare)
 
         arg_values = [args[p.name] for p in self.parameters]
-        with self._profiler.timer_on('apply', comm=args.grid.comm):
+        with self._profiler.timer_on('apply', comm=args.comm):
             self.cfunction(*arg_values)
 
         for i in self.yk_solns.values():

--- a/devito/yask/operator.py
+++ b/devito/yask/operator.py
@@ -151,8 +151,9 @@ class OperatorYASK(Operator):
             i.pre_apply(toshare)
 
         arg_values = [args[p.name] for p in self.parameters]
+        cfunction = self.cfunction
         with self._profiler.timer_on('apply', comm=args.comm):
-            self.cfunction(*arg_values)
+            cfunction(*arg_values)
 
         for i in self.yk_solns.values():
             i.post_apply()

--- a/examples/compiler/01_data_regions.ipynb
+++ b/examples/compiler/01_data_regions.ipynb
@@ -419,6 +419,7 @@
     }
    ],
    "source": [
+    "#NBVAL_IGNORE_OUTPUT\n",
     "op.apply(time_M=2)\n",
     "print(u_new.data_with_halo)"
    ]

--- a/tests/test_autotuner.py
+++ b/tests/test_autotuner.py
@@ -112,7 +112,7 @@ def test_mode_runtime_forward():
     assert op._state['autotuning'][0]['runs'] == 6
 
     # AT is expected to have executed 30 timesteps
-    assert summary['section0'].itershapes[0][0] == 101-30
+    assert summary[('section0', None)].itershapes[0][0] == 101-30
     assert np.all(f.data[0] == 100)
     assert np.all(f.data[1] == 101)
 
@@ -130,7 +130,7 @@ def test_mode_runtime_backward():
     assert op._state['autotuning'][0]['runs'] == 6
 
     # AT is expected to have executed 30 timesteps
-    assert summary['section0'].itershapes[0][0] == 101-30
+    assert summary[('section0', None)].itershapes[0][0] == 101-30
     assert np.all(f.data[0] == 101)
     assert np.all(f.data[1] == 100)
 

--- a/tests/test_dse.py
+++ b/tests/test_dse.py
@@ -630,7 +630,7 @@ def test_tti_rewrite_aggressive_wmpi():
 def test_tti_rewrite_aggressive_opcounts(space_order, expected):
     operator = tti_operator(dse='aggressive', space_order=space_order)
     _, _, _, summary = operator.forward(kernel='centered', save=False)
-    assert summary['section1'].ops == expected
+    assert summary[('section1', None)].ops == expected
 
 
 @switchconfig(profiling='advanced')


### PR DESCRIPTION
This one can clearly wait until after holidays, but basically it enables MPI-level profiling. Rank-0 derives the global execution time as described [here](https://stackoverflow.com/a/5301414)

Potentially, this can be wired with `benchmark.py`

I'd like reviewers to actually **try** the code and take a look at the profiling output