### PR TITLE
MPI: flip domain decomposition

### DIFF
--- a/devito/mpi/distributed.py
+++ b/devito/mpi/distributed.py
@@ -196,11 +196,7 @@ class Distributor(AbstractDistributor):
             # However, `MPI.Compute_dims` is distro-dependent, so we have to enforce
             # some properties through our own wrapper (e.g., OpenMPI v3 does not
             # guarantee that 9 ranks are arranged into a 3x3 grid when shape=(9, 9))
-            topology = compute_dims(self._input_comm.size, len(shape))
-            # At this point MPI's dimension 0 corresponds to the rightmost element
-            # in `topology`. This is in reverse to `shape`'s ordering. Hence, we
-            # now restore consistency
-            self._topology = tuple(reversed(topology))
+            self._topology = compute_dims(self._input_comm.size, len(shape))
 
             if self._input_comm is not input_comm:
                 # By default, Devito arranges processes into a cartesian topology.
@@ -532,7 +528,7 @@ def compute_dims(nprocs, ndim):
         v = int(ceil(v))
         if not v**ndim == nprocs:
             # Fallback
-            return MPI.Compute_dims(nprocs, ndim)
+            return tuple(MPI.Compute_dims(nprocs, ndim))
     else:
         v = int(v)
     return tuple(v for _ in range(ndim))

--- a/tests/test_autotuner.py
+++ b/tests/test_autotuner.py
@@ -219,7 +219,7 @@ def test_at_w_mpi():
     f = TimeFunction(name='f', grid=grid, time_order=1)
     f.data_with_halo[:] = 1.
 
-    eq = Eq(f.forward, f[t, x, y-1] + f[t, x, y+1])
+    eq = Eq(f.forward, f[t, x-1, y] + f[t, x+1, y])
     op = Operator(eq, dle=('advanced', {'openmp': False, 'blockinner': True}))
 
     op.apply(time=-1, autotune=('basic', 'runtime'))
@@ -235,22 +235,22 @@ def test_at_w_mpi():
 
     # Check the halo hasn't been touched during AT
     glb_pos_map = grid.distributor.glb_pos_map
-    if LEFT in glb_pos_map[y]:
-        assert np.all(f._data_ro_with_inhalo[:, :, -1] == 1)
+    if LEFT in glb_pos_map[x]:
+        assert np.all(f._data_ro_with_inhalo[:, -1] == 1)
     else:
-        assert np.all(f._data_ro_with_inhalo[:, :, 0] == 1)
+        assert np.all(f._data_ro_with_inhalo[:, 0] == 1)
 
     # Finally, try running w/o AT, just to be sure nothing was broken
     f.data_with_halo[:] = 1.
     op.apply(time=2)
-    if LEFT in glb_pos_map[y]:
-        assert np.all(f.data_ro_domain[1, :, 0] == 5.)
-        assert np.all(f.data_ro_domain[1, :, 1] == 7.)
-        assert np.all(f.data_ro_domain[1, :, 2:4] == 8.)
+    if LEFT in glb_pos_map[x]:
+        assert np.all(f.data_ro_domain[1, 0] == 5.)
+        assert np.all(f.data_ro_domain[1, 1] == 7.)
+        assert np.all(f.data_ro_domain[1, 2:4] == 8.)
     else:
-        assert np.all(f.data_ro_domain[1, :, 4:6] == 8)
-        assert np.all(f.data_ro_domain[1, :, 6] == 7)
-        assert np.all(f.data_ro_domain[1, :, 7] == 5)
+        assert np.all(f.data_ro_domain[1, 4:6] == 8)
+        assert np.all(f.data_ro_domain[1, 6] == 7)
+        assert np.all(f.data_ro_domain[1, 7] == 5)
 
 
 def test_multiple_blocking():

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -794,64 +794,72 @@ class TestDataDistributed(object):
         t.data[:] = b
 
         c = np.array(t.data[::-1, ::-1, ::-1])
