### PR TITLE
SparseFunction mpi

### DIFF
--- a/devito/operator.py
+++ b/devito/operator.py
@@ -401,7 +401,10 @@ class Operator(Callable):
     def _postprocess_arguments(self, args, **kwargs):
         """Process runtime arguments upon returning from ``.apply()``."""
         for p in self.parameters:
-            p._arg_apply(args[p.name], kwargs.get(p.name))
+            try:
+                p._arg_apply(args[p.name], args[p.coordinates.name], kwargs.get(p.name))
+            except AttributeError:
+                p._arg_apply(args[p.name], kwargs.get(p.name))
 
     @cached_property
     def _known_arguments(self):

--- a/devito/types/sparse.py
+++ b/devito/types/sparse.py
@@ -302,7 +302,7 @@ class AbstractSparseFunction(DiscreteFunction, Differentiable):
         if isinstance(key, AbstractSparseFunction):
             # Gather into `self.data`
             # Coords maye be empty if there is more ranks than coordinates
-            if coordsobj.size > 0:
+            if np.sum([coordsobj._obj.size[i] for i in range(self.ndim)]) > 0:
                 coordsobj = self.coordinates._C_as_ndarray(coordsobj)
             key._dist_gather(self._C_as_ndarray(dataobj), coordsobj)
         elif self.grid.distributor.nprocs > 1:

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -391,14 +391,14 @@ class TestSparseFunction(object):
 
         # Scatter
         loc_data = sf._dist_scatter()[sf]
+        loc_coords = sf._dist_scatter()[sf.coordinates]
         assert len(loc_data) == 1
         assert loc_data[0] == grid.distributor.myrank
-
         # Do some local computation
         loc_data = loc_data*2
 
         # Gather
-        sf._dist_gather(loc_data)
+        sf._dist_gather(loc_data, loc_coords)
         assert len(sf.data) == 1
         assert np.all(sf.data == data[sf.local_indices]*2)
 

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -592,6 +592,29 @@ class TestOperatorSimple(object):
         assert np.all(f1.data == 1.)
         assert np.all(f2.data == 1.)
 
+    @pytest.mark.parallel(mode=4)
+    def test_sparse_coords(self):
+        grid = Grid(shape=(21, 31, 21), extent=(20, 30, 20))
+        x, y, z = grid.dimensions
+
+        coords = np.zeros((21*31, 3))
+        coords[:, 0] = np.asarray([i for i in range(21) for j in range(31)])
+        coords[:, 1] = np.asarray([j for i in range(21) for j in range(31)])
+        sf = SparseFunction(name="s", grid=grid, coordinates=coords, npoint=21*31)
+
+        u = Function(name="u", grid=grid, space_order=1)
+        u.data[:, :, 0] = np.reshape(np.asarray([i+j for i in range(21)
+                                                 for j in range(31)]), (21, 31))
+
+        op = Operator(sf.interpolate(u))
+        op.apply()
+
+        for i in range(21*31):
+            coords_loc = sf.coordinates.data[i, 1]
+            if coords_loc is not None:
+                coords_loc += sf.coordinates.data[i, 0]
+            assert sf.data[i] == coords_loc
+
 
 class TestCodeGeneration(object):
 


### PR DESCRIPTION
Fixes SparseFunction with mpi.

Currently, any SparseFunction out of an operator loses the *mandatory and defining* 

map coords[i] -> data[i]

This fixes so that a give trace `data[:,i]` has its coordinates into `coords[i,:]`. This is mandatory for any operation on SparseFunction such has data residual (rec1- rec2) in FWI/RTM or just saving the result of an operator as the data just by itself doesn't mean anything