### PR TITLE
examples+MPI: Several fixes related to MPI benchmarking and execution of examples

### DIFF
--- a/benchmarks/user/benchmark.py
+++ b/benchmarks/user/benchmark.py
@@ -451,13 +451,17 @@ def get_ob_plotter():
 
 if __name__ == "__main__":
     # If running with MPI, we emit logging messages from rank0 only
-    MPI.Init()  # Devito starts off with MPI disabled!
-    set_log_level('DEBUG', comm=MPI.COMM_WORLD)
+    try:
+        MPI.Init()  # Devito starts off with MPI disabled!
+        set_log_level('DEBUG', comm=MPI.COMM_WORLD)
 
-    if MPI.COMM_WORLD.size > 1 and not configuration['mpi']:
-        warning("It seems that you're running over MPI with %d processes, but "
-                "DEVITO_MPI is unset. Setting `DEVITO_MPI=basic`...")
-        configuration['mpi'] = 'basic'
+        if MPI.COMM_WORLD.size > 1 and not configuration['mpi']:
+            warning("It seems that you're running over MPI with %d processes, but "
+                    "DEVITO_MPI is unset. Setting `DEVITO_MPI=basic`...")
+            configuration['mpi'] = 'basic'
+    except TypeError:
+    # MPI not available
+        pass
 
     # Profiling at max level
     configuration['profiling'] = 'advanced'

--- a/benchmarks/user/benchmark.py
+++ b/benchmarks/user/benchmark.py
@@ -460,7 +460,7 @@ if __name__ == "__main__":
                     "DEVITO_MPI is unset. Setting `DEVITO_MPI=basic`...")
             configuration['mpi'] = 'basic'
     except TypeError:
-    # MPI not available
+        # MPI not available
         pass
 
     # Profiling at max level

--- a/devito/builtins.py
+++ b/devito/builtins.py
@@ -205,7 +205,7 @@ def mmin(f):
         Input operand.
     """
     if isinstance(f, dv.Constant):
-        return f.value
+        return f.data
     elif isinstance(f, dv.Function):
         with MPIReduction(f, op=dv.mpi.MPI.MIN) as mr:
             mr.n.data[0] = np.min(f.data_ro_domain).item()
@@ -223,9 +223,8 @@ def mmax(f):
     f : array_like or Function
         Input operand.
     """
-
     if isinstance(f, dv.Constant):
-        return f.value
+        return f.data
     elif isinstance(f, dv.Function):
         with MPIReduction(f, op=dv.mpi.MPI.MAX) as mr:
             mr.n.data[0] = np.max(f.data_ro_domain).item()

--- a/devito/builtins.py
+++ b/devito/builtins.py
@@ -6,6 +6,8 @@ from sympy import Abs, Pow
 import numpy as np
 
 import devito as dv
+from devito.logger import warning
+
 
 __all__ = ['assign', 'smooth', 'norm', 'sumall', 'inner', 'mmin', 'mmax']
 
@@ -205,6 +207,9 @@ def mmin(f):
         Input operand.
     """
     if not isinstance(f, dv.Function):
+        if dv.configuration['mpi']:
+            warning("returning local min of array,"
+                    "use mmin(v::Function) for global minimum")
         return np.min(f)
 
     with MPIReduction(f, op=dv.mpi.MPI.MIN) as mr:
@@ -222,6 +227,9 @@ def mmax(f):
         Input operand.
     """
     if not isinstance(f, dv.Function):
+        if dv.configuration['mpi']:
+            warning("Returning local max of array,"
+                    "use mmax(v::Function) for global maximum")
         return np.max(f)
 
     with MPIReduction(f, op=dv.mpi.MPI.MAX) as mr:

--- a/examples/seismic/acoustic/acoustic_example.py
+++ b/examples/seismic/acoustic/acoustic_example.py
@@ -71,6 +71,7 @@ def run(shape=(50, 50, 50), spacing=(20.0, 20.0, 20.0), tn=1000.0,
     solver.born(dm, autotune=autotune)
     info("Applying Gradient")
     solver.gradient(rec, u, autotune=autotune, checkpointing=checkpointing)
+    return summary.gflopss, summary.oi, summary.timings, [rec, u.data]
 
 
 if __name__ == "__main__":

--- a/examples/seismic/elastic/elastic_example.py
+++ b/examples/seismic/elastic/elastic_example.py
@@ -7,8 +7,8 @@ from examples.seismic.elastic import ElasticWaveSolver
 from examples.seismic import demo_model, AcquisitionGeometry
 
 
-def elastic_setup(shape=(50, 50), spacing=(15.0, 15.0), tn=500., space_order=4, nbpml=10,
-                  constant=False, **kwargs):
+def elastic_setup(shape=(50, 50), spacing=(15.0, 15.0), tn=500., space_order=4,
+                  nbpml=10, constant=False, **kwargs):
 
     nrec = 2*shape[0]
     preset = 'constant-elastic' if constant else 'layers-elastic'
@@ -43,7 +43,7 @@ def run(shape=(50, 50), spacing=(20.0, 20.0), tn=1000.0,
     # Define receiver geometry (spread across x, just below surface)
     rec1, rec2, vx, vz, txx, tzz, txz, summary = solver.forward(autotune=autotune)
 
-    return (summary.gflopss, summary.oi, summary.timings, 
+    return (summary.gflopss, summary.oi, summary.timings,
             [rec1, rec2, vx, vz, txx, tzz, txz])
 
 

--- a/examples/seismic/elastic/elastic_example.py
+++ b/examples/seismic/elastic/elastic_example.py
@@ -43,11 +43,12 @@ def run(shape=(50, 50), spacing=(20.0, 20.0), tn=1000.0,
     # Define receiver geometry (spread across x, just below surface)
     rec1, rec2, vx, vz, txx, tzz, txz, summary = solver.forward(autotune=autotune)
 
-    return rec1, rec2, vx, vz, txx, tzz, txz, summary
+    return (summary.gflopss, summary.oi, summary.timings, 
+            [rec1, rec2, vx, vz, txx, tzz, txz])
 
 
 def test_elastic():
-    rec1, rec2, vx, vz, txx, tzz, txz, summary = run()
+    _, _, _, [rec1, rec2, vx, vz, txx, tzz, txz] = run()
     norm = lambda x: np.linalg.norm(x.data.reshape(-1))
     assert np.isclose(norm(rec1), 20.9175, atol=1e-3, rtol=0)
     assert np.isclose(norm(rec2), 1.81198, atol=1e-3, rtol=0)

--- a/examples/seismic/model.py
+++ b/examples/seismic/model.py
@@ -3,7 +3,7 @@ import os
 import numpy as np
 
 from examples.seismic.utils import scipy_smooth
-from devito import Grid, SubDomain, Function, Constant, warning, mmin, mmax
+from devito import Grid, SubDomain, Function, Constant, warning, mmax
 from devito.tools import as_tuple
 
 __all__ = ['Model', 'ModelElastic', 'ModelViscoelastic', 'demo_model']
@@ -686,7 +686,7 @@ class Model(GenericModel):
         # The CFL condtion is then given by
         # dt <= coeff * h / (max(velocity))
         coeff = 0.38 if len(self.shape) == 3 else 0.42
-        dt = self.dtype(coeff * mmin(self.spacing) / (self.scale*self._max_vp))
+        dt = self.dtype(coeff * np.min(self.spacing) / (self.scale*self._max_vp))
         return self.dtype("%.3f" % dt)
 
     @property
@@ -801,7 +801,7 @@ class ModelElastic(GenericModel):
         # The CFL condtion is then given by
         # dt < h / (sqrt(2) * max(vp)))
         # FIXME: Fix 'Constant' so that that mmax(self.vp) returns the data value
-        return self.dtype(.5*mmin(self.spacing) / (np.sqrt(2)*mmax(self.vp)))
+        return self.dtype(.5*np.min(self.spacing) / (np.sqrt(2)*mmax(self.vp)))
 
 
 class ModelViscoelastic(ModelElastic):
@@ -863,5 +863,5 @@ class ModelViscoelastic(ModelElastic):
         # imaging, and inversion: methodology, computational aspects and sensitivity"
         # for further details:
         # FIXME: Fix 'Constant' so that that mmax(self.vp) returns the data value
-        return self.dtype(6.*mmin(self.spacing) /
+        return self.dtype(6.*np.min(self.spacing) /
                           (7.*np.sqrt(self.grid.dim)*mmax(self.vp)))

--- a/examples/seismic/model.py
+++ b/examples/seismic/model.py
@@ -801,7 +801,7 @@ class ModelElastic(GenericModel):
         # The CFL condtion is then given by
         # dt < h / (sqrt(2) * max(vp)))
         # FIXME: Fix 'Constant' so that that mmax(self.vp) returns the data value
-        return self.dtype(.5*mmin(self.spacing) / (np.sqrt(2)*mmax(self.vp.data)))
+        return self.dtype(.5*mmin(self.spacing) / (np.sqrt(2)*mmax(self.vp)))
 
 
 class ModelViscoelastic(ModelElastic):
@@ -864,4 +864,4 @@ class ModelViscoelastic(ModelElastic):
         # for further details:
         # FIXME: Fix 'Constant' so that that mmax(self.vp) returns the data value
         return self.dtype(6.*mmin(self.spacing) /
-                          (7.*np.sqrt(self.grid.dim)*mmax(self.vp.data)))
+                          (7.*np.sqrt(self.grid.dim)*mmax(self.vp)))

--- a/examples/seismic/model.py
+++ b/examples/seismic/model.py
@@ -64,11 +64,11 @@ def demo_model(preset, **kwargs):
         origin = kwargs.pop('origin', tuple([0. for _ in shape]))
         nbpml = kwargs.pop('nbpml', 10)
         dtype = kwargs.pop('dtype', np.float32)
-        vp = kwargs.pop('vp', 2.2)
-        qp = kwargs.pop('qp', 100.)
-        vs = kwargs.pop('vs', 1.2)
-        qs = kwargs.pop('qs', 70.)
-        rho = 2.0
+        vp = kwargs.pop('vp', 1.5)
+        qp = kwargs.pop('qp', 10000.)
+        vs = kwargs.pop('vs', 0.5 * vp)
+        qs = kwargs.pop('qs', 7000.)
+        rho = 1.0
 
         return ModelViscoelastic(space_order=space_order, vp=vp, qp=qp, vs=vs,
                                  qs=qs, rho=rho, origin=origin, shape=shape,
@@ -171,16 +171,16 @@ def demo_model(preset, **kwargs):
         dtype = kwargs.pop('dtype', np.float32)
         nbpml = kwargs.pop('nbpml', 10)
         ratio = kwargs.pop('ratio', 2)
-        vp_top = kwargs.pop('vp_top', 1.6)
-        qp_top = kwargs.pop('qp_top', 40.)
-        vs_top = kwargs.pop('vs_top', 0.4)
-        qs_top = kwargs.pop('qs_top', 30.)
-        rho_top = kwargs.pop('rho_top', 1.3)
-        vp_bottom = kwargs.pop('vp_bottom', 2.2)
-        qp_bottom = kwargs.pop('qp_bottom', 100.)
-        vs_bottom = kwargs.pop('vs_bottom', 1.2)
-        qs_bottom = kwargs.pop('qs_bottom', 70.)
-        rho_bottom = kwargs.pop('qs_bottom', 2.0)
+        vp_top = kwargs.pop('vp_top', 1.5)
+        qp_top = kwargs.pop('qp_top', 10000.)
+        vs_top = kwargs.pop('vs_top', 0. * vp_top)
+        qs_top = kwargs.pop('qs_top', 0.)
+        rho_top = kwargs.pop('rho_top', 1.)
+        vp_bottom = kwargs.pop('vp_bottom', 2.5)
+        qp_bottom = kwargs.pop('qp_bottom', 10000.)
+        vs_bottom = kwargs.pop('vs_bottom', 0. * vp_bottom)
+        qs_bottom = kwargs.pop('qs_bottom', 0.)
+        rho_bottom = kwargs.pop('qs_bottom', 2.5/1.5)
 
         # Define a velocity profile in km/s
         vp = np.empty(shape, dtype=dtype)

--- a/examples/seismic/viscoelastic/viscoelastic_example.py
+++ b/examples/seismic/viscoelastic/viscoelastic_example.py
@@ -46,6 +46,7 @@ def run(shape=(50, 50), spacing=(20.0, 20.0), tn=1000.0,
     return (summary.gflopss, summary.oi, summary.timings,
             [rec1, rec2, vx, vz, txx, tzz, txz])
 
+
 def test_viscoelastic():
     _, _, _, [rec1, rec2, vx, vz, txx, tzz, txz] = run()
     norm = lambda x: np.linalg.norm(x.data.reshape(-1))

--- a/examples/seismic/viscoelastic/viscoelastic_example.py
+++ b/examples/seismic/viscoelastic/viscoelastic_example.py
@@ -1,14 +1,14 @@
 import numpy as np
 from argparse import ArgumentParser
 
+from devito import configuration
 from devito.logger import info
 from examples.seismic.viscoelastic import ViscoelasticWaveSolver
 from examples.seismic import demo_model, AcquisitionGeometry
 
 
-def viscoelastic_setup(shape=(50, 50), spacing=(15.0, 15.0), tn=500.,
-                       space_order=4, nbpml=10,
-                       constant=True, **kwargs):
+def viscoelastic_setup(shape=(50, 50), spacing=(15.0, 15.0), tn=500.,space_order=4,
+                       nbpml=10, constant=True, **kwargs):
 
     nrec = 2*shape[0]
     preset = 'constant-viscoelastic' if constant else 'layers-viscoelastic'
@@ -43,7 +43,8 @@ def run(shape=(50, 50), spacing=(20.0, 20.0), tn=1000.0,
     # Define receiver geometry (spread across x, just below surface)
     rec1, rec2, vx, vz, txx, tzz, txz, summary = solver.forward(autotune=autotune)
 
-    return rec1, rec2, vx, vz, txx, tzz, txz, summary
+    return (summary.gflopss, summary.oi, summary.timings,
+            [rec1, rec2, vx, vz, txx, tzz, txz])
 
 
 if __name__ == "__main__":
@@ -51,8 +52,9 @@ if __name__ == "__main__":
     parser = ArgumentParser(description=description)
     parser.add_argument('--2d', dest='dim2', default=False, action='store_true',
                         help="Preset to determine the physical problem setup")
-    parser.add_argument('-a', '--autotune', default=False, action='store_true',
-                        help="Enable autotuning for block sizes")
+    parser.add_argument('-a', '--autotune', default='off',
+                        choices=(configuration._accepted['autotuning']),
+                        help="Operator auto-tuning mode")
     parser.add_argument("-so", "--space_order", default=4,
                         type=int, help="Space order of the simulation")
     parser.add_argument("--nbpml", default=40,

--- a/examples/seismic/viscoelastic/viscoelastic_example.py
+++ b/examples/seismic/viscoelastic/viscoelastic_example.py
@@ -27,7 +27,7 @@ def viscoelastic_setup(shape=(50, 50), spacing=(15.0, 15.0), tn=500., space_orde
         rec_coordinates[:, 1] = np.array(model.domain_size)[1] * .5
         rec_coordinates[:, -1] = model.origin[-1] + 2 * spacing[-1]
     geometry = AcquisitionGeometry(model, rec_coordinates, src_coordinates,
-                                   t0=0.0, tn=tn, src_type='Ricker', f0=0.12)
+                                   t0=0.0, tn=tn, src_type='Ricker', f0=0.010)
 
     # Create solver object to provide relevant operators
     solver = ViscoelasticWaveSolver(model, geometry, space_order=space_order, **kwargs)
@@ -45,6 +45,12 @@ def run(shape=(50, 50), spacing=(20.0, 20.0), tn=1000.0,
 
     return (summary.gflopss, summary.oi, summary.timings,
             [rec1, rec2, vx, vz, txx, tzz, txz])
+
+def test_viscoelastic():
+    _, _, _, [rec1, rec2, vx, vz, txx, tzz, txz] = run()
+    norm = lambda x: np.linalg.norm(x.data.reshape(-1))
+    assert np.isclose(norm(rec1), 15.962572, atol=1e-3, rtol=0)
+    assert np.isclose(norm(rec2), 1.3817718, atol=1e-3, rtol=0)
 
 
 if __name__ == "__main__":

--- a/examples/seismic/viscoelastic/viscoelastic_example.py
+++ b/examples/seismic/viscoelastic/viscoelastic_example.py
@@ -7,7 +7,7 @@ from examples.seismic.viscoelastic import ViscoelasticWaveSolver
 from examples.seismic import demo_model, AcquisitionGeometry
 
 
-def viscoelastic_setup(shape=(50, 50), spacing=(15.0, 15.0), tn=500.,space_order=4,
+def viscoelastic_setup(shape=(50, 50), spacing=(15.0, 15.0), tn=500., space_order=4,
                        nbpml=10, constant=True, **kwargs):
 
     nrec = 2*shape[0]


### PR DESCRIPTION
This PR makes the following contributions:

- Enables the use of `mpirun` with non constant `vp` that was causing hanging by changing the way minimum is returned from `builtins.py`
- Changes parameters in `model.py` for a more stable `viscoelastic` model.
- Changes the order of the returned values from elastic and `viscoelastic` in order to
be compatible with `benchmark.py`.