-        if LEFT in glb_pos_map[y] and LEFT in glb_pos_map[z]:
-            assert np.all(c[0, :, :] == [[63, 62],
-                                         [59, 58]])
-            assert np.all(c[3, :, :] == [[15, 14],
-                                         [11, 10]])
-        elif LEFT in glb_pos_map[y] and RIGHT in glb_pos_map[z]:
-            assert np.all(c[0, :, :] == [[61, 60],
-                                         [57, 56]])
-            assert np.all(c[3, :, :] == [[13, 12],
-                                         [9, 8]])
-        elif RIGHT in glb_pos_map[y] and LEFT in glb_pos_map[z]:
-            assert np.all(c[0, :, :] == [[55, 54],
-                                         [51, 50]])
-            assert np.all(c[3, :, :] == [[7, 6],
-                                         [3, 2]])
+        if LEFT in glb_pos_map[x] and LEFT in glb_pos_map[y]:
+            assert np.all(c[:, :, 0] == [[63, 59],
+                                         [47, 43]])
+            assert np.all(c[:, :, 3] == [[60, 56],
+                                         [44, 40]])
+        elif LEFT in glb_pos_map[x] and RIGHT in glb_pos_map[y]:
+            assert np.all(c[:, :, 0] == [[55, 51],
+                                         [39, 35]])
+            assert np.all(c[:, :, 3] == [[52, 48],
+                                         [36, 32]])
+        elif RIGHT in glb_pos_map[x] and LEFT in glb_pos_map[y]:
+            assert np.all(c[:, :, 0] == [[31, 27],
+                                         [15, 11]])
+            assert np.all(c[:, :, 3] == [[28, 24],
+                                         [12, 8]])
         else:
-            assert np.all(c[0, :, :] == [[53, 52],
-                                         [49, 48]])
-            assert np.all(c[3, :, :] == [[5, 4],
-                                         [1, 0]])
+            assert np.all(c[:, :, 0] == [[23, 19],
+                                         [7, 3]])
+            assert np.all(c[:, :, 3] == [[20, 16],
+                                         [4, 0]])
 
         d = np.array(t.data[::-1])
-        if LEFT in glb_pos_map[y] and LEFT in glb_pos_map[z]:
-            assert np.all(d[1, :, :] == [[32, 33],
-                                         [36, 37]])
-            assert np.all(d[2, :, :] == [[16, 17],
-                                         [20, 21]])
-        elif LEFT in glb_pos_map[y] and RIGHT in glb_pos_map[z]:
-            assert np.all(d[1, :, :] == [[34, 35],
-                                         [38, 39]])
-            assert np.all(d[2, :, :] == [[18, 19],
-                                         [22, 23]])
-        elif RIGHT in glb_pos_map[y] and LEFT in glb_pos_map[z]:
-            assert np.all(d[1, :, :] == [[40, 41],
-                                         [44, 45]])
-            assert np.all(d[2, :, :] == [[24, 25],
-                                         [28, 29]])
+        if LEFT in glb_pos_map[x] and LEFT in glb_pos_map[y]:
+            assert np.all(d[:, :, 1] == [[49, 53],
+                                         [33, 37]])
+            assert np.all(d[:, :, 2] == [[50, 54],
+                                         [34, 38]])
+        elif LEFT in glb_pos_map[x] and RIGHT in glb_pos_map[y]:
+            assert np.all(d[:, :, 1] == [[57, 61],
+                                         [41, 45]])
+            assert np.all(d[:, :, 2] == [[58, 62],
+                                         [42, 46]])
+        elif RIGHT in glb_pos_map[x] and LEFT in glb_pos_map[y]:
+            assert np.all(d[:, :, 1] == [[17, 21],
+                                         [1, 5]])
+            assert np.all(d[:, :, 2] == [[18, 22],
+                                         [2, 6]])
         else:
-            assert np.all(d[1, :, :] == [[42, 43],
-                                         [46, 47]])
-            assert np.all(d[2, :, :] == [[26, 27],
-                                         [30, 31]])
+            assert np.all(d[:, :, 1] == [[25, 29],
+                                         [9, 13]])
+            assert np.all(d[:, :, 2] == [[26, 30],
+                                         [10, 14]])
 
         e = np.array(t.data[:, 3:2:-1])
-        if LEFT in glb_pos_map[y] and LEFT in glb_pos_map[z]:
+        if LEFT in glb_pos_map[x] and LEFT in glb_pos_map[y]:
             assert e.size == 0
