### PR TITLE
Accelerate compilation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -113,7 +113,7 @@ before_script:
 script:
   - flake8 --builtins=ArgumentError .
   # Run test with py.tests
-  - py.test --durations=20 --cov --maxfail=5 --cov devito tests/
+  - py.test --durations=20 --maxfail=5 devito tests/
   # Run remaining specialized examples and tests
   # Additional seismic operator tests
   - if [[ $RUN_EXAMPLES == 'True' ]]; then python benchmarks/user/benchmark.py test -P tti -so 4 -d 20 20 20 -n 5; fi

--- a/azure-pipelines.py
+++ b/azure-pipelines.py
@@ -19,7 +19,7 @@ if os.environ.get('testWithPip') == 'true':
 
 if os.environ.get('testWithPip') != 'true':
     runStep("flake8 --exclude .conda,.git,.ipython --builtins=ArgumentError .")
-    runStep("py.test --durations=20 --maxfail=5 --cov devito tests/")
+    runStep("py.test --durations=20 --maxfail=5 devito tests/")
     if os.environ.get('RUN_EXAMPLES') == 'true':
         runStep(("python benchmarks/user/benchmark.py test " +
                  "-P tti -so 4 -d 20 20 20 -n 5"))

--- a/devito/dse/flowgraph.py
+++ b/devito/dse/flowgraph.py
@@ -2,7 +2,7 @@ from collections import OrderedDict
 from itertools import islice
 
 from devito.ir.equations import ClusterizedEq
-from devito.symbolics import (as_symbol, retrieve_terminals, q_timedimension)
+from devito.symbolics import retrieve_terminals, q_timedimension
 from devito.tools import DefaultOrderedDict, flatten
 from devito.types import Dimension, Symbol
 
@@ -79,13 +79,12 @@ class FlowGraph(OrderedDict):
         # Construct the Nodes, tracking reads and readby
         tensor_map = DefaultOrderedDict(list)
         for i in mapper:
-            tensor_map[as_symbol(i)].append(i)
+            tensor_map[i].append(i)
         reads = DefaultOrderedDict(set)
         readby = DefaultOrderedDict(set)
         for k, v in mapper.items():
             handle = retrieve_terminals(v.rhs, deep=True)
-            reads[k].update(set(flatten([tensor_map.get(as_symbol(i), [])
-                                         for i in handle])))
+            reads[k].update(set(flatten(tensor_map.get(i, []) for i in handle)))
             for i in reads[k]:
                 readby[i].add(k)
 

--- a/devito/finite_differences/differentiable.py
+++ b/devito/finite_differences/differentiable.py
@@ -171,6 +171,20 @@ class Differentiable(sympy.Expr, Evaluable):
         from devito.finite_differences.derivative import Derivative
         return Derivative(self, *symbols, **assumptions)
 
+    def _has(self, pattern):
+        """
+        Unlike generic SymPy use cases, in Devito the majority of calls to `_has`
+        occur through the finite difference routines passing `sympy.core.symbol.Symbol`
+        as `pattern`. Since the generic `_has` can be prohibitively expensive,
+        we here quickly handle this special case, while using the superclass' `_has`
+        as fallback.
+        """
+        if isinstance(pattern, type) and issubclass(pattern, sympy.Symbol):
+            # Symbols (and subclasses) are the leaves of an expression, and they
+            # are promptly available via `free_symbols`. So this is super quick
+            return any(isinstance(i, pattern) for i in self.free_symbols)
+        return super(Differentiable, self)._has(pattern)
+
 
 class Add(sympy.Add, Differentiable):
 

--- a/devito/ir/support/basic.py
+++ b/devito/ir/support/basic.py
@@ -779,6 +779,10 @@ class Scope(object):
     @memoized_meth
     def d_from_access(self, accesses):
         """Generate all dependences involving a given TimedAccess."""
-        return DependenceGroup(d for d in self.d_all
-                               if (d.source in as_tuple(accesses) or
-                                   d.sink in as_tuple(accesses)))
+        accesses = as_tuple(accesses)
+        found = DependenceGroup()
+        for d in self.d_all:
+            for i in accesses:
+                if d.source is i or d.sink is i:
+                    found.append(d)
+        return found

--- a/devito/ir/support/basic.py
+++ b/devito/ir/support/basic.py
@@ -151,7 +151,7 @@ class IterationInstance(LabeledVector):
     def is_scalar(self):
         return self.rank == 0
 
-    def distance(self, other, findex=None, view=None):
+    def distance(self, other, findex=None):
         """
         Compute the distance from ``self`` to ``other``.
 
@@ -161,8 +161,6 @@ class IterationInstance(LabeledVector):
             The IterationInstance from which the distance is computed.
         findex : Dimension, optional
             If supplied, compute the distance only up to and including ``findex``.
-        view : list of Dimension, optional
-            If supplied, project the distance along these Dimensions.
         """
         if not isinstance(other, IterationInstance):
             raise TypeError("Cannot compute distance from obj of type %s", type(other))
@@ -175,20 +173,7 @@ class IterationInstance(LabeledVector):
                 raise TypeError("Cannot compute distance as `findex` not in `findices`")
         else:
             limit = self.rank
-        distance = super(IterationInstance, self).distance(other)[:limit]
-        if view is None:
-            return distance
-        else:
-            proj = [d for d, i in zip(distance, self.findices) if i in as_tuple(view)]
-            return Vector(*proj)
-
-    def section(self, findices):
-        """
-        Return a view of ``self`` in which the slots corresponding to the
-        provided ``findices`` have been zeroed.
-        """
-        return Vector(*[d if i not in as_tuple(findices) else 0
-                        for d, i in zip(self, self.findices)])
+        return super(IterationInstance, self).distance(other)[:limit]
 
 
 class TimedAccess(IterationInstance):

