### PR TITLE
Replace ops fetch memories call

### DIFF
--- a/devito/ops/transformer.py
+++ b/devito/ops/transformer.py
@@ -222,18 +222,18 @@ def create_ops_memory_fetch(f, name_to_ops_dat, par_to_ops_stencil, accessibles_
     ----------
     f : Function or TimeFunction
         Devito object that was transfered into the device memory.
-    name_to_ops_dat : dict of {str : :class:`devito.ops.types.OpsDat`}
+    name_to_ops_dat : dict of {str : OpsDat}
         Given a variable name, get the associated OpsDat object.
-    par_to_ops_stencil : dict of {str : :class:`devito.ops.types.OpsStencil`}
+    par_to_ops_stencil : dict of {str : OpsStencil}
         Link an OpsAccessible name to its OpsStencil variable.
-    accessibles_info : dict of {str : :namedTuple:`devito.ops.types.Accessible_info`}
+    accessibles_info : dict of {str : Accessible_info}
         Contains the time variable used.
-    memspace : :class:`devito.ops.types.OpsMemSpace`
+    memspace : OpsMemSpace
         Specify which memory space should the data be transfered into.
 
     Returns
     ------
-    :class:`devito.ir.iet.nodes.Call`
+    Call
         The actual call to `ops_dat_get_raw_pointer` method from OPS API.
     """
     # Get the OpsDat associated with a Function or TimeFunction f.

--- a/devito/ops/transformer.py
+++ b/devito/ops/transformer.py
@@ -224,9 +224,8 @@ def create_ops_memory_fetch(f, name_to_ops_dat, par_to_ops_stencil, accessibles_
         Devito object that was transfered into the device memory.
     name_to_ops_dat : dict of {str : :class:`devito.ops.types.OpsDat`}
         Given a variable name, get the associated OpsDat object.
-    par_to_ops_stencil : dict of {:class:`devito.ops.types.OpsAccessible` :
-                                  :class:`devito.ops.types.OpsStencil`}
-        Link an OpsAccessible to its OpsStencil variable.
+    par_to_ops_stencil : dict of {str : :class:`devito.ops.types.OpsStencil`}
+        Link an OpsAccessible name to its OpsStencil variable.
     accessibles_info : dict of {str : :namedTuple:`devito.ops.types.Accessible_info`}
         Contains the time variable used.
     memspace : :class:`devito.ops.types.OpsMemSpace`
@@ -248,13 +247,13 @@ def create_ops_memory_fetch(f, name_to_ops_dat, par_to_ops_stencil, accessibles_
     if f.is_TimeFunction:
         return [namespace['ops_memory_fetch'](ops_dat(v.time),
                                               ops_stencil(v.accessible.name),
-                                              memspace.expr.lhs)
+                                              Byref(memspace.expr.lhs))
                 for k, v in accessibles_info.items() if v.origin_name == f.name]
 
     else:
         return [namespace['ops_memory_fetch'](ops_dat(0),
                                               ops_stencil(f.name),
-                                              memspace.expr.lhs)]
+                                              Byref(memspace.expr.lhs))]
 
 
 def create_ops_par_loop(trees, ops_kernel, parameters, block, name_to_ops_dat,

--- a/devito/ops/types.py
+++ b/devito/ops/types.py
@@ -148,11 +148,15 @@ class OpsMemSpace(basic.LocalObject):
         return namespace['ops_memspace_type']
 
 
-class OpsDat(basic.LocalObject):
+class OpsDat(basic.Symbol):
 
     def __init__(self, name, *args, **kwargs):
         super().__init__(name, np.void, *args, **kwargs)
 
     @property
-    def _C_typename(self):
+    def _C_typedata(self):
         return namespace['ops_dat_type']
+
+    @property
+    def _C_typename(self):
+        return self._C_typedata

--- a/devito/ops/types.py
+++ b/devito/ops/types.py
@@ -138,15 +138,18 @@ class OpsStencil(basic.Symbol):
         return namespace['ops_stencil_type']
 
 
-class OpsMemSpace(basic.LocalObject):
+class OpsMemSpace(basic.Symbol):
 
     def __init__(self, name, *args, **kwargs):
         super().__init__(name, np.void, *args, **kwargs)
 
     @property
-    def _C_typename(self):
+    def _C_typedata(self):
         return namespace['ops_memspace_type']
 
+    @property
+    def _C_typename(self):
+        return self._C_typedata
 
 class OpsDat(basic.Symbol):
 

--- a/devito/ops/types.py
+++ b/devito/ops/types.py
@@ -128,14 +128,24 @@ class OpsBlock(basic.Symbol):
         return namespace['ops_block_type']
 
 
-class OpsStencil(basic.LocalObject):
+class OpsStencil(basic.Symbol):
+
+    def __init__(self, name, *args, **kwargs):
+        super().__init__(name, np.void, *args, **kwargs)
+
+    @property
+    def _C_typedata(self):
+        return namespace['ops_stencil_type']
+
+
+class OpsMemSpace(basic.LocalObject):
 
     def __init__(self, name, *args, **kwargs):
         super().__init__(name, np.void, *args, **kwargs)
 
     @property
     def _C_typename(self):
-        return namespace['ops_stencil_type']
+        return namespace['ops_memspace_type']
 
 
 class OpsDat(basic.LocalObject):

--- a/devito/ops/utils.py
+++ b/devito/ops/utils.py
@@ -17,7 +17,7 @@ OpsDatDecl = namedtuple(
 
 OpsArgDecl = namedtuple(
     'OpsArgDecl',
-    ['ops_type', 'ops_name', 'elements_per_point', 'dtype', 'rw_flag'])
+    ['ops_type', 'ops_name', 'elements_per_point', 'ops_stencil', 'dtype', 'rw_flag'])
 
 # OPS API
 namespace['ops_init'] = 'ops_init'
@@ -25,8 +25,8 @@ namespace['ops_partition'] = 'ops_partition'
 namespace['ops_timing_output'] = 'ops_timing_output'
 namespace['ops_exit'] = 'ops_exit'
 namespace['ops_par_loop'] = 'ops_par_loop'
-namespace['ops_dat_fetch_data'] = lambda ops_dat, data: Call(
-    name='ops_dat_fetch_data', arguments=[ops_dat, 0, data])
+namespace['ops_memory_fetch'] = lambda ops_dat, ops_stencil, memspace: Call(
+    name='ops_dat_get_raw_pointer', arguments=[ops_dat, 0, ops_stencil, memspace])
 
 namespace['ops_decl_stencil'] = Function(name='ops_decl_stencil')
 namespace['ops_decl_block'] = Function(name='ops_decl_block')
@@ -40,6 +40,7 @@ namespace['ops_write'] = Macro('OPS_WRITE')
 namespace['ops_stencil_type'] = 'ops_stencil'
 namespace['ops_block_type'] = 'ops_block'
 namespace['ops_dat_type'] = 'ops_dat'
+namespace['ops_memspace_type'] = 'ops_memspace'
 
 # Naming conventions
 namespace['ops_define_dimension'] = lambda i: '#define OPS_%sD' % i
@@ -50,3 +51,4 @@ namespace['ops_dat_base'] = lambda i: '%s_base' % i
 namespace['ops_dat_d_p'] = lambda i: '%s_d_p' % i
 namespace['ops_dat_d_m'] = lambda i: '%s_d_m' % i
 namespace['ops_dat_name'] = lambda i: '%s_dat' % i
+namespace['ops_memspace_name'] = 'memspace'

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -278,30 +278,9 @@ class TestOPSExpression(object):
 
     @pytest.mark.parametrize('equation,expected', [
         ('Eq(u_2d.forward, u_2d + 1)',
-         '[\'ops_dat_fetch_data(u_dat[(time_M)%(2)],0,&(u[(time_M)%(2)]));\','
-         '\'ops_dat_fetch_data(u_dat[(time_M + 1)%(2)],0,&(u[(time_M + 1)%(2)]));\']'),
-        ('Eq(v_2d, v_2d.dt.dx + u_2d.dt)',
-         '[\'ops_dat_fetch_data(v_dat[(time_M)%(3)],0,&(v[(time_M)%(3)]));\','
-         '\'ops_dat_fetch_data(v_dat[(time_M + 1)%(3)],0,&(v[(time_M + 1)%(3)]));\','
-         '\'ops_dat_fetch_data(v_dat[(time_M + 2)%(3)],0,&(v[(time_M + 2)%(3)]));\','
-         '\'ops_dat_fetch_data(u_dat[(time_M)%(2)],0,&(u[(time_M)%(2)]));\','
-         '\'ops_dat_fetch_data(u_dat[(time_M + 1)%(2)],0,&(u[(time_M + 1)%(2)]));\']'),
-        ('Eq(v_3d.forward, v_3d + 1)',
-         '[\'ops_dat_fetch_data(v_dat[(time_M)%(3)],0,&(v[(time_M)%(3)]));\','
-         '\'ops_dat_fetch_data(v_dat[(time_M + 2)%(3)],0,&(v[(time_M + 2)%(3)]));\','
-         '\'ops_dat_fetch_data(v_dat[(time_M + 1)%(3)],0,&(v[(time_M + 1)%(3)]));\']'),
-        ('Eq(x_3d, x_3d.dt2 + v_3d.dt.dx + u_3d.dxr - u_3d.dxl)',
-         '[\'ops_dat_fetch_data(x_dat[(time_M)%(4)],0,&(x[(time_M)%(4)]));\','
-         '\'ops_dat_fetch_data(x_dat[(time_M + 3)%(4)],0,&(x[(time_M + 3)%(4)]));\','
-         '\'ops_dat_fetch_data(x_dat[(time_M + 2)%(4)],0,&(x[(time_M + 2)%(4)]));\','
-         '\'ops_dat_fetch_data(x_dat[(time_M + 1)%(4)],0,&(x[(time_M + 1)%(4)]));\','
-         '\'ops_dat_fetch_data(v_dat[(time_M)%(3)],0,&(v[(time_M)%(3)]));\','
-         '\'ops_dat_fetch_data(v_dat[(time_M + 2)%(3)],0,&(v[(time_M + 2)%(3)]));\','
-         '\'ops_dat_fetch_data(v_dat[(time_M + 1)%(3)],0,&(v[(time_M + 1)%(3)]));\','
-         '\'ops_dat_fetch_data(u_dat[(time_M)%(2)],0,&(u[(time_M)%(2)]));\','
-         '\'ops_dat_fetch_data(u_dat[(time_M + 1)%(2)],0,&(u[(time_M + 1)%(2)]));\']')
-    ])
-    def test_create_fetch_data(self, equation, expected):
+         '[\'ops_dat_get_raw_pointer(u_dat[0],0,S2D_UT0_1PT,&memspace);\','
+         '\'ops_memspace memspace=OPS_HOST\']')])
+    def test_memory_transfer_call(self, equation, expected):
 
         grid_2d = Grid(shape=(4, 4))
         grid_3d = Grid(shape=(4, 4, 4))

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -265,11 +265,9 @@ class TestOPSExpression(object):
         ('Eq(u_2d.forward, u_2d + 1)',
             '[\'ops_dat_get_raw_pointer(u_dat[t0],0,S2D_UT0_1PT,&memspace);\','
             '\'ops_dat_get_raw_pointer(u_dat[t1],0,S2D_UT1_1PT,&memspace);\','
-            '\'ops_memspace memspace;\','
-            '\'memspace = OPS_HOST;\']'),
+            '\'ops_memspace memspace = OPS_HOST;\']'),
         ('Eq(v_3d.backward, v_3d.dt2 + b_3d)',
-            '[\'memspace = OPS_HOST;\','
-            '\'ops_memspace memspace;\','
+            '[\'ops_memspace memspace = OPS_HOST;\','
             '\'ops_dat_get_raw_pointer(v_dat[t5],0,S3D_VT5_1PT,&memspace);\','
             '\'ops_dat_get_raw_pointer(v_dat[t6],0,S3D_VT6_1PT,&memspace);\','
             '\'ops_dat_get_raw_pointer(v_dat[t7],0,S3D_VT7_1PT,&memspace);\','

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -142,29 +142,14 @@ class TestOPSExpression(object):
     @pytest.mark.parametrize('equation,expected', [
         ('Eq(u.forward, u + 1)',
          '[\'ops_dat u_dat[2] = {ops_decl_dat(block, 1, u_dim, u_base, u_d_m, u_d_p, '
-         '&(u[0]), "float", "ut0"), ops_decl_dat(block, 1, u_dim, u_base, u_d_m, u_d_p, '
-         '&(u[1]), "float", "ut1")}\']'),
+         '&(u[0][0][0]), "float", "ut0"), ops_decl_dat(block, 1, u_dim, u_base, u_d_m, u_d_p, ' # noqa
+         '&(u[1][0][0]), "float", "ut1")}\']'),
         ('Eq(u.forward, u + v.dx)',
          '[\'ops_dat u_dat[2] = {ops_decl_dat(block, 1, u_dim, u_base, u_d_m, u_d_p, '
-         '&(u[0]), "float", "ut0"), ops_decl_dat(block, 1, u_dim, u_base, u_d_m, u_d_p, '
-         '&(u[1]), "float", "ut1")}\','
-         '\'ops_dat v_dat;\','
-         '\'v_dat = ops_decl_dat(block, 1, v_dim, v_base, v_d_m, v_d_p, '
-         '&(v[0]), "float", "v")\']'),
-        ('Eq(w1.forward, w1 + 1)',
-         '[\'ops_dat w1_dat[2] = {ops_decl_dat(block, 1, w1_dim, w1_base, w1_d_m, '
-         'w1_d_p, &(w1[0]), "float", "w1time0"), ops_decl_dat(block, 1, w1_dim, '
-         'w1_base, w1_d_m, w1_d_p, &(w1[1]), "float", "w1time1")}\']'),
-        ('Eq(w2.forward, w2 + v.dx)',
-         '[\'ops_dat w2_dat[5] = {ops_decl_dat(block, 1, w2_dim, w2_base, w2_d_m, '
-         'w2_d_p, &(w2[0]), "float", "w2time0"), ops_decl_dat(block, 1, w2_dim, w2_base, '
-         'w2_d_m, w2_d_p, &(w2[1]), "float", "w2time1"), ops_decl_dat(block, 1, w2_dim, '
-         'w2_base, w2_d_m, w2_d_p, &(w2[2]), "float", "w2time2"), ops_decl_dat(block, 1, '
-         'w2_dim, w2_base, w2_d_m, w2_d_p, &(w2[3]), "float", "w2time3"), ops_decl_dat('
-         'block, 1, w2_dim, w2_base, w2_d_m, w2_d_p, &(w2[4]), "float", "w2time4")}\','
-         '\'ops_dat v_dat;\','
-         '\'v_dat = ops_decl_dat(block, 1, v_dim, v_base, v_d_m, v_d_p, '
-         '&(v[0]), "float", "v")\']')
+         '&(u[0][0][0]), "float", "ut0"), ops_decl_dat(block, 1, u_dim, u_base, u_d_m, u_d_p, ' # noqa
+         '&(u[1][0][0]), "float", "ut1")}\','
+         '\'ops_dat v_dat = ops_decl_dat(block, 1, v_dim, v_base, v_d_m, v_d_p, '
+         '&(v[0][0]), "float", "v")\']')
     ])
     def test_create_ops_dat(self, equation, expected):
         grid = Grid(shape=(4, 4))
@@ -279,7 +264,7 @@ class TestOPSExpression(object):
     @pytest.mark.parametrize('equation,expected', [
         ('Eq(u_2d.forward, u_2d + 1)',
          '[\'ops_dat_get_raw_pointer(u_dat[0],0,S2D_UT0_1PT,&memspace);\','
-         '\'ops_memspace memspace=OPS_HOST\']')])
+          '\'ops_memspace memspace = OPS_HOST;\']')])
     def test_memory_transfer_call(self, equation, expected):
 
         grid_2d = Grid(shape=(4, 4))

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -289,6 +289,6 @@ class TestOPSExpression(object):
         b_3d = Function(name='b', grid=grid_3d)                     # noqa
 
         op = Operator(eval(equation))
-        print(op)
+
         for i in eval(expected):
             assert i in str(op)


### PR DESCRIPTION
Instead of using the OPS API method `ops_dat_fetch_data` to get data from GPU, we are now using `ops_dat_get_raw_pointer` method. Because the first method do not bring back the data from the halo region.