-        elif LEFT in glb_pos_map[y] and RIGHT in glb_pos_map[z]:
+        elif LEFT in glb_pos_map[x] and RIGHT in glb_pos_map[y]:
+            assert np.all(e[:, :, 0] == [[12],
+                                         [28]])
+            assert np.all(e[:, :, 1] == [[13],
+                                         [29]])
+            assert np.all(e[:, :, 2] == [[14],
+                                         [30]])
+            assert np.all(e[:, :, 3] == [[15],
+                                         [31]])
+        elif RIGHT in glb_pos_map[x] and LEFT in glb_pos_map[y]:
             assert e.size == 0
-        elif RIGHT in glb_pos_map[y] and LEFT in glb_pos_map[z]:
-            assert np.all(e[0] == [[12, 13]])
-            assert np.all(e[1] == [[28, 29]])
-            assert np.all(e[2] == [[44, 45]])
-            assert np.all(e[3] == [[60, 61]])
         else:
-            assert np.all(e[0] == [[14, 15]])
-            assert np.all(e[1] == [[30, 31]])
-            assert np.all(e[2] == [[46, 47]])
-            assert np.all(e[3] == [[62, 63]])
+            assert np.all(e[:, :, 0] == [[44],
+                                         [60]])
+            assert np.all(e[:, :, 1] == [[45],
+                                         [61]])
+            assert np.all(e[:, :, 2] == [[46],
+                                         [62]])
+            assert np.all(e[:, :, 3] == [[47],
+                                         [63]])
 
     @pytest.mark.parallel(mode=4)
     def test_niche_slicing(self):
@@ -915,72 +923,72 @@ class TestDataDistributed(object):
                                                [0, 0, 0, 0, 0, 0]])
 
         f.data[:] = 0
-        f.data[::2, ::2] = t.data[0, :, :]
+        f.data[::2, ::2] = t.data[:, :, 0]
         if LEFT in glb_pos_map0[x0] and LEFT in glb_pos_map0[y0]:
-            assert np.all(np.array(f.data) == [[0, 0, 1, 0],
+            assert np.all(np.array(f.data) == [[0, 0, 4, 0],
                                                [0, 0, 0, 0],
-                                               [4, 0, 5, 0],
+                                               [16, 0, 20, 0],
                                                [0, 0, 0, 0]])
         elif LEFT in glb_pos_map0[x0] and RIGHT in glb_pos_map0[y0]:
-            assert np.all(np.array(f.data) == [[2, 0, 3, 0],
+            assert np.all(np.array(f.data) == [[8, 0, 12, 0],
                                                [0, 0, 0, 0],
-                                               [6, 0, 7, 0],
+                                               [24, 0, 28, 0],
                                                [0, 0, 0, 0]])
         elif RIGHT in glb_pos_map0[x0] and LEFT in glb_pos_map0[y0]:
-            assert np.all(np.array(f.data) == [[8, 0, 9, 0],
+            assert np.all(np.array(f.data) == [[32, 0, 36, 0],
                                                [0, 0, 0, 0],
-                                               [12, 0, 13, 0],
+                                               [48, 0, 52, 0],
                                                [0, 0, 0, 0]])
         else:
-            assert np.all(np.array(f.data) == [[10, 0, 11, 0],
+            assert np.all(np.array(f.data) == [[40, 0, 44, 0],
                                                [0, 0, 0, 0],
-                                               [14, 0, 15, 0],
+                                               [56, 0, 60, 0],
                                                [0, 0, 0, 0]])
 
         f.data[:] = 0
-        f.data[1::2, 1::2] = t.data[0, :, :]
+        f.data[1::2, 1::2] = t.data[:, :, 0]
         if LEFT in glb_pos_map0[x0] and LEFT in glb_pos_map0[y0]:
             assert np.all(np.array(f.data) == [[0, 0, 0, 0],
-                                               [0, 0, 0, 1],
+                                               [0, 0, 0, 4],
                                                [0, 0, 0, 0],
-                                               [0, 4, 0, 5]])
+                                               [0, 16, 0, 20]])
         elif LEFT in glb_pos_map0[x0] and RIGHT in glb_pos_map0[y0]:
             assert np.all(np.array(f.data) == [[0, 0, 0, 0],
-                                               [0, 2, 0, 3],
+                                               [0, 8, 0, 12],
                                                [0, 0, 0, 0],
-                                               [0, 6, 0, 7]])
+                                               [0, 24, 0, 28]])
         elif RIGHT in glb_pos_map0[x0] and LEFT in glb_pos_map0[y0]:
             assert np.all(np.array(f.data) == [[0, 0, 0, 0],
-                                               [0, 8, 0, 9],
+                                               [0, 32, 0, 36],
                                                [0, 0, 0, 0],
-                                               [0, 12, 0, 13]])
+                                               [0, 48, 0, 52]])
         else:
             assert np.all(np.array(f.data) == [[0, 0, 0, 0],
-                                               [0, 10, 0, 11],
+                                               [0, 40, 0, 44],
                                                [0, 0, 0, 0],
-                                               [0, 14, 0, 15]])
+                                               [0, 56, 0, 60]])
 
         f.data[:] = 0
