### PR TITLE
Better OpenMP

### DIFF
--- a/devito/dle/parallelizer.py
+++ b/devito/dle/parallelizer.py
@@ -96,7 +96,7 @@ class Ompizer(object):
         'for-dynamic-1': lambda i: c.Pragma('omp for collapse(%d) schedule(dynamic,1)'
                                             % i),
         'par-for': lambda i, j: c.Pragma('omp parallel for collapse(%d) '
-                                         'schedule(static,1) num_threads(%d)' % (i, j)),
+                                         'schedule(dynamic,1) num_threads(%d)' % (i, j)),
         'simd-for': c.Pragma('omp simd'),
         'simd-for-aligned': lambda i, j: c.Pragma('omp simd aligned(%s:%d)' % (i, j)),
         'atomic': c.Pragma('omp atomic update')
@@ -145,10 +145,7 @@ class Ompizer(object):
         # Nonaffine -> ... schedule(static) ...
         if omp_pragma is None:
             if all(i.is_Affine for i in candidates):
-                if FindNodes(Prodder).visit(root):
-                    omp_pragma = self.lang['for-dynamic-1']
-                else:
-                    omp_pragma = self.lang['for-static-1']
+                omp_pragma = self.lang['for-dynamic-1']
             else:
                 omp_pragma = self.lang['for-static']
 

--- a/devito/ir/iet/nodes.py
+++ b/devito/ir/iet/nodes.py
@@ -150,11 +150,11 @@ class ExprStmt(object):
     pass
 
 
-class Block(Node):
+class List(Node):
 
-    """A sequence of nodes, wrapped in a block {...}."""
+    """A sequence of Nodes."""
 
-    is_Block = True
+    is_List = True
 
     _traversable = ['body']
 
@@ -180,11 +180,11 @@ class Block(Node):
         return ()
 
 
-class List(Block):
+class Block(List):
 
-    """A sequence of nodes."""
+    """A sequence of Nodes, wrapped in a block {...}."""
 
-    is_List = True
+    is_Block = True
 
 
 class Element(Node):

--- a/devito/ir/iet/nodes.py
+++ b/devito/ir/iet/nodes.py
@@ -129,14 +129,22 @@ class Node(Signer):
         return (str(self.ccode),)
 
 
-# Some useful mixins
-
-
-class Simple(object):
+class ExprStmt(object):
 
     """
-    A mixin to decorate Nodes that do *not* contain other Nodes (IOW,
-    their ``_traversable`` list is empty).
+    A mixin for Nodes that represent C expression statements, which are expressions
+    followed by a semicolon. For example, the lines:
+
+        * i = 0;
+        * j = a[i] + 8;
+        * int a = 3;
+        * foo(b)
+
+    are all expression statements.
+
+    Notes
+    -----
+    An ExprStmt does *not* have children Nodes.
     """
 
     pass
@@ -197,7 +205,7 @@ class Element(Node):
         return "Element::\n\t%s" % (self.element)
 
 
-class Call(Simple, Node):
+class Call(ExprStmt, Node):
 
     """A function call."""
 
@@ -235,7 +243,7 @@ class Call(Simple, Node):
         return ()
 
 
-class Expression(Simple, Node):
+class Expression(ExprStmt, Node):
 
     """A node encapsulating a ClusterizedEq."""
 

--- a/devito/ir/iet/scheduler.py
+++ b/devito/ir/iet/scheduler.py
@@ -4,8 +4,8 @@ import cgen as c
 
 from devito.ir.iet import (ArrayCast, Expression, Increment, LocalExpression, Element,
                            Iteration, List, Conditional, Section, HaloSpot,
-                           ExpressionBundle, MapSections, Transformer, FindNodes,
-                           FindSymbols, XSubs, iet_analyze, filter_iterations)
+                           ExpressionBundle, Transformer, FindNodes, FindSymbols,
+                           MapExprStmts, XSubs, iet_analyze)
 from devito.symbolics import IntDiv, ccode, xreplace_indices
 from devito.tools import as_mapper, as_tuple
 from devito.types import ConditionalDimension
@@ -145,7 +145,7 @@ def iet_insert_decls(iet, external):
 
     # Classify and then schedule declarations to stack/heap
     allocator = Allocator()
-    for k, v in MapSections().visit(iet).items():
+    for k, v in MapExprStmts().visit(iet).items():
         if k.is_Expression:
             if k.is_definition:
                 # On the stack
@@ -168,9 +168,7 @@ def iet_insert_decls(iet, external):
                         continue
                     elif i._mem_stack:
                         # On the stack
-                        key = lambda i: not i.is_Parallel
-                        site = filter_iterations(v, key=key) or iet
-                        allocator.push_object_on_stack(site[-1], i)
+                        allocator.push_object_on_stack(iet[0], i)
                     else:
                         # On the heap
                         allocator.push_array_on_heap(i)

