### PR TITLE
RFC: revisit symbolic processing

### DIFF
--- a/devito/finite_differences/differentiable.py
+++ b/devito/finite_differences/differentiable.py
@@ -1,4 +1,5 @@
 from collections import ChainMap
+from functools import singledispatch
 
 import sympy
 from sympy.functions.elementary.integers import floor
@@ -186,20 +187,88 @@ class Differentiable(sympy.Expr, Evaluable):
         return super(Differentiable, self)._has(pattern)
 
 
-class Add(sympy.Add, Differentiable):
-    pass
+class DifferentiableOp(Differentiable):
+
+    def __new__(cls, *args, **kwargs):
+        obj = cls.__base__.__new__(cls, *args, **kwargs)
+
+        # Unfortunately SymPy may build new sympy.core objects (e.g., sympy.Add),
+        # so here we have to rebuild them as devito.core objects
+        obj = Rebuild.evaluate(obj)
+
+        return obj
 
 
-class Mul(sympy.Mul, Differentiable):
-    pass
+class Add(sympy.Add, DifferentiableOp):
+    __new__ = DifferentiableOp.__new__
 
 
-class Pow(sympy.Pow, Differentiable):
-    pass
+class Mul(sympy.Mul, DifferentiableOp):
+    __new__ = DifferentiableOp.__new__
 
 
-class Mod(sympy.Mod, Differentiable):
-    pass
+class Pow(sympy.Pow, DifferentiableOp):
+    __new__ = DifferentiableOp.__new__
+
+
+class Mod(sympy.Mod, DifferentiableOp):
+    __new__ = DifferentiableOp.__new__
+
+
+class Rebuild(object):
+
+    """
+    Helper class based on single dispatch to reconstruct all nodes in a sympy
+    tree such they are all of type Differentiable.
+    """
+
+    def evaluate(obj):
+        args = [Rebuild._doit(i) for i in obj.args]
+        obj = Rebuild._doit(obj, args)
+        return obj
+
+    def _doit(obj, args=None):
+        cls = Rebuild._cls(obj)
+        if cls is obj.__class__:
+            return obj
+
+        args = args or obj.args
+        newobj = cls(*args, evaluate=False)
+
+        # SymPy objects pretend to be immutable, but in reality they are not.
+        # As facts are deduced, a SymPy core object's ``_assumptions`` data
+        # structure is updated. Since here we use ``evaluate=False`` all over
+        # the place, we have to explicitly reassign the ``_assumptions``.
+        newobj._assumptions = obj._assumptions
+
+        return newobj
+
+    @singledispatch
+    def _cls(obj):
+        return obj.__class__
+
+    @_cls.register(sympy.Add)
+    def _(obj):
+        return Add
+
+    @_cls.register(sympy.Mul)
+    def _(obj):
+        return Mul
+
+    @_cls.register(sympy.Pow)
+    def _(obj):
+        return Pow
+
+    @_cls.register(sympy.Mod)
+    def _(obj):
+        return Mod
+
+    @_cls.register(Add)
+    @_cls.register(Mul)
+    @_cls.register(Pow)
+    @_cls.register(Mod)
+    def _(obj):
+        return obj.__class__
 
 
 # Make sure `sympy.evalf` knows how to evaluate the inherited classes
@@ -210,16 +279,3 @@ class Mod(sympy.Mod, Differentiable):
 evalf_table[Add] = evalf_table[sympy.Add]
 evalf_table[Mul] = evalf_table[sympy.Mul]
 evalf_table[Pow] = evalf_table[sympy.Pow]
-
-
-# Monkey-patch sympy.Mul/sympy.Add/sympy.Pow/...'s __new__ so that we can
-# return a devito.Mul/devito.Add/devito.Pow if any of the arguments is
-# of type Differentiable
-def __new__(cls, *args, **options):
-    if cls in __new__.table and any(isinstance(i, Differentiable) for i in args):
-        return __new__.__real_new__(__new__.table[cls], *args, **options)
-    else:
-        return __new__.__real_new__(cls, *args, **options)
-__new__.table = {getattr(sympy, i.__name__): i for i in [Add, Mul, Pow, Mod]}  # noqa
-__new__.__real_new__ = sympy.Basic.__new__
-sympy.Basic.__new__ = __new__

--- a/tests/test_dse.py
+++ b/tests/test_dse.py
@@ -625,7 +625,7 @@ def test_tti_rewrite_aggressive_wmpi():
 
 @switchconfig(profiling='advanced')
 @pytest.mark.parametrize('space_order,expected', [
-    (8, 152), (16, 268)
+    (8, 154), (16, 270)
 ])
 def test_tti_rewrite_aggressive_opcounts(space_order, expected):
     operator = tti_operator(dse='aggressive', space_order=space_order)


### PR DESCRIPTION
@mloubout after all, I think monkey-patching sympy.Basic is too horrible, even if it works. So I'm here resurrecting one of your former approaches -- rebuilding as devito core types upon sympy.flatten. There are a few differences w.r.t. what you did:

- technically, this is now based on the single dispatch pattern
- only the immediate children are reconstructed
- the sympy assumptions are propagated too