-        f.data[6::-2, 6::-2] = t.data[0, :, :]
+        f.data[6::-2, 6::-2] = t.data[:, :, 0]
         if LEFT in glb_pos_map0[x0] and LEFT in glb_pos_map0[y0]:
-            assert np.all(np.array(f.data) == [[15, 0, 14, 0],
+            assert np.all(np.array(f.data) == [[60, 0, 56, 0],
                                                [0, 0, 0, 0],
-                                               [11, 0, 10, 0],
+                                               [44, 0, 40, 0],
                                                [0, 0, 0, 0]])
         elif LEFT in glb_pos_map0[x0] and RIGHT in glb_pos_map0[y0]:
-            assert np.all(np.array(f.data) == [[13, 0, 12, 0],
+            assert np.all(np.array(f.data) == [[52, 0, 48, 0],
                                                [0, 0, 0, 0],
-                                               [9, 0, 8, 0],
+                                               [36, 0, 32, 0],
                                                [0, 0, 0, 0]])
         elif RIGHT in glb_pos_map0[x0] and LEFT in glb_pos_map0[y0]:
-            assert np.all(np.array(f.data) == [[7, 0, 6, 0],
+            assert np.all(np.array(f.data) == [[28, 0, 24, 0],
                                                [0, 0, 0, 0],
-                                               [3, 0, 2, 0],
+                                               [12, 0, 8, 0],
                                                [0, 0, 0, 0]])
         else:
-            assert np.all(np.array(f.data) == [[5, 0, 4, 0],
+            assert np.all(np.array(f.data) == [[20, 0, 16, 0],
                                                [0, 0, 0, 0],
-                                               [1, 0, 0, 0],
+                                               [4, 0, 0, 0],
                                                [0, 0, 0, 0]])
 
     @pytest.mark.parallel(mode=4)

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -23,7 +23,7 @@ class TestDistributor(object):
 
         distributor = grid.distributor
         expected = {  # nprocs -> [(rank0 shape), (rank1 shape), ...]
-            2: [(15, 8), (15, 7)],
+            2: [(8, 15), (7, 15)],
             4: [(8, 8), (8, 7), (7, 8), (7, 7)]
         }
         assert f.shape == expected[distributor.nprocs][distributor.myrank]
@@ -37,7 +37,7 @@ class TestDistributor(object):
         x, y = grid.dimensions
 
         # A function with fewer dimensions that in `grid`
-        f = Function(name='f', grid=grid, dimensions=(y,), shape=(size_y,))
+        f = Function(name='f', grid=grid, dimensions=(x,), shape=(size_x,))
 
         distributor = grid.distributor
         expected = {  # nprocs -> [(rank0 shape), (rank1 shape), ...]
@@ -116,8 +116,8 @@ class TestDistributor(object):
         PN = MPI.PROC_NULL
         attrs = ['ll', 'lc', 'lr', 'cl', 'cc', 'cr', 'rl', 'rc', 'rr']
         expected = {  # nprocs -> [(rank0 xleft xright ...), (rank1 xleft ...), ...]
-            2: [(PN, PN, PN, PN, 0, 1, PN, PN, PN),
-                (PN, PN, PN, 0, 1, PN, PN, PN, PN)],
+            2: [(PN, PN, PN, PN, 0, PN, PN, 1, PN),
+                (PN, 0, PN, PN, 1, PN, PN, PN, PN)],
             4: [(PN, PN, PN, PN, 0, 1, PN, 2, 3),
                 (PN, PN, PN, 0, 1, PN, 2, 3, PN),
                 (PN, 0, 1, PN, 2, 3, PN, PN, PN),
@@ -135,27 +135,26 @@ class TestFunction(object):
     @pytest.mark.parallel(mode=2)
     def test_halo_exchange_bilateral(self):
         """
-        Test halo exchange between two processes organised in a 1x2 cartesian grid.
+        Test halo exchange between two processes organised in a 2x1 cartesian grid.
 
-        The initial ``data_with_inhalo`` looks like:
+        On the left, the initial ``data_with_inhalo``; on the right, the situation
+        after the halo exchange.
 
-               rank0           rank1
-            0 0 0 0 0 0     0 0 0 0 0 0
-            0 1 1 1 1 0     0 2 2 2 2 0
-            0 1 1 1 1 0     0 2 2 2 2 0
-            0 1 1 1 1 0     0 2 2 2 2 0
-            0 1 1 1 1 0     0 2 2 2 2 0
-            0 0 0 0 0 0     0 0 0 0 0 0
-
-        After the halo exchange, the following is expected and tested for:
-
-               rank0           rank1
-            0 0 0 0 0 0     0 0 0 0 0 0
-            0 1 1 1 1 2     1 2 2 2 2 0
-            0 1 1 1 1 2     1 2 2 2 2 0
-            0 1 1 1 1 2     1 2 2 2 2 0
-            0 1 1 1 1 2     1 2 2 2 2 0
-            0 0 0 0 0 0     0 0 0 0 0 0
+               rank0               rank0
+            0 0 0 0 0 0         0 0 0 0 0 0
+            0 1 1 1 1 0         0 1 1 1 1 0
+            0 1 1 1 1 0         0 1 1 1 1 0
+            0 1 1 1 1 0         0 1 1 1 1 0
+            0 1 1 1 1 0         0 1 1 1 1 0
+            0 0 0 0 0 0         0 2 2 2 2 0
+                         ---->
+               rank1               rank1
+            0 0 0 0 0 0         0 1 1 1 1 0
+            0 2 2 2 2 0         0 2 2 2 2 0
+            0 2 2 2 2 0         0 2 2 2 2 0
+            0 2 2 2 2 0         0 2 2 2 2 0
+            0 2 2 2 2 0         0 2 2 2 2 0
+            0 0 0 0 0 0         0 0 0 0 0 0
         """
         grid = Grid(shape=(12, 12))
         x, y = grid.dimensions
@@ -167,62 +166,65 @@ class TestFunction(object):
         f.data_with_halo   # noqa
 
         glb_pos_map = grid.distributor.glb_pos_map
-        if LEFT in glb_pos_map[y]:
-            assert np.all(f._data_ro_with_inhalo[1:-1, -1] == 2.)
-            assert np.all(f._data_ro_with_inhalo[:, 0] == 0.)
+        if LEFT in glb_pos_map[x]:
+            assert np.all(f.data_ro_domain[:] == 1.)
+            assert np.all(f._data_ro_with_inhalo[-1, 1:-1] == 2.)
+            assert np.all(f._data_ro_with_inhalo[0, :] == 0.)
         else:
-            assert np.all(f._data_ro_with_inhalo[1:-1, 0] == 1.)
-            assert np.all(f._data_ro_with_inhalo[:, -1] == 0.)
-        assert np.all(f._data_ro_with_inhalo[0] == 0.)
-        assert np.all(f._data_ro_with_inhalo[-1] == 0.)
+            assert np.all(f.data_ro_domain[:] == 2.)
+            assert np.all(f._data_ro_with_inhalo[0, 1:-1] == 1.)
+            assert np.all(f._data_ro_with_inhalo[-1, :] == 0.)
+        assert np.all(f._data_ro_with_inhalo[:, 0] == 0.)
+        assert np.all(f._data_ro_with_inhalo[:, -1] == 0.)
 
     @pytest.mark.parallel(mode=2)
     def test_halo_exchange_bilateral_asymmetric(self):
         """
-        Test halo exchange between two processes organised in a 1x2 cartesian grid.
+        Test halo exchange between two processes organised in a 2x1 cartesian grid.
 
-        In this test, the size of left and right halo regions are different.
+        In this test, the size of left and right halo regions have different size.
 
-        The initial ``data_with_inhalo`` looks like:
+        On the left, the initial ``data_with_inhalo``; on the right, the situation
+        after the halo exchange.
 
-               rank0           rank1
-            0 0 0 0 0 0 0     0 0 0 0 0 0 0
-            0 0 0 0 0 0 0     0 0 0 0 0 0 0
-            0 0 1 1 1 1 0     0 0 2 2 2 2 0
-            0 0 1 1 1 1 0     0 0 2 2 2 2 0
-            0 0 1 1 1 1 0     0 0 2 2 2 2 0
-            0 0 1 1 1 1 0     0 0 2 2 2 2 0
-            0 0 0 0 0 0 0     0 0 0 0 0 0 0
-
-        After the halo exchange, the following is expected and tested for:
-
-               rank0           rank1
-            0 0 0 0 0 0 0     0 0 0 0 0 0 0
-            0 0 0 0 0 0 0     0 0 0 0 0 0 0
-            0 0 1 1 1 1 2     1 1 2 2 2 2 0
-            0 0 1 1 1 1 2     1 1 2 2 2 2 0
-            0 0 1 1 1 1 2     1 1 2 2 2 2 0
-            0 0 1 1 1 1 2     1 1 2 2 2 2 0
-            0 0 0 0 0 0 0     0 0 0 0 0 0 0
+                rank0                 rank0
+            0 0 0 0 0 0 0         0 0 0 0 0 0 0
+            0 1 1 1 1 0 0         0 1 1 1 1 0 0
+            0 1 1 1 1 0 0         0 1 1 1 1 0 0
+            0 1 1 1 1 0 0         0 1 1 1 1 0 0
+            0 1 1 1 1 0 0         0 1 1 1 1 0 0
+            0 0 0 0 0 0 0         0 2 2 2 2 0 0
+            0 0 0 0 0 0 0         0 2 2 2 2 0 0
+                           ---->
+                rank1                 rank1
+            0 0 0 0 0 0 0         0 1 1 1 1 0 0
+            0 2 2 2 2 0 0         0 2 2 2 2 0 0
+            0 2 2 2 2 0 0         0 2 2 2 2 0 0
+            0 2 2 2 2 0 0         0 2 2 2 2 0 0
+            0 2 2 2 2 0 0         0 2 2 2 2 0 0
+            0 0 0 0 0 0 0         0 0 0 0 0 0 0
+            0 0 0 0 0 0 0         0 0 0 0 0 0 0
         """
         grid = Grid(shape=(12, 12))
         x, y = grid.dimensions
 
-        f = Function(name='f', grid=grid, space_order=(1, 2, 1))
+        f = Function(name='f', grid=grid, space_order=(1, 1, 2))
         f.data[:] = grid.distributor.myrank + 1
 
         # Now trigger a halo exchange...
         f.data_with_halo   # noqa
 
         glb_pos_map = grid.distributor.glb_pos_map
-        if LEFT in glb_pos_map[y]:
-            assert np.all(f._data_ro_with_inhalo[2:-1, -1] == 2.)
-            assert np.all(f._data_ro_with_inhalo[:, 0:2] == 0.)
+        if LEFT in glb_pos_map[x]:
+            assert np.all(f.data_ro_domain[:] == 1.)
+            assert np.all(f._data_ro_with_inhalo[-2:, 1:-2] == 2.)
+            assert np.all(f._data_ro_with_inhalo[0:1, :] == 0.)
         else:
-            assert np.all(f._data_ro_with_inhalo[2:-1, 0:2] == 1.)
-            assert np.all(f._data_ro_with_inhalo[:, -1] == 0.)
-        assert np.all(f._data_ro_with_inhalo[0:2] == 0.)
-        assert np.all(f._data_ro_with_inhalo[-1] == 0.)
+            assert np.all(f.data_ro_domain[:] == 2.)
+            assert np.all(f._data_ro_with_inhalo[:1, 1:-2] == 1.)
+            assert np.all(f._data_ro_with_inhalo[-2:, :] == 0.)
+        assert np.all(f._data_ro_with_inhalo[:, :1] == 0.)
+        assert np.all(f._data_ro_with_inhalo[:, -2:] == 0.)
 
     @pytest.mark.parallel(mode=4)
     def test_halo_exchange_quadrilateral(self):


### PR DESCRIPTION
In master we decompose z -> y -> x
Now we decompose x -> y -> z

that is, the fastest varying dimension is decomposed last.

so if I have a grid `(16, 16, 16)` and 2 MPI ranks, each rank gets
* with master: `(16, 16, 8)`
* with this PR `(8, 16, 16)`

The larger the fastest (innermost) dimension, the better the performance should be