### PR TITLE
Change from using data to data_allocated in checkpointing

### DIFF
--- a/devito/compiler.py
+++ b/devito/compiler.py
@@ -452,11 +452,6 @@ class CustomCompiler(Compiler):
     flags are read from OMP_LDFLAGS or otherwise default to ``-fopenmp``.
     """
 
-    CC = environ.get('CC', 'gcc')
-    CXX = environ.get('CXX', 'g++')
-    MPICC = environ.get('MPICC', 'mpicc')
-    MPICXX = environ.get('MPICXX', 'mpicxx')
-
     def __init__(self, *args, **kwargs):
         super(CustomCompiler, self).__init__(*args, **kwargs)
         default = '-O3 -g -march=native -fPIC -Wall -std=c99'

--- a/devito/types/dense.py
+++ b/devito/types/dense.py
@@ -324,6 +324,15 @@ class DiscreteFunction(AbstractCachedFunction, ArgProvider):
 
         return EnrichedTuple(*sizes, getters=self.dimensions, left=left, right=right)
 
+    @property
+    def size_allocated(self):
+        """
+        The number of elements this object is expected to store in memory.
+        Note that this would need to be combined with self.dtype to give the actual
+        size in bytes.
+        """
+        return reduce(mul, self.shape_allocated)
+
     @cached_property
     def _mask_modulo(self):
         """Boolean mask telling which Dimensions support modulo-indexing."""

--- a/examples/checkpointing/checkpoint.py
+++ b/examples/checkpointing/checkpoint.py
@@ -88,6 +88,6 @@ def get_symbol_data(symbol, timestep):
     timestep += symbol.time_order - 1
     ptrs = []
     for i in range(symbol.time_order):
-        ptr = symbol.data[timestep - i, :, :]
+        ptr = symbol._data_allocated[timestep - i, :, :]
         ptrs.append(ptr)
     return ptrs

--- a/examples/checkpointing/checkpoint.py
+++ b/examples/checkpointing/checkpoint.py
@@ -73,7 +73,7 @@ class DevitoCheckpoint(Checkpoint):
     @property
     def size(self):
         """The memory consumption of the data contained in a checkpoint."""
-        return sum([o.size*o.time_order for o in self.objects])
+        return sum([o.size_allocated*o.time_order for o in self.objects])
 
     def save(*args):
         raise RuntimeError("Invalid method called. Did you check your version" +
@@ -88,6 +88,6 @@ def get_symbol_data(symbol, timestep):
     timestep += symbol.time_order - 1
     ptrs = []
     for i in range(symbol.time_order):
-        ptr = symbol._data_allocated[timestep - i, :, :]
+        ptr = symbol._data[timestep - i, :, :]
         ptrs.append(ptr)
     return ptrs

--- a/tests/test_data.py
+++ b/tests/test_data.py
@@ -1227,8 +1227,8 @@ def test_numpy_c_contiguous():
     Test that devito.Data is correctly reported by NumPy as being C-contiguous
     """
     grid = Grid(shape=(4, 4))
-    u = Function(name='u', grid=grid, space_order=0)
-    assert(u.data.flags.c_contiguous)
+    u = Function(name='u', grid=grid, space_order=2)
+    assert(u._data_allocated.flags.c_contiguous)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR:
1. Changes the the c contiguous test in tests/test_data.py to use data_allocated and to check for a space_order > 0 to really test the condition that is likely to fail. 
2. Changes the checkpoint API with pyrevolve to use data_allocated instead of data. 

Note: ~This PR includes #925 so merge that first.~ 
TODO: Remove class attributes like `CC` etc from `CustomCompiler`