### PR TITLE
Sympy __neg__ fix

### DIFF
--- a/devito/finite_differences/differentiable.py
+++ b/devito/finite_differences/differentiable.py
@@ -200,19 +200,19 @@ class DifferentiableOp(Differentiable):
         return obj
 
 
-class Add(sympy.Add, DifferentiableOp):
+class Add(DifferentiableOp, sympy.Add):
     __new__ = DifferentiableOp.__new__
 
 
-class Mul(sympy.Mul, DifferentiableOp):
+class Mul(DifferentiableOp, sympy.Mul):
     __new__ = DifferentiableOp.__new__
 
 
-class Pow(sympy.Pow, DifferentiableOp):
+class Pow(DifferentiableOp, sympy.Pow):
     __new__ = DifferentiableOp.__new__
 
 
-class Mod(sympy.Mod, DifferentiableOp):
+class Mod(DifferentiableOp, sympy.Mod):
     __new__ = DifferentiableOp.__new__
 
 


### PR DESCRIPTION
Flip inheritance so that we don't end up with sympy types because of `__neg__`

`__neg__` is unary so cannot be forced via `op_priority` that is only for binary opertations 