### PR TITLE
Fix sympy type 

### DIFF
--- a/devito/dse/rewriters.py
+++ b/devito/dse/rewriters.py
@@ -15,7 +15,7 @@ from devito.exceptions import DSEException
 from devito.logger import dse_warning as warning
 from devito.symbolics import (bhaskara_cos, bhaskara_sin, estimate_cost, freeze,
                               iq_timeinvariant, pow_to_mul, q_leaf, q_sum_of_product,
-                              q_scalar, q_terminalop, xreplace_constrained)
+                              q_terminalop, xreplace_constrained)
 from devito.tools import flatten, generator
 from devito.types import Array, Scalar
 
@@ -123,7 +123,7 @@ class BasicRewriter(AbstractRewriter):
         for e in cluster.exprs:
             if e.is_Increment and e.lhs.function.is_Input:
                 handle = Scalar(name=template(), dtype=e.dtype).indexify()
-                if q_scalar(e.rhs):
+                if e.rhs.is_Number or e.rhs.is_Symbol:
                     extracted = e.rhs
                 else:
                     extracted = e.rhs.func(*[i for i in e.rhs.args if i != e.lhs])

--- a/devito/finite_differences/differentiable.py
+++ b/devito/finite_differences/differentiable.py
@@ -194,7 +194,9 @@ class DifferentiableOp(Differentiable):
 
         # Unfortunately SymPy may build new sympy.core objects (e.g., sympy.Add),
         # so here we have to rebuild them as devito.core objects
-        obj = diffify(obj)
+        # Check if already processed and don't diffify again
+        if kwargs.get('diffify', True):
+            obj = diffify(obj)
 
         return obj
 
@@ -234,11 +236,13 @@ class diffify(object):
 
     def _doit(obj, args=None):
         cls = diffify._cls(obj)
-        if cls is obj.__class__:
+        # Only keep object if arfs don't need to be replaced
+        if cls is obj.__class__ and args is None:
             return obj
 
         args = args or obj.args
-        newobj = cls(*args, evaluate=False)
+        # Already processed so don't diffify again
+        newobj = cls(*args, evaluate=False, diffify=False)
 
         # SymPy objects pretend to be immutable, but in reality they are not.
         # As facts are deduced, a SymPy core object's ``_assumptions`` data

--- a/devito/finite_differences/differentiable.py
+++ b/devito/finite_differences/differentiable.py
@@ -246,9 +246,7 @@ class diffify(object):
                 return obj
 
         # Create object directly from args, avoid any rebuild
-        newobj = cls(*args, evaluate=False)
-
-        return newobj
+        return cls(*args, evaluate=False)
 
     @singledispatch
     def _cls(obj):

--- a/devito/ops/types.py
+++ b/devito/ops/types.py
@@ -112,6 +112,9 @@ class OpsAccess(basic.Basic, sympy.Basic):
     def as_coeff_Add(self):
         return sympy.S.Zero, self
 
+    def as_ordered_factors(self):
+        return (self,)
+
     __repr__ = __str__
 
 

--- a/devito/symbolics/queries.py
+++ b/devito/symbolics/queries.py
@@ -23,7 +23,10 @@ The following SymPy objects are considered as tree leaves: ::
 
 
 def q_scalar(expr):
-    return getattr(expr, 'is_Scalar', False)
+    try:
+        return expr.is_Scalar
+    except AttributeError:
+        return False
 
 
 def q_leaf(expr):

--- a/devito/symbolics/queries.py
+++ b/devito/symbolics/queries.py
@@ -23,7 +23,7 @@ The following SymPy objects are considered as tree leaves: ::
 
 
 def q_scalar(expr):
-    return expr.is_Number or expr.is_Symbol
+    return getattr(expr, 'is_Scalar', False)
 
 
 def q_leaf(expr):

