### PR TITLE
Add support to ops_dat_fetch_data 

### DIFF
--- a/devito/ops/node_factory.py
+++ b/devito/ops/node_factory.py
@@ -43,7 +43,9 @@ class OPSNodeFactory(object):
             symbol_to_access = OpsAccessible(
                 ops_arg_id,
                 indexed.dtype,
-                not is_write
+                not is_write,
+                indexed.function,
+                time_index.var
             )
             self.ops_args[ops_arg_id] = symbol_to_access
             self.ops_params.append(symbol_to_access)

--- a/devito/ops/operator.py
+++ b/devito/ops/operator.py
@@ -56,8 +56,9 @@ class OperatorOPS(Operator):
         to_dat = filter_sorted(to_dat)
 
         iteration_tree = retrieve_iteration_tree(iet, mode='normal')[0]
-        time_upper_bound = iteration_tree.dimensions[TimeFunction._time_position]\
-            .extreme_max
+        if iteration_tree:
+            time_upper_bound = iteration_tree.dimensions[TimeFunction._time_position]\
+                .extreme_max
 
         name_to_ops_dat = {}
         pre_time_loop = []

--- a/devito/ops/operator.py
+++ b/devito/ops/operator.py
@@ -1,13 +1,14 @@
-from devito import Eq
+from devito import Eq, TimeFunction
 from devito.ir.equations import ClusterizedEq
-from devito.ir.iet import Call, List, Expression, find_affine_trees
+from devito.ir.iet import (Call, Expression, find_affine_trees,
+                           List, retrieve_iteration_tree)
 from devito.ir.iet.visitors import FindSymbols, Transformer
 from devito.logger import warning
 from devito.operator import Operator
 from devito.symbolics import Literal
 from devito.tools import filter_sorted
 
-from devito.ops.transformer import create_ops_dat, opsit
+from devito.ops.transformer import create_ops_dat, create_ops_fetch, opsit
 from devito.ops.types import OpsBlock
 from devito.ops.utils import namespace
 
@@ -54,13 +55,21 @@ class OperatorOPS(Operator):
         # be generated (since a set is an unordered collection)
         to_dat = filter_sorted(to_dat)
 
+        iteration_tree = retrieve_iteration_tree(iet, mode='normal')[0]
+        time_upper_bound = iteration_tree.dimensions[TimeFunction._time_position]\
+            .extreme_max
+
         name_to_ops_dat = {}
         pre_time_loop = []
+        after_time_loop = []
         for f in to_dat:
             if f.is_Constant:
                 continue
 
             pre_time_loop.extend(create_ops_dat(f, name_to_ops_dat, ops_block))
+            # To return the result to Devito, it is necessary to copy the data
+            # from the dat object back to the CPU memory.
+            after_time_loop.extend(create_ops_fetch(f, name_to_ops_dat, time_upper_bound))
 
         # Generate ops kernels for each offloadable iteration tree
         mapper = {}
@@ -72,7 +81,8 @@ class OperatorOPS(Operator):
             pre_time_loop.extend(pre_loop)
             self._ops_kernels.append(ops_kernel)
             mapper[trees[0].root] = ops_par_loop_call
-            mapper.update({i.root: mapper.get(i.root) for i in trees})  # Drop trees
+            mapper.update({i.root: mapper.get(i.root)
+                           for i in trees})  # Drop trees
 
         iet = Transformer(mapper).visit(iet)
 
@@ -83,6 +93,7 @@ class OperatorOPS(Operator):
         self._headers.append(namespace['ops_define_dimension'](dims[0]))
         self._includes.append('stdio.h')
 
-        body = [ops_init, ops_block_init, *pre_time_loop, ops_partition, iet, ops_exit]
+        body = [ops_init, ops_block_init, *pre_time_loop,
+                ops_partition, iet, *after_time_loop, ops_exit]
 
         return List(body=body)

--- a/devito/ops/transformer.py
+++ b/devito/ops/transformer.py
@@ -1,7 +1,7 @@
-import numpy as np
 import itertools
+import numpy as np
 
-from sympy import sympify
+from sympy import sympify, Mod
 from sympy.core.numbers import Zero
 
 from devito import Eq
