### PR TITLE
Tweak elastic and viscoelastic testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -121,15 +121,13 @@ script:
   - if [[ $RUN_EXAMPLES == 'True' ]]; then python examples/seismic/acoustic/acoustic_example.py --full; fi
   - if [[ $RUN_EXAMPLES == 'True' ]]; then python examples/seismic/acoustic/acoustic_example.py --full --checkpointing; fi
   - if [[ $RUN_EXAMPLES == 'True' ]]; then python examples/seismic/acoustic/acoustic_example.py --constant --full; fi
-  - if [[ $RUN_EXAMPLES == 'True' ]]; then python examples/seismic/elastic/elastic_example.py --2d; fi
-  - if [[ $RUN_EXAMPLES == 'True' ]]; then python examples/seismic/elastic/elastic_example.py; fi
-  - if [[ $RUN_EXAMPLES == 'True' ]]; then python examples/seismic/viscoelastic/viscoelastic_example.py --2d; fi
   - if [[ $RUN_EXAMPLES == 'True' ]]; then python examples/misc/linalg.py mat-vec mat-mat-sum transpose-mat-vec; fi
   - if [[ $RUN_EXAMPLES == 'True' ]]; then python examples/seismic/tti/tti_example.py -a basic; fi
   - if [[ $RUN_EXAMPLES == 'True' ]]; then python examples/seismic/tti/tti_example.py -a basic --noazimuth; fi
   - if [[ $RUN_EXAMPLES == 'True' ]]; then python examples/cfd/example_diffusion.py; fi
   - if [[ $RUN_EXAMPLES == 'True' ]]; then py.test examples/cfd/example_diffusion.py; fi
   - if [[ $RUN_EXAMPLES == 'True' ]]; then py.test examples/seismic/elastic/elastic_example.py; fi
+  - if [[ $RUN_EXAMPLES == 'True' ]]; then py.test examples/seismic/viscoelastic/viscoelastic_example.py; fi
   # Test tutorial notebooks for the website using nbval
   - if [[ $RUN_EXAMPLES == 'True' ]]; then py.test --nbval examples/cfd; fi
   - if [[ $RUN_EXAMPLES == 'True' ]]; then py.test --nbval examples/seismic/tutorials; fi

--- a/azure-pipelines.py
+++ b/azure-pipelines.py
@@ -31,11 +31,10 @@ if os.environ.get('testWithPip') != 'true':
         runStep("python examples/misc/linalg.py mat-vec mat-mat-sum transpose-mat-vec")
         runStep("python examples/seismic/tti/tti_example.py -a basic")
         runStep("python examples/seismic/tti/tti_example.py -a basic --noazimuth")
-        runStep("python examples/seismic/elastic/elastic_example.py")
-        runStep("python examples/seismic/viscoelastic/viscoelastic_example.py")
         runStep("python examples/cfd/example_diffusion.py")
         runStep("py.test examples/cfd/example_diffusion.py")
         runStep("py.test examples/seismic/elastic/elastic_example.py")
+        runStep("py.test examples/seismic/viscoelastic/viscoelastic_example.py")
         runStep("ipcluster start --profile=mpi -n 4 --daemon")  # Needed by MPI notebooks
         runStep("py.test --nbval examples/cfd")
         runStep("py.test --nbval examples/seismic/tutorials")


### PR DESCRIPTION
Running the 3d elastic example was time consuming and the example was not being 'tested'. This PR removes running (untested) elastic and viscoelastic examples during build testing and now only the 2d simulations with norm tests are run.