### PR TITLE
Allow nbl to be zero in initialize_function

### DIFF
--- a/devito/builtins.py
+++ b/devito/builtins.py
@@ -277,7 +277,7 @@ def initialize_function(function, data, nbl, mapper=None, mode='constant',
         if isinstance(data, dv.Function):
             function.data[:] = data.data[:]
         else:
-            function.data[:] = data
+            function.data[:] = data[:]
         return
 
     if len(as_tuple(nbl)) == 1 and len(as_tuple(nbl)) < function.ndim:

--- a/devito/builtins.py
+++ b/devito/builtins.py
@@ -273,6 +273,13 @@ def initialize_function(function, data, nbl, mapper=None, mode='constant',
     if isinstance(function, dv.TimeFunction):
         raise NotImplementedError("TimeFunctions are not currently supported.")
 
+    if nbl == 0:
+        if isinstance(data, dv.Function):
+            function.data[:] = data.data[:]
+        else:
+            function.data[:] = data
+        return
+
     if len(as_tuple(nbl)) == 1 and len(as_tuple(nbl)) < function.ndim:
         nbl = function.ndim*(as_tuple(nbl)[0], )
     elif len(as_tuple(nbl)) == function.ndim:

--- a/examples/seismic/model.py
+++ b/examples/seismic/model.py
@@ -499,9 +499,10 @@ class GenericModel(object):
         self.grid = Grid(extent=extent, shape=shape_pml, origin=origin_pml, dtype=dtype,
                          subdomains=subdomains)
 
-        # Create dampening field as symbol `damp`
-        self.damp = Function(name="damp", grid=self.grid)
-        initialize_damp(self.damp, self.nbl, self.spacing, mask=damp_mask)
+        if self.nbl != 0:
+            # Create dampening field as symbol `damp`
+            self.damp = Function(name="damp", grid=self.grid)
+            initialize_damp(self.damp, self.nbl, self.spacing, mask=damp_mask)
 
     def physical_params(self, **kwargs):
         """

--- a/examples/seismic/model.py
+++ b/examples/seismic/model.py
@@ -503,6 +503,8 @@ class GenericModel(object):
             # Create dampening field as symbol `damp`
             self.damp = Function(name="damp", grid=self.grid)
             initialize_damp(self.damp, self.nbl, self.spacing, mask=damp_mask)
+        else:
+            self.damp = 1 if damp_mask else 0
 
     def physical_params(self, **kwargs):
         """

--- a/tests/test_builtins.py
+++ b/tests/test_builtins.py
@@ -190,6 +190,15 @@ class TestInitializeFunction(object):
         assert np.all(a[::-1, :] - np.array(f.data[0:4, 4:8]) == 0)
         assert np.all(a[::-1, :] - np.array(f.data[8:12, 4:8]) == 0)
 
+    def test_nbl_zero(self):
+        """Test for nbl = 0."""
+        a = np.arange(16).reshape((4, 4))
+        grid = Grid(shape=(4, 4))
+        f = Function(name='f', grid=grid, dtype=np.int32)
+        initialize_function(f, a, 0)
+
+        assert np.all(a[:] - np.array(f.data[:]) == 0)
+
     @skipif('nompi')
     @pytest.mark.parallel(mode=4)
     def test_if_parallel(self):


### PR DESCRIPTION
This small PR:
- Allows `nbl` to be zero when calling `initialize_function` hence allowing a `Model` be created with no damping region (as was previously the case).
- If a `Model` is created with no damping region a damping field is now not created.
- A test has been added for when `initialize_function` is called with `nbl=0`.