@@ -11,7 +11,7 @@ from devito.ir.iet.visitors import FindNodes
 from devito.ops.node_factory import OPSNodeFactory
 from devito.ops.types import Array, OpsAccessible, OpsDat, OpsStencil
 from devito.ops.utils import namespace
-from devito.symbolics import Byref, ListInitializer, Literal
+from devito.symbolics import Add, Byref, ListInitializer, Literal
 from devito.tools import dtype_to_cstr
 from devito.types import Constant, DefaultDimension, Symbol
 
@@ -35,16 +35,19 @@ def opsit(trees, count, name_to_ops_dat, block, dims):
         expressions.extend(FindNodes(Expression).visit(tree.inner))
 
     for expr in expressions:
-        ops_expressions.append(Expression(make_ops_ast(expr.expr, node_factory)))
+        ops_expressions.append(Expression(
+            make_ops_ast(expr.expr, node_factory)))
 
-    parameters = sorted(node_factory.ops_params, key=lambda i: (i.is_Constant, i.name))
+    parameters = sorted(node_factory.ops_params,
+                        key=lambda i: (i.is_Constant, i.name))
 
     stencil_arrays_initializations = []
     par_to_ops_stencil = {}
 
     for p in parameters:
         if isinstance(p, OpsAccessible):
-            stencil, initialization = to_ops_stencil(p, node_factory.ops_args_accesses[p])
+            stencil, initialization = to_ops_stencil(
+                p, node_factory.ops_args_accesses[p])
 
             par_to_ops_stencil[p] = stencil
             stencil_arrays_initializations.append(initialization)
@@ -138,11 +141,13 @@ def create_ops_dat(f, name_to_ops_dat, block):
         padding = f.padding[:time_pos] + f.padding[time_pos + 1:]
         halo = f.halo[:time_pos] + f.halo[time_pos + 1:]
         d_p_val = tuple(sympify([p[0] + h[0] for p, h in zip(padding, halo)]))
-        d_m_val = tuple(sympify([-(p[1] + h[1]) for p, h in zip(padding, halo)]))
+        d_m_val = tuple(sympify([-(p[1] + h[1])
+                                 for p, h in zip(padding, halo)]))
 
         ops_dat_array = Array(
             name=namespace['ops_dat_name'](f.name),
-            dimensions=(DefaultDimension(name='dat', default_value=time_dims),),
+            dimensions=(DefaultDimension(
+                name='dat', default_value=time_dims),),
             dtype='ops_dat',
             scope='stack'
         )
@@ -150,9 +155,7 @@ def create_ops_dat(f, name_to_ops_dat, block):
         dat_decls = []
         for i in range(time_dims):
             name = '%s%s%s' % (f.name, time_index, i)
-            name_to_ops_dat[name] = ops_dat_array.indexify(
-                [Symbol('%s%s' % (time_index, i))]
-            )
+
             dat_decls.append(namespace['ops_decl_dat'](
                 block,
                 1,
@@ -160,7 +163,7 @@ def create_ops_dat(f, name_to_ops_dat, block):
                 Symbol(base.name),
                 Symbol(d_m.name),
                 Symbol(d_p.name),
-                Byref(f.indexify([i])),
+                f.indexify([i]),
                 Literal('"%s"' % f._C_typedata),
                 Literal('"%s"' % name)
             ))
@@ -169,12 +172,18 @@ def create_ops_dat(f, name_to_ops_dat, block):
             ops_dat_array,
             ListInitializer(dat_decls)
         )))
+
+        # Insering the ops_dat array in case of TimeFunction.
+        name_to_ops_dat[f.name] = ops_dat_array
+
     else:
         ops_dat = OpsDat("%s_dat" % f.name)
         name_to_ops_dat[f.name] = ops_dat
 
