### PR TITLE
Feature - add ops fetch

### DIFF
--- a/devito/ops/node_factory.py
+++ b/devito/ops/node_factory.py
@@ -44,7 +44,9 @@ class OPSNodeFactory(object):
             symbol_to_access = OpsAccessible(
                 ops_arg_id,
                 indexed.dtype,
-                not is_write
+                not is_write,
+                indexed.function,
+                time_index.var
             )
 
             accessible_info = AccessibleInfo(

--- a/devito/ops/node_factory.py
+++ b/devito/ops/node_factory.py
@@ -43,7 +43,9 @@ class OPSNodeFactory(object):
             symbol_to_access = OpsAccessible(
                 ops_arg_id,
                 indexed.dtype,
-                not is_write
+                not is_write,
+                indexed.function,
+                time_index.var
             )
             self.ops_args[ops_arg_id] = symbol_to_access
             self.ops_params.append(symbol_to_access)

--- a/devito/ops/node_factory.py
+++ b/devito/ops/node_factory.py
@@ -43,10 +43,12 @@ class OPSNodeFactory(object):
             symbol_to_access = OpsAccessible(
                 ops_arg_id,
                 indexed.dtype,
-                not is_write,
-                indexed.function,
-                time_index.var
+                not is_write
             )
+
+            symbol_to_access._origin_name = indexed.function.name
+            symbol_to_access._time_access = time_index.var \
+                if indexed.function.is_TimeFunction else None
             self.ops_args[ops_arg_id] = symbol_to_access
             self.ops_params.append(symbol_to_access)
         else:

--- a/devito/ops/node_factory.py
+++ b/devito/ops/node_factory.py
@@ -44,9 +44,7 @@ class OPSNodeFactory(object):
             symbol_to_access = OpsAccessible(
                 ops_arg_id,
                 indexed.dtype,
-                not is_write,
-                indexed.function,
-                time_index.var
+                not is_write
             )
 
             accessible_info = AccessibleInfo(

--- a/devito/ops/operator.py
+++ b/devito/ops/operator.py
@@ -58,7 +58,8 @@ class OperatorOPS(Operator):
         to_dat = filter_sorted(to_dat)
 
         iteration_tree = retrieve_iteration_tree(iet, mode='normal')[0]
-        time_upper_bound = iteration_tree.dimensions[TimeFunction._time_position].extreme_max
+        time_upper_bound = iteration_tree.dimensions[TimeFunction._time_position]\
+            .extreme_max
 
         name_to_ops_dat = {}
         pre_time_loop = []

--- a/devito/ops/operator.py
+++ b/devito/ops/operator.py
@@ -58,8 +58,9 @@ class OperatorOPS(Operator):
         to_dat = filter_sorted(to_dat)
 
         iteration_tree = retrieve_iteration_tree(iet, mode='normal')[0]
-        time_upper_bound = iteration_tree.dimensions[TimeFunction._time_position]\
-            .extreme_max
+        if iteration_tree:
+            time_upper_bound = iteration_tree.dimensions[TimeFunction._time_position]\
+                .extreme_max
 
         name_to_ops_dat = {}
         pre_time_loop = []

--- a/devito/ops/operator.py
+++ b/devito/ops/operator.py
@@ -1,6 +1,7 @@
-from devito import Eq
+from devito import Eq, TimeFunction
 from devito.ir.equations import ClusterizedEq
-from devito.ir.iet import Call, List, Expression, find_affine_trees
+from devito.ir.iet import (Call, Expression, find_affine_trees,
+                           FindNodes, Iteration, List, retrieve_iteration_tree)
 from devito.ir.iet.visitors import FindSymbols, Transformer
 from devito.logger import warning
 from devito.operator import Operator
@@ -9,7 +10,7 @@ from devito.tools import filter_sorted
 
 from devito.ops import ops_configuration
 from devito.ops.transformer import create_ops_dat, create_ops_fetch, opsit
-from devito.ops.types import OpsBlock
+from devito.ops.types import OpsBlock, OpsAccessible
 from devito.ops.utils import namespace
 
 __all__ = ['OperatorOPS']
@@ -65,8 +66,8 @@ class OperatorOPS(Operator):
 
             pre_time_loop.extend(create_ops_dat(f, name_to_ops_dat, ops_block))
             # To return the result to Devito, it is necessary to copy the data
-            # from the GPU into the CPU memory
-            after_time_loop.append(create_ops_fetch(f, name_to_ops_dat))
+            # from the dat object into the CPU memory
+            after_time_loop.extend(create_ops_fetch(f, name_to_ops_dat))
 
         # Generate ops kernels for each offloadable iteration tree
         mapper = {}

--- a/devito/ops/operator.py
+++ b/devito/ops/operator.py
@@ -84,8 +84,7 @@ class OperatorOPS(Operator):
             pre_time_loop.extend(pre_loop)
             self._ops_kernels.append(ops_kernel)
             mapper[trees[0].root] = ops_par_loop_call
-            mapper.update({i.root: mapper.get(i.root)
-                           for i in trees})  # Drop trees
+            mapper.update({i.root: mapper.get(i.root) for i in trees})  # Drop trees
 
         iet = Transformer(mapper).visit(iet)
 

--- a/devito/ops/operator.py
+++ b/devito/ops/operator.py
@@ -30,6 +30,13 @@ class OperatorOPS(Operator):
     def _specialize_iet(self, iet, **kwargs):
         warning("The OPS backend is still work-in-progress")
 
+        # If there is no iteration tree, then there is no loop to be optimized using OPS.
+        iteration_tree = retrieve_iteration_tree(iet, mode='normal')
+        if not len(iteration_tree):
+            return iet
+        time_upper_bound = iteration_tree[0].dimensions[TimeFunction._time_position]\
+            .extreme_max
+
         ops_init = Call(namespace['ops_init'], [0, 0, 2])
         ops_partition = Call(namespace['ops_partition'], Literal('""'))
         ops_exit = Call(namespace['ops_exit'])
@@ -56,11 +63,6 @@ class OperatorOPS(Operator):
         # To ensure deterministic code generation we order the datasets to
         # be generated (since a set is an unordered collection)
         to_dat = filter_sorted(to_dat)
-
-        iteration_tree = retrieve_iteration_tree(iet, mode='normal')[0]
-        if iteration_tree:
-            time_upper_bound = iteration_tree.dimensions[TimeFunction._time_position]\
-                .extreme_max
 
         name_to_ops_dat = {}
         pre_time_loop = []

--- a/devito/ops/operator.py
+++ b/devito/ops/operator.py
@@ -1,7 +1,7 @@
 from devito import Eq, TimeFunction
 from devito.ir.equations import ClusterizedEq
 from devito.ir.iet import (Call, Expression, find_affine_trees,
-                           FindNodes, Iteration, List, retrieve_iteration_tree)
+                           List, retrieve_iteration_tree)
 from devito.ir.iet.visitors import FindSymbols, Transformer
 from devito.logger import warning
 from devito.operator import Operator
@@ -10,7 +10,7 @@ from devito.tools import filter_sorted
 
 from devito.ops import ops_configuration
 from devito.ops.transformer import create_ops_dat, create_ops_fetch, opsit
-from devito.ops.types import OpsBlock, OpsAccessible
+from devito.ops.types import OpsBlock
 from devito.ops.utils import namespace
 
 __all__ = ['OperatorOPS']
@@ -57,6 +57,9 @@ class OperatorOPS(Operator):
         # be generated (since a set is an unordered collection)
         to_dat = filter_sorted(to_dat)
 
+        iteration_tree = retrieve_iteration_tree(iet, mode='normal')[0]
+        time_upper_bound = iteration_tree.dimensions[TimeFunction._time_position].extreme_max
+
         name_to_ops_dat = {}
         pre_time_loop = []
         after_time_loop = []
@@ -66,8 +69,8 @@ class OperatorOPS(Operator):
 
             pre_time_loop.extend(create_ops_dat(f, name_to_ops_dat, ops_block))
             # To return the result to Devito, it is necessary to copy the data
-            # from the dat object into the CPU memory
-            after_time_loop.extend(create_ops_fetch(f, name_to_ops_dat))
+            # from the dat object back to the CPU memory.
+            after_time_loop.extend(create_ops_fetch(f, name_to_ops_dat, time_upper_bound))
 
         # Generate ops kernels for each offloadable iteration tree
         mapper = {}

--- a/devito/ops/transformer.py
+++ b/devito/ops/transformer.py
@@ -4,12 +4,12 @@ import numpy as np
 from sympy import sympify, Mod
 from sympy.core.numbers import Zero
 
-from devito import Eq, TimeFunction
+from devito import Eq
 from devito.ir.equations import ClusterizedEq
 from devito.ir.iet.nodes import Call, Callable, Expression, IterationTree
 from devito.ir.iet.visitors import FindNodes
 from devito.ops.node_factory import OPSNodeFactory
-from devito.ops.types import Array, OpsAccessible, OpsDat, OpsStencil, OpsAccess
+from devito.ops.types import Array, OpsAccessible, OpsDat, OpsStencil
 from devito.ops.utils import namespace
 from devito.symbolics import Add, Byref, ListInitializer, Literal
 from devito.tools import dtype_to_cstr

--- a/devito/ops/transformer.py
+++ b/devito/ops/transformer.py
@@ -4,16 +4,16 @@ import numpy as np
 from sympy import sympify, Mod
 from sympy.core.numbers import Zero
 
-from devito import Eq
+from devito import Eq, TimeFunction
 from devito.ir.equations import ClusterizedEq
 from devito.ir.iet.nodes import Call, Callable, Expression, IterationTree
 from devito.ir.iet.visitors import FindNodes
 from devito.ops.node_factory import OPSNodeFactory
-from devito.ops.types import Array, OpsAccessible, OpsDat, OpsStencil
+from devito.ops.types import Array, OpsAccessible, OpsDat, OpsStencil, OpsAccess
 from devito.ops.utils import namespace
 from devito.symbolics import Add, Byref, ListInitializer, Literal
 from devito.tools import dtype_to_cstr
-from devito.types import Constant, DefaultDimension, Symbol
+from devito.types import Constant, DefaultDimension, Indexed, Symbol
 
 
 def opsit(trees, count, name_to_ops_dat, block, dims):

--- a/devito/ops/transformer.py
+++ b/devito/ops/transformer.py
@@ -157,7 +157,7 @@ def create_ops_dat(f, name_to_ops_dat, block):
                 Symbol(base.name),
                 Symbol(d_m.name),
                 Symbol(d_p.name),
-                Byref(f.indexify([i])),
+                f.indexify([i]),
                 Literal('"%s"' % f._C_typedata),
                 Literal('"%s"' % name)
             ))