--- a/devito/ir/support/basic.py
+++ b/devito/ir/support/basic.py
@@ -724,7 +724,7 @@ class Scope(object):
                 for r in self.reads.get(k, []):
                     try:
                         distance = r.distance(w)
-                        is_flow = distance < 0 or (distance == 0 and r.lex_ge(w))
+                        is_flow = distance < 0 or (r.lex_ge(w) and distance == 0)
                     except TypeError:
                         # Non-integer vectors are not comparable.
                         # Conservatively, we assume it is a dependence, unless
@@ -743,7 +743,7 @@ class Scope(object):
                 for r in self.reads.get(k, []):
                     try:
                         distance = r.distance(w)
-                        is_anti = distance > 0 or (distance == 0 and r.lex_lt(w))
+                        is_anti = distance > 0 or (r.lex_lt(w) and distance == 0)
                     except TypeError:
                         # Non-integer vectors are not comparable.
                         # Conservatively, we assume it is a dependence, unless
@@ -762,7 +762,7 @@ class Scope(object):
                 for w2 in self.writes.get(k, []):
                     try:
                         distance = w2.distance(w1)
-                        is_output = distance > 0 or (distance == 0 and w2.lex_gt(w1))
+                        is_output = distance > 0 or (w2.lex_gt(w1) and distance == 0)
                     except TypeError:
                         # Non-integer vectors are not comparable.
                         # Conservatively, we assume it is a dependence

--- a/devito/symbolics/manipulation.py
+++ b/devito/symbolics/manipulation.py
@@ -246,6 +246,15 @@ def split_affine(expr):
     """
     if expr.is_Number:
         return AffineFunction(None, None, expr)
+
+    # Handle super-quickly the calls like `split_affine(x+1)`, which are
+    # the majority.
+    if expr.is_Add and len(expr.args) == 2:
+        if expr.args[0].is_Number and expr.args[1].is_Symbol:
+            # SymPy deterministically orders arguments -- first numbers, then symbols
+            return AffineFunction(expr.args[1], 1, expr.args[0])
+
+    # Fallback
     poly = expr.as_poly()
     if not (poly.is_univariate and poly.is_linear) or not LM(poly).is_Symbol:
         raise ValueError

--- a/devito/symbolics/queries.py
+++ b/devito/symbolics/queries.py
@@ -149,16 +149,16 @@ def q_affine(expr, vars):
         # The vast majority of calls here are incredibly simple tests
         # like q_affine(x+1, [x]).  Catch these quickly and
         # explicitly, instead of calling the very slow function `diff`.
-        if expr == x:
+        if expr is x:
             continue
         if expr.is_Add and len(expr.args) == 2:
-            if expr.args[0] == x and expr.args[1].is_Number:
+            if expr.args[1] is x and expr.args[0].is_Number:
                 continue
-            if expr.args[1] == x and expr.args[0].is_Number:
+            if expr.args[0] is x and expr.args[1].is_Number:
                 continue
 
         try:
-            if diff(expr, x) == nan or not Eq(diff(expr, x, x), 0):
+            if diff(expr, x) is nan or not Eq(diff(expr, x, x), 0):
                 return False
         except TypeError:
             return False

--- a/tests/test_dse.py
+++ b/tests/test_dse.py
@@ -678,3 +678,7 @@ def test_tti_v2_rewrite_aggressive_opcounts(space_order, expected):
     assert len(sections) == 2
     assert sections[0].sops == 4
     assert sections[1].sops == expected
+
+
+if __name__ == "__main__":
+    test_tti_rewrite_aggressive_opcounts(16, 270)

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -1119,8 +1119,6 @@ class TestLoopScheduling(object):
     @pytest.mark.parametrize('exprs', [
         ('Eq(ti0[x,y,z], ti0[x,y,z] + ti1[x,y,z])', 'Eq(ti1[x,y,z], ti3[x,y,z])',
          'Eq(ti3[x,y,z], ti1[x,y,z] + 1.)'),
-        ('Eq(ti0[x,y,z], ti0[x,y,z-1] + ti1[x,y,z-1])', 'Eq(ti1[x,y,z], ti3[x,y,z-1])',
-         'Eq(ti3[x,y,z], ti3[x,y,z-1] + ti0[x,y,z])'),
         ('Eq(ti0[x,y,z+2], ti0[x,y,z-1] + ti1[x,y,z+1])',
          'Eq(ti1[x,y,z+3], ti3[x,y,z+1])',
          'Eq(ti3[x,y,z+2], ti0[x,y,z+1]*ti3[x,y,z-1])'),


### PR DESCRIPTION
Re-engineer code to improve the devito compilation times. 

I've used python's cProfile to find out the hotspots

I've also dropped unused code (which is always a good thing)

for example, `tti -so16` is now **vastly** faster to generate code. Let's see the overall CI times

[profiling_test_dse_v6.pdf](https://github.com/opesci/devito/files/3595120/profiling_test_dse_v6.pdf)

Attached you find the last profile I got from `test_tti_rewrite_aggressive_opcounts(16, 270) `, which I have left within ``__main__`` in ``test_dse.py`` as I hope soon we can get back at this. In particular, now most of the time is spent in API calls (basically to take derivatives, to compute derivatives shortcuts, etc)