### PR TITLE
CustomCompiler should respect environment variables

### DIFF
--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -466,10 +466,10 @@ class CustomCompiler(Compiler):
             self.ldflags += environ.get('OMP_LDFLAGS', '-fopenmp').split(' ')
 
     def __lookup_cmds__(self):
-        self.CC = 'gcc'
-        self.CXX = 'g++'
-        self.MPICC = 'mpicc'
-        self.MPICXX = 'mpicxx'
+        self.CC = environ.get('CC', 'gcc')
+        self.CXX = environ.get('CXX', 'g++')
+        self.MPICC = environ.get('MPICC', 'mpicc')
+        self.MPICXX = environ.get('MPICXX', 'mpicxx')
 
 
 compiler_registry = {


### PR DESCRIPTION
It seems strange to find this bug so please correct me if I'm missing something. 

CustomCompiler, as it is in master, effectively seems to ignore the `CC` and other environment variables. Even though it reads these values once but they are overwritten by the hardcoded values in the lines I changed below. 

Changed the lines so the values are always read from the environment. 