@@ -189,7 +189,7 @@ def create_ops_dat(f, name_to_ops_dat, block):
                 Symbol(base.name),
                 Symbol(d_m.name),
                 Symbol(d_p.name),
-                Byref(f.indexify([0])),
+                f.indexify([0]),
                 Literal('"%s"' % f._C_typedata),
                 Literal('"%s"' % f.name)
             )

--- a/devito/ops/transformer.py
+++ b/devito/ops/transformer.py
@@ -162,7 +162,7 @@ def create_ops_dat(f, name_to_ops_dat, block):
                 Symbol(base.name),
                 Symbol(d_m.name),
                 Symbol(d_p.name),
-                Byref(f.indexify([i])),
+                f.indexify([i]),
                 Literal('"%s"' % f._C_typedata),
                 Literal('"%s"' % name)
             ))
@@ -194,7 +194,7 @@ def create_ops_dat(f, name_to_ops_dat, block):
                 Symbol(base.name),
                 Symbol(d_m.name),
                 Symbol(d_p.name),
-                Byref(f.indexify([0])),
+                f.indexify([0]),
                 Literal('"%s"' % f._C_typedata),
                 Literal('"%s"' % f.name)
             )
@@ -269,10 +269,14 @@ def create_ops_arg(p, name_to_ops_dat, par_to_ops_stencil):
             namespace['ops_read']
         )
     else:
-        if p.origin.is_TimeFunction:
+        if p._origin.is_TimeFunction:
+            from devito.types.basic import AbstractCachedFunction  # noqa
+
+            print(name_to_ops_dat[p._origin.name], type(name_to_ops_dat[p._origin.name]))
+            print(isinstance(name_to_ops_dat[p._origin.name], AbstractCachedFunction))
             # This is a parameter generated from TimeFunction
             return namespace['ops_arg_dat'](
-                name_to_ops_dat[p.origin.name].indexify([p.time_index]),
+                name_to_ops_dat[p._origin.name].indexify([p._origin_time_index]),
                 1,
                 par_to_ops_stencil[p],
                 Literal('"%s"' % dtype_to_cstr(p.dtype)),

--- a/devito/ops/transformer.py
+++ b/devito/ops/transformer.py
@@ -215,7 +215,7 @@ def create_ops_fetch(f, name_to_ops_dat, time_upper_bound):
                                     (f.name,
                                      f.indices[f._time_position],
                                      i)].base, Mod(Add(time_upper_bound, -i), f._time_size)),
-            Byref(f.indexify([Add(time_upper_bound, -i)])))
+            Byref(f.indexify([Mod(Add(time_upper_bound, -i), f._time_size)])))
             for i in range(f._time_size)]
     else:
         ops_fetch = [namespace['ops_dat_fetch_data'](

--- a/devito/ops/transformer.py
+++ b/devito/ops/transformer.py
@@ -172,7 +172,7 @@ def create_ops_dat(f, name_to_ops_dat, block):
             ListInitializer(dat_decls)
         )))
 
-        # Insering the ops_dat array in case of TimeFunction.
+        # Inserting the ops_dat array in case of TimeFunction.
         name_to_ops_dat[f.name] = ops_dat_array
 
     else:
@@ -270,10 +270,6 @@ def create_ops_arg(p, name_to_ops_dat, par_to_ops_stencil):
         )
     else:
         if p._origin.is_TimeFunction:
-            from devito.types.basic import AbstractCachedFunction  # noqa
-
-            print(name_to_ops_dat[p._origin.name], type(name_to_ops_dat[p._origin.name]))
-            print(isinstance(name_to_ops_dat[p._origin.name], AbstractCachedFunction))
             # This is a parameter generated from TimeFunction
             return namespace['ops_arg_dat'](
                 name_to_ops_dat[p._origin.name].indexify([p._origin_time_index]),

--- a/devito/ops/transformer.py
+++ b/devito/ops/transformer.py
@@ -157,7 +157,7 @@ def create_ops_dat(f, name_to_ops_dat, block):
                 Symbol(base.name),
                 Symbol(d_m.name),
                 Symbol(d_p.name),
-                f.indexify([i]),
+                Byref(f.indexify([i])),
                 Literal('"%s"' % f._C_typedata),
                 Literal('"%s"' % name)
             ))
