### PR TITLE
Optimize MPI computation/communication overlap

### DIFF
--- a/devito/dle/rewriters.py
+++ b/devito/dle/rewriters.py
@@ -427,8 +427,8 @@ class PlatformRewriter(AbstractRewriter):
                     except IndexError:
                         # Fallback: use the outermost Iteration
                         candidate = tree.root
-                    mapper[candidate] = candidate._rebuild(nodes=((prodder._rebuild(),) +
-                                                                  candidate.nodes))
+                    mapper[candidate] = candidate._rebuild(nodes=(candidate.nodes +
+                                                                  (prodder._rebuild(),)))
                     mapper[prodder] = None
 
         iet = Transformer(mapper, nested=True).visit(iet)

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -820,11 +820,11 @@ class TestCodeGeneration(object):
 
         trees = retrieve_iteration_tree(op._func_table['compute0'].root)
         assert len(trees) == 2
-        tree = trees[1]
-        # Make sure `pokempi0` is within the outer Iteration
+        tree = trees[0]
+        # Make sure `pokempi0` is the last node within the outer Iteration
         assert len(tree) == 2
         assert len(tree.root.nodes) == 2
-        call = tree.root.nodes[0]
+        call = tree.root.nodes[1]
         assert call.name == 'pokempi0'
         assert call.arguments[0].name == 'msg0'
 
@@ -834,10 +834,10 @@ class TestCodeGeneration(object):
         trees = retrieve_iteration_tree(op._func_table['bf0'].root)
         assert len(trees) == 2
         tree = trees[1]
-        # Make sure `pokempi0` is within the inner Iteration over blocks
-        assert len(tree) == 4
+        # Make sure `pokempi0` is the last node within the inner Iteration over blocks
+        assert len(tree) == 2
         assert len(tree.root.nodes[0].nodes) == 2
-        call = tree.root.nodes[0].nodes[0]
+        call = tree.root.nodes[0].nodes[1]
         assert call.name == 'pokempi0'
         assert call.arguments[0].name == 'msg0'
 

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -830,6 +830,8 @@ class TestCodeGeneration(object):
         try:
             # W/ OpenMP, we prod until all comms have completed
             assert call.then_body[0].body[0].is_While
+            # W/ OpenMP, we expect dynamic thread scheduling
+            assert 'dynamic,1' in tree.root.pragmas[0].value
             assert configuration['openmp']
         except AttributeError:
             # W/o OpenMP, it's a different story
@@ -851,6 +853,8 @@ class TestCodeGeneration(object):
         try:
             # W/ OpenMP, we prod until all comms have completed
             assert call.then_body[0].body[0].is_While
+            # W/ OpenMP, we expect dynamic thread scheduling
+            assert 'dynamic,1' in tree.root.pragmas[0].value
             assert configuration['openmp']
         except AttributeError:
             # W/o OpenMP, it's a different story

--- a/tests/test_mpi.py
+++ b/tests/test_mpi.py
@@ -827,16 +827,14 @@ class TestCodeGeneration(object):
         call = tree.root.nodes[1]
         assert call.name == 'pokempi0'
         assert call.arguments[0].name == 'msg0'
-        try:
+        if configuration['openmp']:
             # W/ OpenMP, we prod until all comms have completed
             assert call.then_body[0].body[0].is_While
             # W/ OpenMP, we expect dynamic thread scheduling
             assert 'dynamic,1' in tree.root.pragmas[0].value
-            assert configuration['openmp']
-        except AttributeError:
+        else:
             # W/o OpenMP, it's a different story
             assert call._single_thread
-            assert not configuration['openmp']
 
         # Now we do as before, but enforcing loop blocking (by default off,
         # as heuristically it is not enabled when the Iteration nest has depth < 3)
@@ -850,16 +848,14 @@ class TestCodeGeneration(object):
         call = tree.root.nodes[0].nodes[1]
         assert call.name == 'pokempi0'
         assert call.arguments[0].name == 'msg0'
-        try:
+        if configuration['openmp']:
             # W/ OpenMP, we prod until all comms have completed
             assert call.then_body[0].body[0].is_While
             # W/ OpenMP, we expect dynamic thread scheduling
             assert 'dynamic,1' in tree.root.pragmas[0].value
-            assert configuration['openmp']
-        except AttributeError:
+        else:
             # W/o OpenMP, it's a different story
             assert call._single_thread
-            assert not configuration['openmp']
 
 
 class TestOperatorAdvanced(object):


### PR DESCRIPTION
Improve the `DEVITO_MPI=full` mode such that:

- one OpenMP thread continuously prods the asynchronous progress engine until all comms have finished
- dynamic scheduling is used in place of static if we are prodding

tests updated and enriched accoringly

EDIT: yes, this makes the code go faster according to my measurements 