### PR TITLE
ops: Avoided unwanted redeclaration when an Array is passed as a Call argument

### DIFF
--- a/devito/ir/iet/scheduler.py
+++ b/devito/ir/iet/scheduler.py
@@ -163,7 +163,7 @@ def iet_insert_decls(iet, external):
                     site = v if v else iet
                     allocator.push_object_on_stack(site[-1], i)
                 elif i.is_Array:
-                    if i in as_tuple(external):
+                    if i in as_tuple(external) or i._mem_external:
                         # The Array is defined in some other IET
                         continue
                     elif i._mem_stack:

--- a/devito/ops/transformer.py
+++ b/devito/ops/transformer.py
@@ -231,7 +231,7 @@ def create_ops_par_loop(trees, ops_kernel, parameters, block, name_to_ops_dat,
         dimensions=(DefaultDimension(
             name='range', default_value=len(it_range)),),
         dtype=np.int32,
-        allocation='external'
+        scope='external'
     )
 
     range_array_init = Expression(ClusterizedEq(Eq(

--- a/devito/ops/transformer.py
+++ b/devito/ops/transformer.py
@@ -231,7 +231,7 @@ def create_ops_par_loop(trees, ops_kernel, parameters, block, name_to_ops_dat,
         dimensions=(DefaultDimension(
             name='range', default_value=len(it_range)),),
         dtype=np.int32,
-        scope='stack'
+        allocation='external'
     )
 
     range_array_init = Expression(ClusterizedEq(Eq(

--- a/devito/ops/types.py
+++ b/devito/ops/types.py
@@ -9,6 +9,14 @@ from devito.ops.utils import namespace
 
 class Array(basic.Array):
 
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._allocation = kwargs.get('allocation')
+
+    @property
+    def _mem_external(self):
+        return self._allocation == 'external'
+
     @property
     def _C_typedata(self):
         if isinstance(self.dtype, str):

--- a/devito/ops/types.py
+++ b/devito/ops/types.py
@@ -9,14 +9,6 @@ from devito.ops.utils import namespace
 
 class Array(basic.Array):
 
-    def __init__(self, *args, **kwargs):
-        super().__init__(*args, **kwargs)
-        self._allocation = kwargs.get('allocation')
-
-    @property
-    def _mem_external(self):
-        return self._allocation == 'external'
-
     @property
     def _C_typedata(self):
         if isinstance(self.dtype, str):

--- a/devito/types/basic.py
+++ b/devito/types/basic.py
@@ -816,7 +816,7 @@ class Array(AbstractCachedFunction):
             super(Array, self).__init__(*args, **kwargs)
 
             self._scope = kwargs.get('scope', 'heap')
-            assert self._scope in ['heap', 'stack']
+            assert self._scope in ['heap', 'stack', 'external']
 
     def __padding_setup__(self, **kwargs):
         padding = kwargs.get('padding')
@@ -876,6 +876,10 @@ class Array(AbstractCachedFunction):
         return self._scope == 'heap'
 
     @property
+    def _mem_external(self):
+        return self._scope == 'external'
+
+    @property
     def _C_typename(self):
         return ctypes_to_cstr(POINTER(dtype_to_ctype(self.dtype)))
 
@@ -890,7 +894,7 @@ class Array(AbstractCachedFunction):
         self._halo = kwargs.get('halo', self._halo)
         self._padding = kwargs.get('padding', self._padding)
         self._scope = kwargs.get('scope', self._scope)
-        assert self._scope in ['heap', 'stack']
+        assert self._scope in ['heap', 'stack', 'external']
 
     # Pickling support
     _pickle_kwargs = AbstractCachedFunction._pickle_kwargs + ['dimensions', 'scope']


### PR DESCRIPTION
**This implementation is avoiding to create a third type for _scope.**

For the backend OPS, we are creating an Array and passing it as an argument to a Call, generating unnecessary alignment.
```
int OPS_Kernel_0_range[4] = {x_m, x_M, y_m, y_M};
for (int time = time_m, t0 = (time)%(3), t1 = (time + 1)%(3), t2 = (time + 2)%(3); .....)
{
   int OPS_Kernel_0_range[4] __attribute__((aligned(64)));
   ops_par_loop(..., (int *)OPS_Kernel_0_range, ...);
}
```

allocation should be True if the associated data was/is/will be allocated directly from Python.