@@ -189,7 +189,7 @@ def create_ops_dat(f, name_to_ops_dat, block):
                 Symbol(base.name),
                 Symbol(d_m.name),
                 Symbol(d_p.name),
-                f.indexify([0]),
+                Byref(f.indexify([0])),
                 Literal('"%s"' % f._C_typedata),
                 Literal('"%s"' % f.name)
             )

--- a/devito/ops/transformer.py
+++ b/devito/ops/transformer.py
@@ -265,21 +265,17 @@ def create_ops_arg(p, accessible_origin, name_to_ops_dat, par_to_ops_stencil):
     else:
         accessible_info = accessible_origin[p.name]
 
-        if accessible_info.time:
-            return namespace['ops_arg_dat'](
-                name_to_ops_dat[accessible_info.origin_name].indexify(
-                    [accessible_info.time]),
-                1,
-                par_to_ops_stencil[p],
-                Literal('"%s"' % dtype_to_cstr(p.dtype)),
-                namespace['ops_read'] if p.read_only else namespace['ops_write'])
-        else:
-            return namespace['ops_arg_dat'](
-                name_to_ops_dat[p.name],
-                1,
-                par_to_ops_stencil[p],
-                Literal('"%s"' % dtype_to_cstr(p.dtype)),
-                namespace['ops_read'] if p.read_only else namespace['ops_write'])
+        dat_name = name_to_ops_dat[p.name] \
+            if accessible_info.time is None \
+            else name_to_ops_dat[accessible_info.origin_name].\
+            indexify([accessible_info.time])
+
+        return namespace['ops_arg_dat'](
+            dat_name,
+            1,
+            par_to_ops_stencil[p],
+            Literal('"%s"' % dtype_to_cstr(p.dtype)),
+            namespace['ops_read'] if p.read_only else namespace['ops_write'])
 
 
 def make_ops_ast(expr, nfops, is_write=False):

--- a/devito/ops/transformer.py
+++ b/devito/ops/transformer.py
@@ -13,7 +13,7 @@ from devito.ops.types import Array, OpsAccessible, OpsDat, OpsStencil
 from devito.ops.utils import namespace
 from devito.symbolics import Add, Byref, ListInitializer, Literal
 from devito.tools import dtype_to_cstr
-from devito.types import Constant, DefaultDimension, Indexed, Symbol
+from devito.types import Constant, DefaultDimension, Symbol
 
 
 def opsit(trees, count, name_to_ops_dat, block, dims):

--- a/devito/ops/transformer.py
+++ b/devito/ops/transformer.py
@@ -210,21 +210,15 @@ def create_ops_dat(f, name_to_ops_dat, block):
 def create_ops_fetch(f, name_to_ops_dat, time_upper_bound):
 
     if f.is_TimeFunction:
+        ops_fetch = [namespace['ops_dat_fetch_data'](
+            Indexed(name_to_ops_dat['%s%s%s' %
+                                    (f.name,
+                                     f.indices[f._time_position],
+                                     i)].base, Mod(Add(time_upper_bound, -i),
+                                                   f._time_size)),
+            Indexed(f.indexed, Mod(Add(time_upper_bound, -i), f._time_size)))
+            for i in range(f._time_size)]
 
-        ops_fetch = []
-        for i in range(f._time_size):
-            dim = Mod(Add(time_upper_bound, -i), f._time_size)
-            dim_symbol = Symbol(name="time_%s%s" % (f.name, str(i)), dtype=np.int32)
-
-            ops_fetch.append(Expression(ClusterizedEq(Eq(dim_symbol, dim))))
-
-            ops_fetch.append(namespace['ops_dat_fetch_data'](
-                Indexed(name_to_ops_dat['%s%s%s' %
-                                        (f.name,
-                                         f.indices[f._time_position],
-                                         i)].
-                        base, dim_symbol),
-                Byref(f.indexify([dim_symbol]))))
     else:
         ops_fetch = [namespace['ops_dat_fetch_data'](
             name_to_ops_dat[f.name], Byref(f.indexify([0])))]