--- a/devito/ir/iet/visitors.py
+++ b/devito/ir/iet/visitors.py
@@ -91,7 +91,7 @@ class PrintAST(Visitor):
     def visit_tuple(self, o):
         return '\n'.join([self._visit(i) for i in o])
 
-    def visit_Block(self, o):
+    def visit_List(self, o):
         self._depth += 1
         if self.verbose:
             body = [self._visit(o.header), self._visit(o.body), self._visit(o.footer)]
@@ -553,7 +553,7 @@ class FindSymbols(Visitor):
         symbols += self.rule(o)
         return filter_sorted(symbols, key=attrgetter('name'))
 
-    visit_Block = visit_Iteration
+    visit_List = visit_Iteration
     visit_Conditional = visit_Iteration
 
     def visit_Expression(self, o):

--- a/devito/ir/iet/visitors.py
+++ b/devito/ir/iet/visitors.py
@@ -17,7 +17,7 @@ from devito.symbolics import ccode
 from devito.tools import GenericVisitor, as_tuple, filter_sorted, flatten
 
 
-__all__ = ['FindNodes', 'FindSections', 'FindSymbols', 'MapSections', 'MapNodes',
+__all__ = ['FindNodes', 'FindSections', 'FindSymbols', 'MapExprStmts', 'MapNodes',
            'IsPerfectIteration', 'XSubs', 'printAST', 'CGen', 'Transformer',
            'FindAdjacent']
 
@@ -402,7 +402,7 @@ class FindSections(Visitor):
         queue.remove(o)
         return ret
 
-    def visit_Simple(self, o, ret=None, queue=None):
+    def visit_ExprStmt(self, o, ret=None, queue=None):
         if ret is None:
             ret = self.default_retval()
         if queue is not None:
@@ -410,7 +410,7 @@ class FindSections(Visitor):
         return ret
 
     def visit_Conditional(self, o, ret=None, queue=None):
-        # Essentially like visit_Simple, but also go down through the children
+        # Essentially like visit_ExprStmt, but also go down through the children
         if ret is None:
             ret = self.default_retval()
         if queue is not None:
@@ -420,20 +420,22 @@ class FindSections(Visitor):
         return ret
 
 
-class MapSections(FindSections):
+class MapExprStmts(FindSections):
 
     """
-    Construct a mapper from Simple Nodes (i.e., Nodes that do *not* contain
-    other Nodes, such as Expressions and Calls) to the enclosing Iteration nest.
+    Construct a mapper from ExprStmts, i.e. expression statements such as Calls
+    and Expressions, to their enclosing block (e.g., Iteration, Block).
     """
 
-    def visit_Simple(self, o, ret=None, queue=None):
+    def visit_ExprStmt(self, o, ret=None, queue=None):
         if ret is None:
             ret = self.default_retval()
         ret[o] = as_tuple(queue)
         return ret
 
     visit_Conditional = FindSections.visit_Node
+
+    visit_Block = FindSections.visit_Iteration
 
 
 class MapNodes(Visitor):

--- a/tests/test_dle.py
+++ b/tests/test_dle.py
@@ -390,7 +390,7 @@ class TestNodeParallelism(object):
 
     def test_scheduling(self):
         """
-        Affine iterations -> #pragma omp ... schedule(static,1) ...
+        Affine iterations -> #pragma omp ... schedule(dynamic,1) ...
         Non-affine iterations -> #pragma omp ... schedule(static) ...
         """
         grid = Grid(shape=(11, 11))
@@ -406,7 +406,7 @@ class TestNodeParallelism(object):
         iterations = FindNodes(Iteration).visit(op)
         assert len(iterations) == 4
         assert iterations[1].is_Affine
-        assert 'schedule(static,1)' in iterations[1].pragmas[0].value
+        assert 'schedule(dynamic,1)' in iterations[1].pragmas[0].value
         assert not iterations[3].is_Affine
         assert 'schedule(static)' in iterations[3].pragmas[0].value
 
@@ -430,9 +430,9 @@ class TestNestedParallelism(object):
         assert np.all(u.data[0] == 10)
 
         iterations = FindNodes(Iteration).visit(op._func_table['bf0'])
-        assert iterations[0].pragmas[0].value == 'omp for collapse(1) schedule(static,1)'
+        assert iterations[0].pragmas[0].value == 'omp for collapse(1) schedule(dynamic,1)'
         assert iterations[2].pragmas[0].value ==\
-            ('omp parallel for collapse(1) schedule(static,1) num_threads(%d)'
+            ('omp parallel for collapse(1) schedule(dynamic,1) num_threads(%d)'
              % nhyperthreads())
 
     @patch("devito.dle.parallelizer.Ompizer.NESTED", 0)
@@ -453,9 +453,9 @@ class TestNestedParallelism(object):
         assert np.all(u.data[0] == 10)
 
         iterations = FindNodes(Iteration).visit(op._func_table['bf0'])
-        assert iterations[0].pragmas[0].value == 'omp for collapse(2) schedule(static,1)'
+        assert iterations[0].pragmas[0].value == 'omp for collapse(2) schedule(dynamic,1)'
         assert iterations[2].pragmas[0].value ==\
-            ('omp parallel for collapse(2) schedule(static,1) num_threads(%d)'
+            ('omp parallel for collapse(2) schedule(dynamic,1) num_threads(%d)'
              % nhyperthreads())
 
     @patch("devito.dse.rewriters.AdvancedRewriter.MIN_COST_ALIAS", 1)
@@ -478,12 +478,12 @@ class TestNestedParallelism(object):
 
         assert trees[0][0] is trees[1][0]
         assert trees[0][0].pragmas[0].value ==\
-            'omp for collapse(1) schedule(static,1)'
+            'omp for collapse(1) schedule(dynamic,1)'
         assert trees[0][2].pragmas[0].value ==\
-            ('omp parallel for collapse(1) schedule(static,1) num_threads(%d)'
+            ('omp parallel for collapse(1) schedule(dynamic,1) num_threads(%d)'
              % nhyperthreads())
         assert trees[1][2].pragmas[0].value ==\
-            ('omp parallel for collapse(1) schedule(static,1) num_threads(%d)'
+            ('omp parallel for collapse(1) schedule(dynamic,1) num_threads(%d)'
              % nhyperthreads())
 
 

--- a/tests/test_dle.py
+++ b/tests/test_dle.py
@@ -391,7 +391,7 @@ class TestNodeParallelism(object):
     def test_scheduling(self):
         """
         Affine iterations -> #pragma omp ... schedule(dynamic,1) ...
-        Non-affine iterations -> #pragma omp ... schedule(static) ...
+        Non-affine iterations -> #pragma omp ... schedule(dynamic,chunk_size) ...
         """
         grid = Grid(shape=(11, 11))
 
@@ -408,7 +408,7 @@ class TestNodeParallelism(object):
         assert iterations[1].is_Affine
         assert 'schedule(dynamic,1)' in iterations[1].pragmas[0].value
         assert not iterations[3].is_Affine
-        assert 'schedule(static)' in iterations[3].pragmas[0].value
+        assert 'schedule(dynamic,chunk_size)' in iterations[3].pragmas[0].value
 
 
 class TestNestedParallelism(object):

--- a/tests/test_dse.py
+++ b/tests/test_dse.py
@@ -39,9 +39,9 @@ def test_scheduling_after_rewrite():
     trees = retrieve_iteration_tree(op)
 
     # Check loop nest structure
-    assert len(trees) == 4
-    assert all(i.dim == j for i, j in zip(trees[0], grid.dimensions))  # time invariant
-    assert trees[1][0].dim == trees[2][0].dim == trees[3][0].dim == grid.time_dim
+    assert all(i.dim is j for i, j in zip(trees[0], grid.dimensions))  # time invariant
+    assert trees[1].root.dim is grid.time_dim
+    assert all(trees[1].root.dim is tree.root.dim for tree in trees[1:])
 
 
 @pytest.mark.parametrize('exprs,expected', [

--- a/tests/test_operator.py
+++ b/tests/test_operator.py
@@ -1299,7 +1299,7 @@ class TestLoopScheduling(object):
         for e in exprs:
             eqns.append(eval(e))
 
-        op = Operator(eqns, dse='noop', dle='noop')
+        op = Operator(eqns, dse='noop', dle=('noop', {'openmp': False}))
 
         trees = retrieve_iteration_tree(op)
         iters = FindNodes(Iteration).visit(op)
@@ -1513,7 +1513,9 @@ class TestLoopScheduling(object):
         eqn3 = Eq(u2.forward, u2 + 2*u2.backward - u1.dt2)
         eqn4 = sf2.interpolate(u2)
 
-        op = Operator([eqn1] + eqn2 + [eqn3] + eqn4)
+        # Note: DLE disabled only because with OpenMP otherwise there might be more
+        # `trees` than 4
+        op = Operator([eqn1] + eqn2 + [eqn3] + eqn4, dle=('noop', {'openmp': False}))
         trees = retrieve_iteration_tree(op)
         assert len(trees) == 4
         # Time loop not shared due to the WAR
@@ -1523,7 +1525,7 @@ class TestLoopScheduling(object):
 
         # Now single, shared time loop expected
         eqn2 = sf1.inject(u1.forward, expr=sf1)
-        op = Operator([eqn1] + eqn2 + [eqn3] + eqn4)
+        op = Operator([eqn1] + eqn2 + [eqn3] + eqn4, dle=('noop', {'openmp': False}))
         trees = retrieve_iteration_tree(op)
         assert len(trees) == 4
         assert all(trees[0][0] is i[0] for i in trees)


### PR DESCRIPTION
Two main things:

- use `schedule(dynamic,1)` for FD loops (delivers better performance than `schedule(static,1)` on all tested xeons)
- use `schedule(dynamic,chunk_size)` for sparse loops, where `chunk_size` is `number_of_iterations / (nthreads * alpha)` where `alpha` is currently set to 3 (found empirically)

Would appreciate some performance testing

