### PR TITLE
ops/node_factory: refactoring new_ops_gbl

### DIFF
--- a/devito/ops/node_factory.py
+++ b/devito/ops/node_factory.py
@@ -9,9 +9,9 @@ from devito.ops.utils import AccessibleInfo
 
 class OPSNodeFactory(object):
     """
-    Generate OPS nodes for building an OPS expression.
+    Generate OPS nodes for building OPS expressions.
     A new OPS argument is created based on the indexed name, and its time dimension.
-    Such a pair identifies an unique argument within the OPS kernel. The function
+    Such a pair identifies an unique argument within an OPS kernel. The function
     returns the stored argument associated with this pair, if it was already created.
     """
 
@@ -68,14 +68,25 @@ class OPSNodeFactory(object):
 
         return OpsAccess(symbol_to_access, space_indices)
 
-    def new_ops_gbl(self, c):
-        if c in self.ops_args:
-            return self.ops_args[c].accessible
+    def new_ops_gbl(self, expr):
+        """
+        Ensure Constant symbols are accessed as C pointers.
 
-        new_c = AccessibleInfo(Constant(name='*%s' % c.name, dtype=c.dtype),
-                               None,
-                               None)
-        self.ops_args[c] = new_c
-        self.ops_params.append(new_c.accessible)
+        Parameters
+        ----------
+        expr : Expression
+               Constant expression.
 
-        return new_c.accessible
+        Returns
+        -------
+        Constant
+            Constant symbol, as a pointer.
+        """
+        if expr not in self.ops_args:
+            self.ops_args[expr] = AccessibleInfo(Constant(name='*%s' % expr.name,
+                                                          dtype=expr.dtype),
+                                                 None,
+                                                 None)
+            self.ops_params.append(self.ops_args[expr].accessible)
+
+        return Constant(name='(*%s)' % expr.name, dtype=expr.dtype)

--- a/devito/ops/node_factory.py
+++ b/devito/ops/node_factory.py
@@ -3,7 +3,7 @@ from collections import defaultdict, OrderedDict
 from devito import Constant, TimeFunction
 from devito.types.dimension import SpaceDimension
 from devito.symbolics import split_affine
-from devito.ops.types import OpsAccess, OpsAccessible
+from devito.ops.types import OpsAccess, OpsAccessible, RawAccessToFloat
 from devito.ops.utils import AccessibleInfo
 
 