--- a/devito/ops/types.py
+++ b/devito/ops/types.py
@@ -31,15 +31,15 @@ class OpsAccessible(basic.Symbol):
     """
     is_Scalar = True
 
-    def __new__(cls, name, dtype, read_only, * args, **kwargs):
+    def __new__(cls, name, dtype, read_only, origin, origin_time_index, * args, **kwargs):
         obj = basic.Symbol.__new__(cls, name, dtype, *args, **kwargs)
-        obj.__init__(name, dtype, read_only, origin, time_index, *args, **kwargs)
+        obj.__init__(name, dtype, read_only, origin, origin_time_index, *args, **kwargs)
         return obj
 
-    def __init__(self, name, dtype, read_only, origin, time_index, * args, **kwargs):
+    def __init__(self, name, dtype, read_only, origin, origin_time_index, * args, **kwargs):
         self.read_only = read_only
-        self.origin = origin
-        self.time_index = time_index
+        self._origin = origin
+        self._origin_time_index = origin_time_index
         super().__init__(name, dtype, *args, **kwargs)
 
     @property
@@ -56,6 +56,9 @@ class OpsAccessible(basic.Symbol):
     @property
     def _C_typedata(self):
         return 'ACC<%s>' % dtype_to_cstr(self.dtype)
+
+    def ops_id(self):
+        return '%s%s' % (self._origin.name, self._origin_time_index)
 
 
 class OpsAccess(basic.Basic, sympy.Basic):
@@ -141,7 +144,7 @@ class OpsBlock(basic.Symbol):
         return namespace['ops_block_type']
 
 
-class OpsDat(basic.Symbol):
+class OpsDat(basic.LocalObject):
 
     def __init__(self, name, *args, **kwargs):
         super().__init__(name, np.void, *args, **kwargs)

--- a/devito/ops/types.py
+++ b/devito/ops/types.py
@@ -31,7 +31,7 @@ class OpsAccessible(basic.Symbol):
     """
     is_Scalar = True
 
-    def __new__(cls, name, dtype, read_only, * args, **kwargs):
+    def __new__(cls, name, dtype, read_only, *args, **kwargs):
         obj = basic.Symbol.__new__(cls, name, dtype, *args, **kwargs)
         obj.__init__(name, dtype, read_only, *args, **kwargs)
         return obj

--- a/devito/ops/types.py
+++ b/devito/ops/types.py
@@ -31,13 +31,15 @@ class OpsAccessible(basic.Symbol):
     """
     is_Scalar = True
 
-    def __new__(cls, name, dtype, read_only, *args, **kwargs):
+    def __new__(cls, name, dtype, read_only, origin, time_index, * args, **kwargs):
         obj = basic.Symbol.__new__(cls, name, dtype, *args, **kwargs)
-        obj.__init__(name, dtype, read_only, *args, **kwargs)
+        obj.__init__(name, dtype, read_only, origin, time_index, *args, **kwargs)
         return obj
 
-    def __init__(self, name, dtype, read_only, *args, **kwargs):
+    def __init__(self, name, dtype, read_only, origin, time_index, * args, **kwargs):
         self.read_only = read_only
+        self.origin = origin
+        self.time_index = time_index
         super().__init__(name, dtype, *args, **kwargs)
 
     @property

--- a/devito/ops/types.py
+++ b/devito/ops/types.py
@@ -31,16 +31,15 @@ class OpsAccessible(basic.Symbol):
     """
     is_Scalar = True
 
-    def __new__(cls, name, dtype, read_only, origin, origin_time_index, * args, **kwargs):
+    def __new__(cls, name, dtype, read_only, * args, **kwargs):
         obj = basic.Symbol.__new__(cls, name, dtype, *args, **kwargs)
-        obj.__init__(name, dtype, read_only, origin, origin_time_index, *args, **kwargs)
+        obj.__init__(name, dtype, read_only, *args, **kwargs)
         return obj
 
-    def __init__(self, name, dtype, read_only, origin, origin_time_index, *args,
-                 **kwargs):
+    def __init__(self, name, dtype, read_only, *args, **kwargs):
         self.read_only = read_only
-        self._origin = origin
-        self._origin_time_index = origin_time_index
+        self._time_access = None
+        self._origin_name = None
         super().__init__(name, dtype, *args, **kwargs)
 
     @property
@@ -58,8 +57,13 @@ class OpsAccessible(basic.Symbol):
     def _C_typedata(self):
         return 'ACC<%s>' % dtype_to_cstr(self.dtype)
 
-    def ops_id(self):
-        return '%s%s' % (self._origin.name, self._origin_time_index)
+    @property
+    def time_access(self):
+        return self._time_access
+
+    @property
+    def origin_name(self):
+        return self._origin_name
 
 
 class OpsAccess(basic.Basic, sympy.Basic):

--- a/devito/ops/types.py
+++ b/devito/ops/types.py
@@ -36,7 +36,8 @@ class OpsAccessible(basic.Symbol):
         obj.__init__(name, dtype, read_only, origin, origin_time_index, *args, **kwargs)
         return obj
 
-    def __init__(self, name, dtype, read_only, origin, origin_time_index, * args, **kwargs):
+    def __init__(self, name, dtype, read_only, origin, origin_time_index, *args,
+                 **kwargs):
         self.read_only = read_only
         self._origin = origin
         self._origin_time_index = origin_time_index