-        d_p_val = tuple(sympify([p[0] + h[0] for p, h in zip(f.padding, f.halo)]))
-        d_m_val = tuple(sympify([-(p[1] + h[1]) for p, h in zip(f.padding, f.halo)]))
+        d_p_val = tuple(sympify([p[0] + h[0]
+                                 for p, h in zip(f.padding, f.halo)]))
+        d_m_val = tuple(sympify([-(p[1] + h[1])
+                                 for p, h in zip(f.padding, f.halo)]))
         dim_shape = sympify(f.shape)
 
         ops_decl_dat = Expression(ClusterizedEq(Eq(
@@ -186,7 +195,7 @@ def create_ops_dat(f, name_to_ops_dat, block):
                 Symbol(base.name),
                 Symbol(d_m.name),
                 Symbol(d_p.name),
-                Byref(f.indexify([0])),
+                f.indexify([0]),
                 Literal('"%s"' % f._C_typedata),
                 Literal('"%s"' % f.name)
             )
@@ -201,6 +210,22 @@ def create_ops_dat(f, name_to_ops_dat, block):
     return res
 
 
+def create_ops_fetch(f, name_to_ops_dat, time_upper_bound):
+
+    if f.is_TimeFunction:
+        ops_fetch = [namespace['ops_dat_fetch_data'](
+            name_to_ops_dat[f.name].indexify(
+                [Mod(Add(time_upper_bound, -i), f._time_size)]),
+            Byref(f.indexify([Mod(Add(time_upper_bound, -i), f._time_size)])))
+            for i in range(f._time_size)]
+
+    else:
+        ops_fetch = [namespace['ops_dat_fetch_data'](
+            name_to_ops_dat[f.name], Byref(f.indexify([0])))]
+
+    return ops_fetch
+
+
 def create_ops_par_loop(
         trees, ops_kernel, parameters, block, name_to_ops_dat, par_to_ops_stencil, dims):
     it_range = []
@@ -211,7 +236,8 @@ def create_ops_par_loop(
 
     range_array = Array(
         name='%s_range' % ops_kernel.name,
-        dimensions=(DefaultDimension(name='range', default_value=len(it_range)),),
+        dimensions=(DefaultDimension(
+            name='range', default_value=len(it_range)),),
         dtype=np.int32,
         scope='stack'
     )
@@ -244,13 +270,25 @@ def create_ops_arg(p, name_to_ops_dat, par_to_ops_stencil):
             namespace['ops_read']
         )
     else:
-        return namespace['ops_arg_dat'](
-            name_to_ops_dat[p.name],
-            1,
-            par_to_ops_stencil[p],
-            Literal('"%s"' % dtype_to_cstr(p.dtype)),
-            namespace['ops_read'] if p.read_only else namespace['ops_write']
-        )
+        if p._origin.is_TimeFunction:
+            from devito.types.basic import AbstractCachedFunction  # noqa
+
+            print(name_to_ops_dat[p._origin.name], type(name_to_ops_dat[p._origin.name]))
+            print(isinstance(name_to_ops_dat[p._origin.name], AbstractCachedFunction))
+            # This is a parameter generated from TimeFunction
+            return namespace['ops_arg_dat'](
+                name_to_ops_dat[p._origin.name].indexify([p._origin_time_index]),
+                1,
+                par_to_ops_stencil[p],
+                Literal('"%s"' % dtype_to_cstr(p.dtype)),
+                namespace['ops_read'] if p.read_only else namespace['ops_write'])
+        else:
+            return namespace['ops_arg_dat'](
+                name_to_ops_dat[p.name],
+                1,
+                par_to_ops_stencil[p],
+                Literal('"%s"' % dtype_to_cstr(p.dtype)),
+                namespace['ops_read'] if p.read_only else namespace['ops_write'])
 
 
 def make_ops_ast(expr, nfops, is_write=False):

--- a/devito/ops/transformer.py
+++ b/devito/ops/transformer.py
@@ -173,7 +173,7 @@ def create_ops_dat(f, name_to_ops_dat, block):
             ListInitializer(dat_decls)
         )))
 
-        # Insering the ops_dat array in case of TimeFunction.
+        # Inserting the ops_dat array in case of TimeFunction.
         name_to_ops_dat[f.name] = ops_dat_array
 
     else:
@@ -271,10 +271,6 @@ def create_ops_arg(p, name_to_ops_dat, par_to_ops_stencil):
         )
     else:
         if p._origin.is_TimeFunction:
-            from devito.types.basic import AbstractCachedFunction  # noqa
-
-            print(name_to_ops_dat[p._origin.name], type(name_to_ops_dat[p._origin.name]))
-            print(isinstance(name_to_ops_dat[p._origin.name], AbstractCachedFunction))
             # This is a parameter generated from TimeFunction
             return namespace['ops_arg_dat'](
                 name_to_ops_dat[p._origin.name].indexify([p._origin_time_index]),

--- a/devito/ops/types.py
+++ b/devito/ops/types.py
@@ -36,7 +36,8 @@ class OpsAccessible(basic.Symbol):
         obj.__init__(name, dtype, read_only, origin, origin_time_index, *args, **kwargs)
         return obj
 
-    def __init__(self, name, dtype, read_only, origin, origin_time_index, * args, **kwargs):
+    def __init__(self, name, dtype, read_only, origin, origin_time_index, *args,
+                 **kwargs):
         self.read_only = read_only
         self._origin = origin
         self._origin_time_index = origin_time_index

--- a/devito/ops/types.py
+++ b/devito/ops/types.py
@@ -31,13 +31,15 @@ class OpsAccessible(basic.Symbol):
     """
     is_Scalar = True
 
-    def __new__(cls, name, dtype, read_only, *args, **kwargs):
+    def __new__(cls, name, dtype, read_only, origin, origin_time_index, * args, **kwargs):
         obj = basic.Symbol.__new__(cls, name, dtype, *args, **kwargs)
-        obj.__init__(name, dtype, read_only, *args, **kwargs)
+        obj.__init__(name, dtype, read_only, origin, origin_time_index, *args, **kwargs)
         return obj
 
-    def __init__(self, name, dtype, read_only, *args, **kwargs):
+    def __init__(self, name, dtype, read_only, origin, origin_time_index, * args, **kwargs):
         self.read_only = read_only
+        self._origin = origin
+        self._origin_time_index = origin_time_index
         super().__init__(name, dtype, *args, **kwargs)
 
     @property
@@ -54,6 +56,9 @@ class OpsAccessible(basic.Symbol):
     @property
     def _C_typedata(self):
         return 'ACC<%s>' % dtype_to_cstr(self.dtype)
+
+    def ops_id(self):
+        return '%s%s' % (self._origin.name, self._origin_time_index)
 
 
 class OpsAccess(basic.Basic, sympy.Basic):

--- a/devito/ops/utils.py
+++ b/devito/ops/utils.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 from sympy import Function
 
+from devito.ir.iet.nodes import Call
 from devito.symbolics import Macro
 
 
@@ -13,6 +14,8 @@ namespace['ops_partition'] = 'ops_partition'
 namespace['ops_timing_output'] = 'ops_timing_output'
 namespace['ops_exit'] = 'ops_exit'
 namespace['ops_par_loop'] = 'ops_par_loop'
+namespace['ops_dat_fetch_data'] = lambda ops_dat, data: Call(
+    name='ops_dat_fetch_data', arguments=[ops_dat, 0, data])
 
 namespace['ops_decl_stencil'] = Function(name='ops_decl_stencil')
 namespace['ops_decl_block'] = Function(name='ops_decl_block')

--- a/devito/symbolics/extended_sympy.py
+++ b/devito/symbolics/extended_sympy.py
@@ -8,6 +8,7 @@ from sympy import Expr, Integer, Float, Function, Symbol
 from sympy.core.basic import _aresame
 from sympy.functions.elementary.trigonometric import TrigonometricFunction
 
+from devito.symbolics.printer import ccode
 from devito.tools import Pickable, as_tuple
 
 __all__ = ['FrozenExpr', 'Eq', 'CondEq', 'CondNe', 'Mul', 'Add', 'Pow', 'IntDiv',
@@ -303,9 +304,9 @@ class Byref(sympy.Expr, Pickable):
 
     def __str__(self):
         if self.base.is_Symbol:
-            return "&%s" % self.base
+            return "&%s" % ccode(self.base)
         else:
-            return "&(%s)" % self.base
+            return "&(%s)" % ccode(self.base)
 
     __repr__ = __str__
 

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -4,7 +4,7 @@ import numpy as np
 
 from conftest import skipif
 from sympy import Integer
-from sympy.core.numbers import Zero, One # noqa
+from sympy.core.numbers import Zero, One  # noqa
 
 pytestmark = skipif('noops', whole_module=True)
 
@@ -14,13 +14,13 @@ pytestmark = skipif('noops', whole_module=True)
 # `pytestmark` above
 from devito import Eq, Function, Grid, Operator, TimeFunction, configuration  # noqa
 from devito.ops.node_factory import OPSNodeFactory  # noqa
-from devito.ops.operator import OperatorOPS # noqa
-from devito.ops.transformer import create_ops_arg, create_ops_dat, make_ops_ast, to_ops_stencil # noqa
-from devito.ops.types import OpsAccessible, OpsDat, OpsStencil, OpsBlock # noqa
-from devito.ops.utils import namespace # noqa
-from devito.symbolics import Byref, Literal, indexify # noqa
-from devito.tools import dtype_to_cstr # noqa
-from devito.types import Constant, Symbol # noqa
+from devito.ops.operator import OperatorOPS  # noqa
+from devito.ops.transformer import create_ops_arg, create_ops_dat, make_ops_ast, to_ops_stencil  # noqa
+from devito.ops.types import OpsAccessible, OpsDat, OpsStencil, OpsBlock  # noqa
+from devito.ops.utils import namespace  # noqa
+from devito.symbolics import Byref, Literal, indexify  # noqa
+from devito.tools import dtype_to_cstr  # noqa
+from devito.types import Constant, Symbol  # noqa
 
 
 class TestOPSExpression(object):
@@ -131,60 +131,29 @@ class TestOPSExpression(object):
             Literal('"%s"' % stencil_name.upper())
         )
 
-    def test_create_ops_dat_time_function(self):
-        grid = Grid(shape=(4))
+    @pytest.mark.parametrize('equation,expected', [
+        ('Eq(u.forward, u + 1)',
+         '[\'ops_dat u_dat[2] = {ops_decl_dat(block, 1, u_dim, u_base, u_d_m, u_d_p, '
+         'u[0], "float", "ut0"), ops_decl_dat(block, 1, u_dim, u_base, u_d_m, u_d_p, '
+         'u[1], "float", "ut1")}\']'),
+        ('Eq(u.forward, u + v.dx)',
+         '[\'ops_dat u_dat[2] = {ops_decl_dat(block, 1, u_dim, u_base, u_d_m, u_d_p, '
+         'u[0], "float", "ut0"), ops_decl_dat(block, 1, u_dim, u_base, u_d_m, u_d_p, '
+         'u[1], "float", "ut1")}\','
+         '\'ops_dat v_dat;\','
+         '\'v_dat = ops_decl_dat(block, 1, v_dim, v_base, v_d_m, v_d_p, '
+         'v[0], "float", "v")\']')
+    ])
+    def test_create_ops_dat(self, equation, expected):
+        grid = Grid(shape=(4, 4))
 
-        u = TimeFunction(name='u', grid=grid, space_order=2)
+        u = TimeFunction(name='u', grid=grid, space_order=2)  # noqa
+        v = Function(name='v', grid=grid, space_order=2)  # noqa
 
-        block = OpsBlock('block')
+        op = Operator(eval(equation))
 
-        name_to_ops_dat = {}
-
-        result = create_ops_dat(u, name_to_ops_dat, block)
-
-        assert name_to_ops_dat['ut0'].base.name == namespace['ops_dat_name'](u.name)
-        assert name_to_ops_dat['ut0'].indices == (Symbol('t0'),)
-        assert name_to_ops_dat['ut1'].base.name == namespace['ops_dat_name'](u.name)
-        assert name_to_ops_dat['ut1'].indices == (Symbol('t1'),)
-
-        assert result[0].expr.lhs.name == namespace['ops_dat_dim'](u.name)
-        assert result[0].expr.rhs.params == (Integer(4),)
-
-        assert result[1].expr.lhs.name == namespace['ops_dat_base'](u.name)
-        assert result[1].expr.rhs.params == (Zero(),)
-
-        assert result[2].expr.lhs.name == namespace['ops_dat_d_p'](u.name)
-        assert result[2].expr.rhs.params == (Integer(2),)
-
-        assert result[3].expr.lhs.name == namespace['ops_dat_d_m'](u.name)
-        assert result[3].expr.rhs.params == (Integer(-2),)
-
-        assert result[4].expr.lhs.name == namespace['ops_dat_name'](u.name)
-        assert len(result[4].expr.rhs.params) == 2
-        assert result[4].expr.rhs.params[0].name == namespace['ops_decl_dat'].name
-        assert result[4].expr.rhs.params[0].args == (
-            block,
-            1,
-            Symbol(namespace['ops_dat_dim'](u.name)),
-            Symbol(namespace['ops_dat_base'](u.name)),
-            Symbol(namespace['ops_dat_d_m'](u.name)),
-            Symbol(namespace['ops_dat_d_p'](u.name)),
-            Byref(u.indexify((0,))),
-            Literal('"%s"' % u._C_typedata),
-            Literal('"ut0"')
-        )
-        assert result[4].expr.rhs.params[1].name == namespace['ops_decl_dat'].name
-        assert result[4].expr.rhs.params[1].args == (
-            block,
-            1,
-            Symbol(namespace['ops_dat_dim'](u.name)),
-            Symbol(namespace['ops_dat_base'](u.name)),
-            Symbol(namespace['ops_dat_d_m'](u.name)),
-            Symbol(namespace['ops_dat_d_p'](u.name)),
-            Byref(u.indexify((1,))),
-            Literal('"%s"' % u._C_typedata),
-            Literal('"ut1"')
-        )
+        for i in eval(expected):
+            assert i in str(op)
 
     def test_create_ops_dat_function(self):
         grid = Grid(shape=(4))
@@ -221,7 +190,7 @@ class TestOPSExpression(object):
             Symbol(namespace['ops_dat_base'](u.name)),
             Symbol(namespace['ops_dat_d_m'](u.name)),
             Symbol(namespace['ops_dat_d_p'](u.name)),
-            Byref(u.indexify((0,))),
+            u.indexify((0,)),
             Literal('"%s"' % u._C_typedata),
             Literal('"u"')
         )
@@ -256,3 +225,24 @@ class TestOPSExpression(object):
                 Literal('"%s"' % dtype_to_cstr(u.dtype)),
                 namespace['ops_read'] if read else namespace['ops_write']
             ]
+
+    @pytest.mark.parametrize('equation,expected', [
+        ('Eq(u.forward, u + 1)',
+         '[\'ops_dat_fetch_data(u_dat[(time_M)%(2)],0,&(u[(time_M)%(2)]));\','
+         '\'ops_dat_fetch_data(u_dat[(time_M + 1)%(2)],0,&(u[(time_M + 1)%(2)]));\']'),
+        ('Eq(v, v.dx + u)',
+         '[\'ops_dat_fetch_data(v_dat[(time_M)%(2)],0,&(v[(time_M)%(2)]));\','
+         '\'ops_dat_fetch_data(v_dat[(time_M + 1)%(2)],0,&(v[(time_M + 1)%(2)]));\','
+         '\'ops_dat_fetch_data(u_dat[(time_M)%(2)],0,&(u[(time_M)%(2)]));\','
+         '\'ops_dat_fetch_data(u_dat[(time_M + 1)%(2)],0,&(u[(time_M + 1)%(2)]));\']'),
+    ])
+    def test_create_fetch_data(self, equation, expected):
+
+        grid = Grid(shape=(4, 4))
+
+        u = TimeFunction(name='u', grid=grid)  # noqa
+        v = TimeFunction(name='v', grid=grid)  # noqa
+
+        op = Operator(eval(equation))
+        for i in eval(expected):
+            assert i in str(op)


### PR DESCRIPTION
**Add ops_dat_fetch_data call to the OPS backend** 

- This OPS API call is responsible to get data from the GPU and returning to the pointer allocated from Devito in the main memory.   
- For all ops_dat created, it is then created an `ops_dat_fetch_dat` call, that will bring the result from the GPU.   
- Modified `Byref` class to use ccode instead of plain `str`.   
- Created new tests for this OPS feature and modified tests for `ops_dat`.  
- Modified `OpsAccessible` to hold reference of what Devito type it was generated from.
- Modified dict `name_to_ops_dat` to only have values that are `OpsDat` or `Array` of `OpsDat`, instead of also having Indexed.
