### PR TITLE
Update `comm` and `nb` argument values from grid

### DIFF
--- a/devito/mpi/distributed.py
+++ b/devito/mpi/distributed.py
@@ -470,6 +470,7 @@ class MPICommObject(Object):
 
     def _arg_values(self, *args, **kwargs):
         grid = kwargs.get('grid', None)
+        # Update `comm` based on object attached to `grid`
         if grid is not None:
             return grid.distributor._obj_comm._arg_defaults()
         else:
@@ -523,6 +524,7 @@ class MPINeighborhood(CompositeObject):
 
     def _arg_values(self, *args, **kwargs):
         grid = kwargs.get('grid', None)
+        # Update `nb` based on object attached to `grid`
         if grid is not None:
             return grid.distributor._obj_neighborhood._arg_defaults()
         else:

--- a/devito/mpi/distributed.py
+++ b/devito/mpi/distributed.py
@@ -468,6 +468,13 @@ class MPICommObject(Object):
         comm_val = self.dtype.from_address(comm_ptr)
         self.value = comm_val
 
+    def _arg_values(self, *args, **kwargs):
+        grid = kwargs.get('grid', None)
+        if grid is not None:
+            return grid.distributor._obj_comm._arg_defaults()
+        else:
+            return self._arg_defaults()
+
     # Pickling support
     _pickle_args = []
 
@@ -513,6 +520,13 @@ class MPINeighborhood(CompositeObject):
         for name, i in zip(self.fields, self.entries):
             setattr(values[self.name]._obj, name, self.neighborhood[i])
         return values
+
+    def _arg_values(self, *args, **kwargs):
+        grid = kwargs.get('grid', None)
+        if grid is not None:
+            return grid.distributor._obj_neighborhood._arg_defaults()
+        else:
+            return self._arg_defaults()
 
     # Pickling support
     _pickle_args = ['neighborhood']

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -361,7 +361,7 @@ class Operator(Callable):
 
         # Process Objects (which may need some `args`)
         for o in self.objects:
-            args.update(o._arg_values(args=args, grid=grid, **kwargs))
+            args.update(o._arg_values(args, grid=grid, **kwargs))
 
         # Sanity check
         for p in self.parameters:

--- a/devito/operator.py
+++ b/devito/operator.py
@@ -361,7 +361,7 @@ class Operator(Callable):
 
         # Process Objects (which may need some `args`)
         for o in self.objects:
-            args.update(o._arg_values(args, **kwargs))
+            args.update(o._arg_values(args=args, grid=grid, **kwargs))
 
         # Sanity check
         for p in self.parameters:


### PR DESCRIPTION
This small PR fixes issue #998. Operator objects `comm` and `nb` now have their argument values correctly updated if a grid with a new distributor is 'passed' to the operator.

Note: Still need to add some comments in the code.