--- a/devito/ops/types.py
+++ b/devito/ops/types.py
@@ -38,8 +38,6 @@ class OpsAccessible(basic.Symbol):
 
     def __init__(self, name, dtype, read_only, *args, **kwargs):
         self.read_only = read_only
-        self._time_access = None
-        self._origin_name = None
         super().__init__(name, dtype, *args, **kwargs)
 
     @property
@@ -56,14 +54,6 @@ class OpsAccessible(basic.Symbol):
     @property
     def _C_typedata(self):
         return 'ACC<%s>' % dtype_to_cstr(self.dtype)
-
-    @property
-    def time_access(self):
-        return self._time_access
-
-    @property
-    def origin_name(self):
-        return self._origin_name
 
 
 class OpsAccess(basic.Basic, sympy.Basic):

--- a/devito/ops/types.py
+++ b/devito/ops/types.py
@@ -139,7 +139,7 @@ class OpsBlock(basic.Symbol):
         return namespace['ops_block_type']
 
 
-class OpsDat(basic.LocalObject):
+class OpsDat(basic.Symbol):
 
     def __init__(self, name, *args, **kwargs):
         super().__init__(name, np.void, *args, **kwargs)

--- a/devito/ops/types.py
+++ b/devito/ops/types.py
@@ -31,15 +31,15 @@ class OpsAccessible(basic.Symbol):
     """
     is_Scalar = True
 
-    def __new__(cls, name, dtype, read_only, origin, time_index, * args, **kwargs):
+    def __new__(cls, name, dtype, read_only, origin, origin_time_index, * args, **kwargs):
         obj = basic.Symbol.__new__(cls, name, dtype, *args, **kwargs)
-        obj.__init__(name, dtype, read_only, origin, time_index, *args, **kwargs)
+        obj.__init__(name, dtype, read_only, origin, origin_time_index, *args, **kwargs)
         return obj
 
-    def __init__(self, name, dtype, read_only, origin, time_index, * args, **kwargs):
+    def __init__(self, name, dtype, read_only, origin, origin_time_index, * args, **kwargs):
         self.read_only = read_only
-        self.origin = origin
-        self.time_index = time_index
+        self._origin = origin
+        self._origin_time_index = origin_time_index
         super().__init__(name, dtype, *args, **kwargs)
 
     @property
@@ -56,6 +56,9 @@ class OpsAccessible(basic.Symbol):
     @property
     def _C_typedata(self):
         return 'ACC<%s>' % dtype_to_cstr(self.dtype)
+
+    def ops_id(self):
+        return '%s%s' % (self._origin.name, self._origin_time_index)
 
 
 class OpsAccess(basic.Basic, sympy.Basic):
@@ -141,7 +144,7 @@ class OpsBlock(basic.Symbol):
         return namespace['ops_block_type']
 
 
-class OpsDat(basic.Symbol):
+class OpsDat(basic.LocalObject):
 
     def __init__(self, name, *args, **kwargs):
         super().__init__(name, np.void, *args, **kwargs)

--- a/devito/ops/types.py
+++ b/devito/ops/types.py
@@ -33,11 +33,13 @@ class OpsAccessible(basic.Symbol):
 
     def __new__(cls, name, dtype, read_only, * args, **kwargs):
         obj = basic.Symbol.__new__(cls, name, dtype, *args, **kwargs)
-        obj.__init__(name, dtype, read_only, *args, **kwargs)
+        obj.__init__(name, dtype, read_only, origin, time_index, *args, **kwargs)
         return obj
 
-    def __init__(self, name, dtype, read_only, *args, **kwargs):
+    def __init__(self, name, dtype, read_only, origin, time_index, * args, **kwargs):
         self.read_only = read_only
+        self.origin = origin
+        self.time_index = time_index
         super().__init__(name, dtype, *args, **kwargs)
 
     @property

--- a/devito/ops/utils.py
+++ b/devito/ops/utils.py
@@ -13,6 +13,7 @@ namespace['ops_partition'] = 'ops_partition'
 namespace['ops_timing_output'] = 'ops_timing_output'
 namespace['ops_exit'] = 'ops_exit'
 namespace['ops_par_loop'] = 'ops_par_loop'
+namespace['ops_dat_fetch_data'] = 'ops_dat_fetch_data'
 
 namespace['ops_decl_stencil'] = Function(name='ops_decl_stencil')
 namespace['ops_decl_block'] = Function(name='ops_decl_block')

--- a/devito/ops/utils.py
+++ b/devito/ops/utils.py
@@ -1,4 +1,4 @@
-from collections import OrderedDict
+from collections import OrderedDict, namedtuple
 from sympy import Function
 
 from devito.ir.iet.nodes import Call
@@ -7,6 +7,7 @@ from devito.symbolics import Macro
 
 # OPS Conventions
 namespace = OrderedDict()
+AccessibleInfo = namedtuple('AccessibleInfo', ['accessible', 'time', 'origin_name'])
 
 # OPS API
 namespace['ops_init'] = 'ops_init'

--- a/devito/ops/utils.py
+++ b/devito/ops/utils.py
@@ -1,6 +1,7 @@
 from collections import OrderedDict
 from sympy import Function
 
+from devito.ir.iet.nodes import Call
 from devito.symbolics import Macro
 
 
@@ -13,7 +14,8 @@ namespace['ops_partition'] = 'ops_partition'
 namespace['ops_timing_output'] = 'ops_timing_output'
 namespace['ops_exit'] = 'ops_exit'
 namespace['ops_par_loop'] = 'ops_par_loop'
-namespace['ops_dat_fetch_data'] = 'ops_dat_fetch_data'
+namespace['ops_dat_fetch_data'] = lambda ops_dat, data: Call(
+    name='ops_dat_fetch_data', arguments=[ops_dat, 0, data])
 
 namespace['ops_decl_stencil'] = Function(name='ops_decl_stencil')
 namespace['ops_decl_block'] = Function(name='ops_decl_block')

--- a/devito/symbolics/extended_sympy.py
+++ b/devito/symbolics/extended_sympy.py
@@ -8,6 +8,7 @@ from sympy import Expr, Integer, Float, Function, Symbol
 from sympy.core.basic import _aresame
 from sympy.functions.elementary.trigonometric import TrigonometricFunction
 
+from devito.symbolics.printer import ccode
 from devito.tools import Pickable, as_tuple
 
 __all__ = ['FrozenExpr', 'Eq', 'CondEq', 'CondNe', 'Mul', 'Add', 'Pow', 'IntDiv',
@@ -303,9 +304,9 @@ class Byref(sympy.Expr, Pickable):
 
     def __str__(self):
         if self.base.is_Symbol:
-            return "&%s" % self.base
+            return "&%s" % ccode(self.base)
         else:
-            return "&(%s)" % self.base
+            return "&(%s)" % ccode(self.base)
 
     __repr__ = __str__
 

--- a/devito/symbolics/extended_sympy.py
+++ b/devito/symbolics/extended_sympy.py
@@ -9,7 +9,7 @@ from sympy.core.basic import _aresame
 from sympy.functions.elementary.trigonometric import TrigonometricFunction
 
 from devito.symbolics.printer import ccode
-from devito.tools import Pickable, as_tuple
+from devito.tools import Pickable, as_tuple, is_integer
 
 __all__ = ['FrozenExpr', 'Eq', 'CondEq', 'CondNe', 'Mul', 'Add', 'Pow', 'IntDiv',
            'FunctionFromPointer', 'FieldFromPointer', 'FieldFromComposite',
@@ -263,7 +263,7 @@ class ListInitializer(sympy.Expr, Pickable):
         for p in as_tuple(params):
             if isinstance(p, str):
                 args.append(Symbol(p))
-            elif isinstance(p, (int, np.integer)):
+            elif is_integer(p):
                 args.append(Integer(p))
             elif not isinstance(p, Expr):
                 raise ValueError("`params` must be an iterable of Expr or str")

--- a/devito/symbolics/extended_sympy.py
+++ b/devito/symbolics/extended_sympy.py
@@ -263,8 +263,8 @@ class ListInitializer(sympy.Expr, Pickable):
         for p in as_tuple(params):
             if isinstance(p, str):
                 args.append(Symbol(p))
-            elif isinstance(p, int):
-                args.append(p)
+            elif isinstance(p, (int, np.integer)):
+                args.append(Integer(p))
             elif not isinstance(p, Expr):
                 raise ValueError("`params` must be an iterable of Expr or str")
             else:

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -194,16 +194,16 @@ class TestOPSExpression(object):
             Literal('"u"')
         )
 
-        def test_create_ops_arg_constant(self):
-            a = Constant(name='*a')
+    def test_create_ops_arg_constant(self):
+        a = Constant(name='*a')
 
-            res = create_ops_arg(a, {}, {})
+        res = create_ops_arg(a, {}, {}, {})
 
-            assert type(res) == namespace['ops_arg_gbl']
-            assert str(res.args[0]) == str(Byref(Constant(name='a')))
-            assert res.args[1] == 1
-            assert res.args[2] == Literal('"%s"' % dtype_to_cstr(a.dtype))
-            assert res.args[3] == namespace['ops_read']
+        assert type(res) == namespace['ops_arg_gbl']
+        assert str(res.args[0]) == str(Byref(Constant(name='a')))
+        assert res.args[1] == 1
+        assert res.args[2] == Literal('"%s"' % dtype_to_cstr(a.dtype))
+        assert res.args[3] == namespace['ops_read']
 
     @pytest.mark.parametrize('read', [True, False])
     def test_create_ops_arg_function(self, read):

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -17,7 +17,7 @@ from devito.ops.node_factory import OPSNodeFactory  # noqa
 from devito.ops.transformer import create_ops_arg, create_ops_dat, make_ops_ast, to_ops_stencil  # noqa
 from devito.ops.types import OpsAccessible, OpsDat, OpsStencil, OpsBlock  # noqa
 from devito.ops.utils import namespace  # noqa
-from devito.symbolics import Byref, indexify, Literal  # noqa
+from devito.symbolics import Byref, Literal, indexify  # noqa
 from devito.tools import dtype_to_cstr  # noqa
 from devito.types import Buffer, Constant, Symbol  # noqa
 

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -133,14 +133,21 @@ class TestOPSExpression(object):
     @pytest.mark.parametrize('equation,expected', [
         ('Eq(u.forward, u + 1)',
          '[\'ops_dat u_dat[2] = {ops_decl_dat(block, 1, u_dim, u_base, u_d_m, u_d_p, '
-         '&(u[0]), "float", "ut0"), ops_decl_dat(block, 1, u_dim, u_base, u_d_m, u_d_p, '
-         '&(u[1]), "float", "ut1")}\']')
+         'u[0], "float", "ut0"), ops_decl_dat(block, 1, u_dim, u_base, u_d_m, u_d_p, '
+         'u[1], "float", "ut1")}\']'),
+        ('Eq(u.forward, u + v.dx)',
+         '[\'ops_dat u_dat[2] = {ops_decl_dat(block, 1, u_dim, u_base, u_d_m, u_d_p, '
+         'u[0], "float", "ut0"), ops_decl_dat(block, 1, u_dim, u_base, u_d_m, u_d_p, '
+         'u[1], "float", "ut1")}\','
+         '\'ops_dat v_dat;\','
+         '\'v_dat = ops_decl_dat(block, 1, v_dim, v_base, v_d_m, v_d_p, '
+         'v[0], "float", "v")\']')
     ])
     def test_create_ops_dat(self, equation, expected):
-        grid = Grid(shape=(4))
+        grid = Grid(shape=(4, 4))
 
         u = TimeFunction(name='u', grid=grid, space_order=2)  # noqa
-        v = Function(name='u', grid=grid, space_order=2)  # noqa
+        v = Function(name='v', grid=grid, space_order=2)  # noqa
 
         op = Operator(eval(equation))
 
@@ -182,7 +189,7 @@ class TestOPSExpression(object):
             Symbol(namespace['ops_dat_base'](u.name)),
             Symbol(namespace['ops_dat_d_m'](u.name)),
             Symbol(namespace['ops_dat_d_p'](u.name)),
-            Byref(u.indexify((0,))),
+            u.indexify((0,)),
             Literal('"%s"' % u._C_typedata),
             Literal('"u"')
         )
@@ -235,14 +242,14 @@ class TestOPSExpression(object):
     @pytest.mark.parametrize('equation,expected', [
         ('Eq(u.forward, u + 1)',
          '[\'ops_dat_fetch_data(u_dat[(time_M)%(2)],0,&(u[(time_M)%(2)]));\','
-         '\'ops_dat_fetch_data(u_dat[(time_M - 1)%(2)],0,&(u[(time_M - 1)%(2)]));\']'),
+         '\'ops_dat_fetch_data(u_dat[(time_M + 1)%(2)],0,&(u[(time_M + 1)%(2)]));\']'),
         ('Eq(v, v.dx + u)',
          '[\'ops_dat_fetch_data(v_dat[(time_M)%(2)],0,&(v[(time_M)%(2)]));\','
-         '\'ops_dat_fetch_data(v_dat[(time_M - 1)%(2)],0,&(v[(time_M - 1)%(2)]));\','
+         '\'ops_dat_fetch_data(v_dat[(time_M + 1)%(2)],0,&(v[(time_M + 1)%(2)]));\','
          '\'ops_dat_fetch_data(u_dat[(time_M)%(2)],0,&(u[(time_M)%(2)]));\','
-         '\'ops_dat_fetch_data(u_dat[(time_M - 1)%(2)],0,&(u[(time_M - 1)%(2)]));\']'),
+         '\'ops_dat_fetch_data(u_dat[(time_M + 1)%(2)],0,&(u[(time_M + 1)%(2)]));\']'),
     ])
-    def test_create_ops_dat_fetch_data(self, equation, expected):
+    def test_create_fetch_data(self, equation, expected):
 
         grid = Grid(shape=(4, 4))
 


### PR DESCRIPTION
**Add ops_dat_fetch_data call to the OPS backend**    

- This OPS API call is responsible to get data from the GPU and returning to the pointer allocated from Devito in the main memory.
- For all ops_dat created, it is then created an ops_dat_fetch_dat call, that will bring the result from the GPU.
- Modified Byref class to use ccode instead of plain str.
- Created new tests for this OPS feature and modified tests for ops_dat.
- Modified `ops_args` dictionary to hold more information about the `OpsAccessible` creation.
- Modified dict name_to_ops_dat to only have values that are OpsDat or Array of OpsDat, instead of also having Indexed.

**This is basically #927 + rebasing on top of latest master**