### PR TITLE
Adds one to dimension max-value in create_ops_par_loop

### DIFF
--- a/devito/ops/operator.py
+++ b/devito/ops/operator.py
@@ -108,4 +108,8 @@ class OperatorOPS(Operator):
 
     def _compile(self):
         if self._lib is None:
+<<<<<<< 67244a44c128716e87149ba3f0c5758cda9311d8
             self._compiler.prepare_ops(self._soname, str(self.ccode), str(self.hcode))
+=======
+            self._compiler.create_files(self._soname, str(self.ccode), str(self.hcode))
+>>>>>>> Simplifying the compiler, removing jit_compilation

--- a/devito/ops/operator.py
+++ b/devito/ops/operator.py
@@ -108,8 +108,4 @@ class OperatorOPS(Operator):
 
     def _compile(self):
         if self._lib is None:
-<<<<<<< 67244a44c128716e87149ba3f0c5758cda9311d8
             self._compiler.prepare_ops(self._soname, str(self.ccode), str(self.hcode))
-=======
-            self._compiler.create_files(self._soname, str(self.ccode), str(self.hcode))
->>>>>>> Simplifying the compiler, removing jit_compilation

--- a/devito/ops/transformer.py
+++ b/devito/ops/transformer.py
@@ -224,6 +224,8 @@ def create_ops_par_loop(trees, ops_kernel, parameters, block, name_to_ops_dat,
     for tree in trees:
         if isinstance(tree, IterationTree):
             for bounds in [it.bounds() for it in tree]:
+                # from IPython import embed
+                # embed()
                 it_range.extend(bounds[:-1]+(bounds[-1]+1,))
 
     range_array = Array(

--- a/devito/ops/transformer.py
+++ b/devito/ops/transformer.py
@@ -224,7 +224,7 @@ def create_ops_par_loop(trees, ops_kernel, parameters, block, name_to_ops_dat,
     for tree in trees:
         if isinstance(tree, IterationTree):
             for bounds in [it.bounds() for it in tree]:
-                it_range.extend(bounds)
+                it_range.extend(bounds[:-1]+(bounds[-1]+1,))
 
     range_array = Array(
         name='%s_range' % ops_kernel.name,

--- a/devito/ops/transformer.py
+++ b/devito/ops/transformer.py
@@ -4,7 +4,7 @@ import numpy as np
 from sympy import Mod
 from sympy.core.numbers import Zero
 
-from devito import Eq
+from devito import Eq, TimeFunction
 from devito.ir.equations import ClusterizedEq
 from devito.ir.iet.nodes import Call, Callable, Expression, IterationTree
 from devito.ir.iet.visitors import FindNodes
@@ -221,10 +221,13 @@ def create_ops_fetch(f, name_to_ops_dat, time_upper_bound):
 def create_ops_par_loop(trees, ops_kernel, parameters, block, name_to_ops_dat,
                         accessible_origin, par_to_ops_stencil, dims):
     it_range = []
+    devito_to_ops_indexer = 1
     for tree in trees:
         if isinstance(tree, IterationTree):
-            for bounds in [it.bounds() for it in tree]:
-                it_range.extend(bounds[:-1]+(bounds[-1]+1,))
+            for it in tree:
+                it_range.extend((it.dimensions[TimeFunction._time_position].extreme_min,
+                                it.dimensions[TimeFunction._time_position].extreme_max +
+                                devito_to_ops_indexer))
 
     range_array = Array(
         name='%s_range' % ops_kernel.name,

--- a/devito/ops/transformer.py
+++ b/devito/ops/transformer.py
@@ -224,8 +224,6 @@ def create_ops_par_loop(trees, ops_kernel, parameters, block, name_to_ops_dat,
     for tree in trees:
         if isinstance(tree, IterationTree):
             for bounds in [it.bounds() for it in tree]:
-                # from IPython import embed
-                # embed()
                 it_range.extend(bounds[:-1]+(bounds[-1]+1,))
 
     range_array = Array(

--- a/devito/ops/transformer.py
+++ b/devito/ops/transformer.py
@@ -4,7 +4,7 @@ import numpy as np
 from sympy import Mod
 from sympy.core.numbers import Zero
 
-from devito import Eq, TimeFunction
+from devito import Eq
 from devito.ir.equations import ClusterizedEq
 from devito.ir.iet.nodes import Call, Callable, Expression, IterationTree
 from devito.ir.iet.visitors import FindNodes
@@ -224,10 +224,8 @@ def create_ops_par_loop(trees, ops_kernel, parameters, block, name_to_ops_dat,
     devito_to_ops_indexer = 1
     for tree in trees:
         if isinstance(tree, IterationTree):
-            for it in tree:
-                it_range.extend((it.dimensions[TimeFunction._time_position].extreme_min,
-                                it.dimensions[TimeFunction._time_position].extreme_max +
-                                devito_to_ops_indexer))
+            for i in tree:
+                it_range.extend([i.symbolic_min, i.symbolic_max + devito_to_ops_indexer])
 
     range_array = Array(
         name='%s_range' % ops_kernel.name,

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -239,6 +239,18 @@ class TestOPSExpression(object):
         operator = Operator(eval(equation))
         assert expected in str(operator.ccode)
 
+    @pytest.mark.parametrize('equation, expected', [
+        ('Eq(u.forward, u+1)',
+         'int OPS_Kernel_0_range[4] = {x_m, x_M + 1, y_m, y_M + 1};')
+    ])
+    def test_upper_bound(self, equation, expected):
+        grid = Grid((5,5))
+        u = TimeFunction(name='u', grid=grid)
+        
+        op = Operator(eval(equation))
+
+        assert expected in str(op.ccode)
+
     @pytest.mark.parametrize('equation,expected', [
         ('Eq(u_2d.forward, u_2d + 1)',
          '[\'ops_dat_fetch_data(u_dat[(time_M)%(2)],0,&(u[(time_M)%(2)]));\','
@@ -281,3 +293,4 @@ class TestOPSExpression(object):
 
         for i in eval(expected):
             assert i in str(op)
+

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -244,9 +244,8 @@ class TestOPSExpression(object):
          'int OPS_Kernel_0_range[4] = {x_m, x_M + 1, y_m, y_M + 1};')
     ])
     def test_upper_bound(self, equation, expected):
-        grid = Grid((5,5))
-        u = TimeFunction(name='u', grid=grid)
-        
+        grid = Grid((5, 5))
+        u = TimeFunction(name='u', grid=grid) # noqa
         op = Operator(eval(equation))
 
         assert expected in str(op.ccode)
@@ -293,4 +292,3 @@ class TestOPSExpression(object):
 
         for i in eval(expected):
             assert i in str(op)
-


### PR DESCRIPTION
Since ops iterates a loop until the value is < x_Max and devito iterates
a loop until the value is <= x_Max, we lose a value when going to OPS.
This commit solves this adding one to each dimension max-value, making
OPS iterate the ops_par_loop until the value is < x_Max + 1