--- a/devito/symbolics/search.py
+++ b/devito/symbolics/search.py
@@ -1,8 +1,9 @@
 from devito.symbolics.queries import (q_indexed, q_function, q_terminal, q_leaf, q_xop,
-                                      q_trigonometry)
+                                      q_trigonometry, q_scalar)
 
 __all__ = ['retrieve_indexed', 'retrieve_functions', 'retrieve_function_carriers',
-           'retrieve_terminals', 'retrieve_xops', 'retrieve_trigonometry', 'search']
+           'retrieve_terminals', 'retrieve_xops', 'retrieve_trigonometry', 'search',
+           'retrieve_scalars']
 
 
 class Search(object):
@@ -129,6 +130,11 @@ def retrieve_indexed(expr, mode='all', deep=False):
 def retrieve_functions(expr, mode='all'):
     """Shorthand to retrieve the DiscreteFunctions in ``expr``."""
     return search(expr, q_function, mode, 'dfs')
+
+
+def retrieve_scalars(expr, mode='all'):
+    """Shorthand to retrieve the Scalar in ``expr``."""
+    return search(expr, q_scalar, mode, 'dfs')
 
 
 def retrieve_function_carriers(expr, mode='all'):

--- a/tests/test_differentiable.py
+++ b/tests/test_differentiable.py
@@ -1,0 +1,41 @@
+import sympy
+from devito import Function, Grid, Differentiable
+from devito.finite_differences.differentiable import Add, Mul, Pow, diffify
+
+
+def test_differentiable():
+    a = Function(name="a", grid=Grid((10, 10)))
+    e = Function(name="e", grid=Grid((10, 10)))
+
+    assert isinstance(1.2 * a.dx, Mul)
+    assert isinstance(e + a, Add)
+    assert isinstance(e * a, Mul)
+    assert isinstance(a * a, Pow)
+    assert isinstance(1 / (a * a), Pow)
+
+    addition = a + 1.2 * a.dx
+    assert isinstance(addition, Add)
+    assert all(isinstance(a, Differentiable) for a in addition.args)
+
+    addition2 = a + e * a.dx
+    assert isinstance(addition2, Add)
+    assert all(isinstance(a, Differentiable) for a in addition2.args)
+
+
+def test_diffify():
+    a = Function(name="a", grid=Grid((10, 10)))
+    e = Function(name="e", grid=Grid((10, 10)))
+
+    assert isinstance(diffify(sympy.Mul(*[1.2, a.dx])), Mul)
+    assert isinstance(diffify(sympy.Add(*[a, e])), Add)
+    assert isinstance(diffify(sympy.Mul(*[e, a])), Mul)
+    assert isinstance(diffify(sympy.Mul(*[a, a])), Pow)
+    assert isinstance(diffify(sympy.Pow(*[a*a, -1])), Pow)
+
+    addition = diffify(sympy.Add(*[a, sympy.Mul(*[1.2, a.dx])]))
+    assert isinstance(addition, Add)
+    assert all(isinstance(a, Differentiable) for a in addition.args)
+
+    addition2 = diffify(sympy.Add(*[a, sympy.Mul(*[e, a.dx])]))
+    assert isinstance(addition2, Add)
+    assert all(isinstance(a, Differentiable) for a in addition2.args)

--- a/tests/test_dse.py
+++ b/tests/test_dse.py
@@ -645,7 +645,7 @@ def test_tti_rewrite_aggressive_wmpi():
 
 @switchconfig(profiling='advanced')
 @pytest.mark.parametrize('space_order,expected', [
-    (8, 152), (16, 268)
+    (8, 154), (16, 270)
 ])
 def test_tti_rewrite_aggressive_opcounts(space_order, expected):
     operator = tti_operator(dse='aggressive', space_order=space_order)
@@ -655,7 +655,7 @@ def test_tti_rewrite_aggressive_opcounts(space_order, expected):
 
 @switchconfig(profiling='advanced')
 @pytest.mark.parametrize('space_order,expected', [
-    (4, 185), (12, 377)
+    (4, 183), (12, 375)
 ])
 def test_tti_v2_rewrite_aggressive_opcounts(space_order, expected):
     grid = Grid(shape=(3, 3, 3))
