### PR TITLE
nthreads2 for nonaffine loops

### DIFF
--- a/devito/archinfo.py
+++ b/devito/archinfo.py
@@ -187,8 +187,8 @@ class Platform(object):
 
 class Cpu64(Platform):
 
-    # The known isas ​​will be overwritten in the specialized classes
-    known_isas = tuple()
+    # The known ISAs will be overwritten in the specialized classes
+    known_isas = ()
 
     def _detect_isa(self):
         for i in reversed(self.known_isas):
@@ -227,6 +227,7 @@ class Device(Platform):
 
 # CPUs
 CPU64 = Cpu64('cpu64')
+CPU64_DUMMY = Intel64('cpu64-dummy', cores_logical=2, cores_physical=1, isa='sse')
 INTEL64 = Intel64('intel64')
 SNB = Intel64('snb')
 IVB = Intel64('ivb')
@@ -244,6 +245,7 @@ NVIDIAX = Device('nvidiax')
 
 
 platform_registry = {
+    'cpu64-dummy': CPU64_DUMMY,
     'intel64': INTEL64,
     'snb': SNB,
     'ivb': IVB,

--- a/devito/core/autotuning.py
+++ b/devito/core/autotuning.py
@@ -99,7 +99,7 @@ def autotune(operator, args, level, mode):
             tunable.append(generate_nthreads(operator.nthreads, args, level))
             tunable = list(product(*tunable))
         except ValueError:
-            # Some arguments are cumpolsory, otherwise autotuning is skipped
+            # Some arguments are compulsory, otherwise autotuning is skipped
             continue
 
         # Symbolic number of loop-blocking blocks per thread

--- a/devito/core/operator.py
+++ b/devito/core/operator.py
@@ -40,7 +40,7 @@ class OperatorCore(Operator):
 
     @property
     def nthreads(self):
-        nthreads = [i for i in self.input if isinstance(i, NThreads)]
+        nthreads = [i for i in self.input if type(i).__base__ is NThreads]
         if len(nthreads) == 0:
             return 1
         else:

--- a/devito/dle/__init__.py
+++ b/devito/dle/__init__.py
@@ -1,4 +1,5 @@
 from devito.dle.blocking_utils import *  # noqa
-from devito.dle.parallelizer import NThreads, Ompizer  # noqa
+from devito.dle.parallelizer import (NThreads, NThreadsNested,  # noqa
+                                     NThreadsNonaffine, Ompizer)
 from devito.dle.rewriters import *  # noqa
 from devito.dle.transformer import *  # noqa

--- a/devito/dle/blocking_utils.py
+++ b/devito/dle/blocking_utils.py
@@ -399,6 +399,8 @@ class IterationFold(Iteration):
 
 class BlockDimension(IncrDimension):
 
+    is_PerfKnob = True
+
     @cached_property
     def symbolic_min(self):
         return Scalar(name=self.min_name, dtype=np.int32, is_const=True)

--- a/devito/dle/parallelizer.py
+++ b/devito/dle/parallelizer.py
@@ -24,6 +24,8 @@ def nhyperthreads():
 
 class NThreadsMixin(object):
 
+    is_PerfKnob = True
+
     def __new__(cls, **kwargs):
         name = kwargs.get('name', cls.name)
         value = cls.default_value()

--- a/devito/dle/parallelizer.py
+++ b/devito/dle/parallelizer.py
@@ -29,23 +29,24 @@ class NThreadsMixin(object):
 class NThreads(Constant, NThreadsMixin):
 
     name = 'nthreads0'
-    aliases = (name, 'nthreads')
 
     @classmethod
     def default_value(cls):
         return int(os.environ.get('OMP_NUM_THREADS', ncores()))
 
     def __new__(cls, **kwargs):
-        name = kwargs.get('name', NThreads.name)
-        value = NThreads.default_value()
-        return super(NThreads, cls).__new__(cls, name=name, dtype=np.int32, value=value)
+        name = kwargs.get('name', cls.name)
+        value = cls.default_value()
+        obj = super(NThreads, cls).__new__(cls, name=name, dtype=np.int32, value=value)
+        obj.aliases = as_tuple(kwargs.get('aliases')) + (name,)
+        return obj
 
     @property
     def _arg_names(self):
-        return NThreads.aliases
+        return self.aliases
 
     def _arg_values(self, **kwargs):
-        for i in NThreads.aliases:
+        for i in self.aliases:
             if i in kwargs:
                 return {self.name: kwargs.pop(i)}
         # Fallback: as usual, pick the default value
@@ -61,10 +62,15 @@ class NThreadsNested(Constant, NThreadsMixin):
         return nhyperthreads()
 
     def __new__(cls, **kwargs):
-        name = kwargs.get('name', NThreadsNested.name)
+        name = kwargs.get('name', cls.name)
         value = NThreadsNested.default_value()
         return super(NThreadsNested, cls).__new__(cls, name=name, dtype=np.int32,
                                                   value=value)
+
+
+class NThreadsNonaffine(NThreads):
+
+    name = 'nthreads2'
 
 
 class ParallelRegion(Block):
@@ -78,10 +84,6 @@ class ParallelRegion(Block):
     def _make_header(cls, nthreads, private):
         private = ('private(%s)' % ','.join(private)) if private else ''
         return c.Pragma('omp parallel num_threads(%s) %s' % (nthreads.name, private))
-
-    @property
-    def functions(self):
-        return (self.nthreads,)
 
 
 class ParallelTree(List):
@@ -190,8 +192,9 @@ class Ompizer(object):
             self.key = key
         else:
             self.key = lambda i: i.is_ParallelRelaxed and not i.is_Vectorizable
-        self.nthreads = NThreads()
+        self.nthreads = NThreads(aliases='nthreads')
         self.nthreads_nested = NThreadsNested()
+        self.nthreads_nonaffine = NThreadsNonaffine()
 
     def _make_atomic_incs(self, partree):
         if not partree.is_ParallelAtomic:
@@ -249,6 +252,7 @@ class Ompizer(object):
         if all(i.is_Affine for i in candidates):
             if nthreads is None:
                 # pragma omp for ... schedule(..., 1)
+                nthreads = self.nthreads
                 omp_pragma = self.lang['for'](ncollapse, 1)
             else:
                 # pragma omp parallel for ... schedule(..., 1)
@@ -256,11 +260,13 @@ class Ompizer(object):
         else:
             # pragma omp for ... schedule(..., expr)
             assert nthreads is None
+            nthreads = self.nthreads_nonaffine
+
             chunk_size = Symbol(name='chunk_size')
             omp_pragma = self.lang['for'](ncollapse, chunk_size)
 
             niters = prod([root.symbolic_size] + [j.symbolic_size for j in collapsable])
-            value = INT(Max(niters / (self.nthreads*self.CHUNKSIZE_NONAFFINE), 1))
+            value = INT(Max(niters / (nthreads*self.CHUNKSIZE_NONAFFINE), 1))
             prefix.append(Expression(DummyEq(chunk_size, value, dtype=np.int32)))
 
         # Create a ParallelTree
@@ -277,7 +283,7 @@ class Ompizer(object):
         private = [i for i in FindSymbols().visit(partree)
                    if i.is_Array and i._mem_stack]
         private = sorted(set([i.name for i in private]))
-        return ParallelRegion(partree, self.nthreads, private)
+        return ParallelRegion(partree, partree.nthreads, private)
 
     def _make_guard(self, partree, collapsed):
         # Do not enter the parallel region if the step increment is 0; this

--- a/devito/logger.py
+++ b/devito/logger.py
@@ -4,7 +4,7 @@ import logging
 import sys
 from contextlib import contextmanager
 
-__all__ = ('set_log_level', 'set_log_noperf',
+__all__ = ('set_log_level', 'set_log_noperf', 'is_log_enabled_for',
            'log', 'warning', 'error', 'perf', 'perf_adv', 'dse', 'dse_warning',
            'dle', 'dle_warning',
            'RED', 'GREEN', 'BLUE')
@@ -102,6 +102,14 @@ def set_log_level(level, comm=None):
 def set_log_noperf():
     """Do not print performance-related messages."""
     logger.setLevel(WARNING)
+
+
+def is_log_enabled_for(level):
+    """
+    Wrapper around `logging.isEnabledFor`. Indicates if a message of severity
+    level would be processed by this logger.
+    """
+    return logger.isEnabledFor(logger_registry[level])
 
 
 def log(msg, level=INFO, *args, **kwargs):

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -9,7 +9,7 @@ import ctypes
 from devito.dle import transform
 from devito.equation import Eq
 from devito.exceptions import InvalidOperator
-from devito.logger import info, perf, warning
+from devito.logger import info, perf, warning, is_log_enabled_for
 from devito.ir.equations import LoweredEq
 from devito.ir.clusters import clusterize
 from devito.ir.iet import (Callable, MetaCall, iet_build, iet_insert_decls,
@@ -556,6 +556,10 @@ class Operator(Callable):
 
         summary = self._profiler.summary(args, self._dtype, reduce_over='apply')
 
+        if not is_log_enabled_for('PERF'):
+            # Do not waste time
+            return summary
+
         if summary.globals:
             indent = " "*2
 
@@ -600,7 +604,23 @@ class Operator(Callable):
                 perf("%s* %s%s computed in %.2f s"
                      % (indent, name, rank, fround(v.time)))
 
+        # Emit relevant configuration values
         perf("Configuration:  %s" % self._state['optimizations'])
+
+        # Emit relevant performance arguments
+        perf_args = {}
+        for i in self.input + self.dimensions:
+            if not i.is_PerfKnob:
+                continue
+            try:
+                perf_args[i.name] = args[i.name]
+            except KeyError:
+                # Try with the aliases
+                for a in i._arg_names:
+                    if a in args:
+                        perf_args[a] = args[a]
+                        break
+        perf("Performance arguments:  %s" % perf_args)
 
         return summary
 

--- a/devito/types/basic.py
+++ b/devito/types/basic.py
@@ -80,6 +80,9 @@ class Basic(object):
     is_Scalar = False
     is_Tensor = False
 
+    # Some other properties
+    is_PerfKnob = False  # Does it impact the Operator performance?
+
     @abc.abstractmethod
     def __init__(self, *args, **kwargs):
         return

--- a/tests/test_autotuner.py
+++ b/tests/test_autotuner.py
@@ -317,6 +317,7 @@ def test_hierarchical_blocking():
     assert len(op._state['autotuning'][1]['tuned']) == 4
 
 
+@switchconfig(platform='cpu64-dummy')  # To fix the core count
 def test_multiple_threads():
     """
     Test autotuning when different ``num_threads`` for a given OpenMP parallel
@@ -333,7 +334,7 @@ def test_multiple_threads():
     assert len(op._state['autotuning'][0]['tuned']) == 3
 
 
-@switchconfig(platform='knl7210')  # To systematically trigger nested parallelism
+@switchconfig(platform='knl7210')  # To trigger nested parallelism
 def test_nested_nthreads():
     grid = Grid(shape=(96, 96, 96))
     f = TimeFunction(name='f', grid=grid)

--- a/tests/test_autotuner.py
+++ b/tests/test_autotuner.py
@@ -160,7 +160,7 @@ def test_blocking_only():
     assert op._state['autotuning'][0]['runs'] == 6
     assert op._state['autotuning'][0]['tpr'] == options['squeezer'] + 1
     assert len(op._state['autotuning'][0]['tuned']) == 2
-    assert 'nthreads0' not in op._state['autotuning'][0]['tuned']
+    assert 'nthreads' not in op._state['autotuning'][0]['tuned']
 
 
 def test_mixed_blocking_nthreads():
@@ -173,7 +173,7 @@ def test_mixed_blocking_nthreads():
     assert op._state['autotuning'][0]['runs'] == 6
     assert op._state['autotuning'][0]['tpr'] == options['squeezer'] + 1
     assert len(op._state['autotuning'][0]['tuned']) == 3
-    assert 'nthreads0' in op._state['autotuning'][0]['tuned']
+    assert 'nthreads' in op._state['autotuning'][0]['tuned']
 
 
 def test_tti_aggressive():
@@ -196,7 +196,7 @@ def test_discarding_runs():
     assert op._state['autotuning'][0]['runs'] == 18
     assert op._state['autotuning'][0]['tpr'] == options['squeezer'] + 1
     assert len(op._state['autotuning'][0]['tuned']) == 3
-    assert op._state['autotuning'][0]['tuned']['nthreads0'] == 4
+    assert op._state['autotuning'][0]['tuned']['nthreads'] == 4
 
     # With 1 < 4 threads, the AT eventually tries many more combinations
     op.apply(time=100, nthreads=1, autotune='aggressive')
@@ -204,7 +204,7 @@ def test_discarding_runs():
     assert op._state['autotuning'][1]['runs'] == 25
     assert op._state['autotuning'][1]['tpr'] == options['squeezer'] + 1
     assert len(op._state['autotuning'][1]['tuned']) == 3
-    assert op._state['autotuning'][1]['tuned']['nthreads0'] == 1
+    assert op._state['autotuning'][1]['tuned']['nthreads'] == 1
 
 
 @skipif('nompi')
@@ -345,9 +345,9 @@ def test_nested_nthreads():
     assert op._state['autotuning'][0]['runs'] == 6
     assert op._state['autotuning'][0]['tpr'] == options['squeezer'] + 1
     assert len(op._state['autotuning'][0]['tuned']) == 3
-    assert 'nthreads0' in op._state['autotuning'][0]['tuned']
+    assert 'nthreads' in op._state['autotuning'][0]['tuned']
     # No tuning for the nested level
-    assert 'nthreads1' not in op._state['autotuning'][0]['tuned']
+    assert 'nthreads_nested' not in op._state['autotuning'][0]['tuned']
 
 
 def test_few_timesteps():


### PR DESCRIPTION
In master:
* the `nthreads0` variable is used for both "FD loops" and "sparse loops"
* the `nthreads1` variable is used for nested "FD loops" (applies to KNL only ATM)

with this PR:
* the `nthreads0` variable is used for "FD loops"
* the `nthreads1` variable is used for nested "FD loops" (applies to KNL only ATM)
* the `nthreads2` variable is used for "sparse loops"

performance-wise nothing changes unless one supplies different (non-default) values for `nthreads0` and `nthreads2` to `op.apply`