@@ -83,10 +83,9 @@ class OPSNodeFactory(object):
             Constant symbol, as a pointer.
         """
         if expr not in self.ops_args:
-            self.ops_args[expr] = AccessibleInfo(Constant(name='*%s' % expr.name,
-                                                          dtype=expr.dtype),
-                                                 None,
-                                                 None)
-            self.ops_params.append(self.ops_args[expr].accessible)
 
-        return Constant(name='(*%s)' % expr.name, dtype=expr.dtype)
+            param = RawAccessToFloat(name=expr.name, dtype=expr.dtype)
+            self.ops_args[expr] = AccessibleInfo(param, None, None)
+            self.ops_params.append(param)
+
+        return Constant(name='(*%s)' % expr.name)

--- a/devito/ops/transformer.py
+++ b/devito/ops/transformer.py
@@ -273,7 +273,7 @@ def create_ops_arg(p, accessible_origin, name_to_ops_dat, par_to_ops_stencil):
 
     if p.is_Constant:
         ops_type = namespace['ops_arg_gbl']
-        ops_name = Byref(Constant(name=p.name[1:]))
+        ops_name = Byref(Constant(name=p.name))
         rw_flag = namespace['ops_read']
     else:
         ops_type = namespace['ops_arg_dat']

--- a/devito/ops/types.py
+++ b/devito/ops/types.py
@@ -3,8 +3,10 @@ import sympy
 
 import devito.types.basic as basic
 
-from devito.tools import dtype_to_cstr
+from devito.tools import dtype_to_cstr, ctypes_to_cstr
 from devito.ops.utils import namespace
+
+from ctypes import POINTER, c_float
 
 
 class Array(basic.Array):
@@ -15,6 +17,26 @@ class Array(basic.Array):
             return self.dtype
 
         return super()._C_typedata
+
+
+class RawAccessToFloat(basic.Symbol):
+    is_Constant = True
+
+    def __init_finalize__(self, name, read_only=True, **kwargs):
+        self.name = name
+        self.read_only = read_only
+        super().__init_finalize__(name, **kwargs)
+
+    @property
+    def _C_name(self):
+        return self.name
+
+    @property
+    def _C_typename(self):
+        return '%s%s' % (
+            'const ' if self.read_only else '',
+            ctypes_to_cstr(POINTER(c_float))
+        )
 
 
 class OpsAccessible(basic.Symbol):

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -28,13 +28,13 @@ class TestOPSExpression(object):
         ('Eq(u,3*a - 4**a)', 'void OPS_Kernel_0(ACC<float> & ut0)\n'
          '{\n  ut0(0) = -2.97015324253729F;\n}'),
         ('Eq(u, u.dxl)',
-         'void OPS_Kernel_0(ACC<float> & ut0, const float *h_x)\n'
+         'void OPS_Kernel_0(ACC<float> & ut0, const float * h_x)\n'
          '{\n  float r0 = 1.0/(*h_x);\n  '
          'ut0(0) = (-2.0F*ut0(-1) + 5.0e-1F*ut0(-2) + 1.5F*ut0(0))*r0;\n}'),
         ('Eq(v,1)', 'void OPS_Kernel_0(ACC<float> & vt0)\n'
          '{\n  vt0(0, 0) = 1;\n}'),
         ('Eq(v,v.dxl + v.dxr - v.dyr - v.dyl)',
-         'void OPS_Kernel_0(ACC<float> & vt0, const float *h_x, const float *h_y)\n'
+         'void OPS_Kernel_0(ACC<float> & vt0, const float * h_x, const float * h_y)\n'
          '{\n  float r1 = 1.0/(*h_y);\n  float r0 = 1.0/(*h_x);\n  '
          'vt0(0, 0) = (5.0e-1F*(-vt0(2, 0) + vt0(-2, 0)) + 2.0F*(-vt0(-1, 0) + '
          'vt0(1, 0)))*r0 + (5.0e-1F*(-vt0(0, -2) + vt0(0, 2)) + '
@@ -53,7 +53,7 @@ class TestOPSExpression(object):
          '{\n  ut1(0) = 1 + ut0(0);\n}'),
         ('Eq(v.forward, v.dt - v.laplace + v.dt)',
          'void OPS_Kernel_0(const ACC<float> & vt0, ACC<float> & vt1, '
-         'const float *dt, const float *h_x, const float *h_y)\n'
+         'const float * dt, const float * h_x, const float * h_y)\n'
          '{\n  float r2 = 1.0/(*dt);\n'
          '  float r1 = 1.0/((*h_y)*(*h_y));\n'
          '  float r0 = 1.0/((*h_x)*(*h_x));\n'
@@ -207,7 +207,7 @@ class TestOPSExpression(object):
         )
 
     def test_create_ops_arg_constant(self):
-        a = Constant(name='*a')
+        a = Constant(name='a')
 
         ops_arg = create_ops_arg(a, {}, {}, {})
 

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -29,13 +29,13 @@ class TestOPSExpression(object):
          '{\n  ut0(0) = -2.97015324253729F;\n}'),
         ('Eq(u, u.dxl)',
          'void OPS_Kernel_0(ACC<float> & ut0, const float *h_x)\n'
-         '{\n  float r0 = 1.0/*h_x;\n  '
+         '{\n  float r0 = 1.0/(*h_x);\n  '
          'ut0(0) = (-2.0F*ut0(-1) + 5.0e-1F*ut0(-2) + 1.5F*ut0(0))*r0;\n}'),
         ('Eq(v,1)', 'void OPS_Kernel_0(ACC<float> & vt0)\n'
          '{\n  vt0(0, 0) = 1;\n}'),
         ('Eq(v,v.dxl + v.dxr - v.dyr - v.dyl)',
          'void OPS_Kernel_0(ACC<float> & vt0, const float *h_x, const float *h_y)\n'
-         '{\n  float r1 = 1.0/*h_y;\n  float r0 = 1.0/*h_x;\n  '
+         '{\n  float r1 = 1.0/(*h_y);\n  float r0 = 1.0/(*h_x);\n  '
          'vt0(0, 0) = (5.0e-1F*(-vt0(2, 0) + vt0(-2, 0)) + 2.0F*(-vt0(-1, 0) + '
          'vt0(1, 0)))*r0 + (5.0e-1F*(-vt0(0, -2) + vt0(0, 2)) + '
          '2.0F*(-vt0(0, 1) + vt0(0, -1)))*r1;\n}'),
@@ -54,9 +54,9 @@ class TestOPSExpression(object):
         ('Eq(v.forward, v.dt - v.laplace + v.dt)',
          'void OPS_Kernel_0(const ACC<float> & vt0, ACC<float> & vt1, '
          'const float *dt, const float *h_x, const float *h_y)\n'
-         '{\n  float r2 = 1.0/*dt;\n'
-         '  float r1 = 1.0/(*h_y**h_y);\n'
-         '  float r0 = 1.0/(*h_x**h_x);\n'
+         '{\n  float r2 = 1.0/(*dt);\n'
+         '  float r1 = 1.0/((*h_y)*(*h_y));\n'
+         '  float r0 = 1.0/((*h_x)*(*h_x));\n'
          '  vt1(0, 0) = (-(vt0(1, 0) + vt0(-1, 0)) + 2.0F*vt0(0, 0))*r0 + '
          '(-(vt0(0, 1) + vt0(0, -1)) + 2.0F*vt0(0, 0))*r1 + '
          '2*(-vt0(0, 0) + vt1(0, 0))*r2;\n}'),


### PR DESCRIPTION
This PR is an updated version of #991 .

From #991:
When translating to OPS a division by pointer (like /*dt) would make the
rest of the code commentary in c++. This was solved by encasing the 
pointer by parenthesis.

In this PR, requested changes are made upon updated master.