@@ -701,4 +701,4 @@ def test_tti_v2_rewrite_aggressive_opcounts(space_order, expected):
 
 
 if __name__ == "__main__":
-    test_tti_v2_rewrite_aggressive_opcounts(4, 185)
+    test_tti_v2_rewrite_aggressive_opcounts(4, 183)

--- a/tests/test_dse.py
+++ b/tests/test_dse.py
@@ -701,4 +701,4 @@ def test_tti_v2_rewrite_aggressive_opcounts(space_order, expected):
 
 
 if __name__ == "__main__":
-    test_tti_rewrite_aggressive_opcounts(16, 270)
+    test_tti_v2_rewrite_aggressive_opcounts(4, 185)

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -30,15 +30,15 @@ class TestOPSExpression(object):
         ('Eq(u, u.dxl)',
          'void OPS_Kernel_0(ACC<float> & ut0, const float *h_x)\n'
          '{\n  float r0 = 1.0/*h_x;\n  '
-         'ut0(0) = -2.0F*ut0(-1)*r0 + 5.0e-1F*ut0(-2)*r0 + 1.5F*ut0(0)*r0;\n}'),
+         'ut0(0) = (-2.0F*ut0(-1) + 5.0e-1F*ut0(-2) + 1.5F*ut0(0))*r0;\n}'),
         ('Eq(v,1)', 'void OPS_Kernel_0(ACC<float> & vt0)\n'
          '{\n  vt0(0, 0) = 1;\n}'),
         ('Eq(v,v.dxl + v.dxr - v.dyr - v.dyl)',
          'void OPS_Kernel_0(ACC<float> & vt0, const float *h_x, const float *h_y)\n'
          '{\n  float r1 = 1.0/*h_y;\n  float r0 = 1.0/*h_x;\n  '
-         'vt0(0, 0) = 5.0e-1F*(-vt0(2, 0)*r0 + vt0(-2, 0)*r0 - '
-         'vt0(0, -2)*r1 + vt0(0, 2)*r1) + 2.0F*(-vt0(-1, 0)*r0 + '
-         'vt0(1, 0)*r0 - vt0(0, 1)*r1 + vt0(0, -1)*r1);\n}'),
+         'vt0(0, 0) = (5.0e-1F*(-vt0(2, 0) + vt0(-2, 0)) + 2.0F*(-vt0(-1, 0) + '
+         'vt0(1, 0)))*r0 + (5.0e-1F*(-vt0(0, -2) + vt0(0, 2)) + '
+         '2.0F*(-vt0(0, 1) + vt0(0, -1)))*r1;\n}'),
         ('Eq(v,v**2 - 3*v)',
          'void OPS_Kernel_0(ACC<float> & vt0)\n'
          '{\n  vt0(0, 0) = -3*vt0(0, 0) + vt0(0, 0)*vt0(0, 0);\n}'),
@@ -57,9 +57,9 @@ class TestOPSExpression(object):
          '{\n  float r2 = 1.0/*dt;\n'
          '  float r1 = 1.0/(*h_y**h_y);\n'
          '  float r0 = 1.0/(*h_x**h_x);\n'
-         '  vt1(0, 0) = 2*vt1(0, 0)*r2 + 2.0F*(vt0(0, 0)*r0 + vt0(0, 0)*r1) - '
-         '(vt0(1, 0)*r0 + vt0(-1, 0)*r0 + vt0(0, 1)*r1 + vt0(0, -1)*r1 + '
-         '2*vt0(0, 0)*r2);\n}'),
+         '  vt1(0, 0) = (-(vt0(1, 0) + vt0(-1, 0)) + 2.0F*vt0(0, 0))*r0 + '
+         '(-(vt0(0, 1) + vt0(0, -1)) + 2.0F*vt0(0, 0))*r1 + '
+         '2*(-vt0(0, 0) + vt1(0, 0))*r2;\n}'),
     ])
     def test_kernel_generation(self, equation, expected):
         """


### PR DESCRIPTION
Basically forces diffify to replace args at `doit` as currently it is ignored so eben if arguments are turned back to our type if the top class is our it ignores the replacement.