### PR TITLE
Replace _ops_kernels by _func_table in OPS    

### DIFF
--- a/devito/ops/operator.py
+++ b/devito/ops/operator.py
@@ -112,9 +112,10 @@ class OperatorOPS(Operator):
         return ''.join(str(kernel.root) for kernel in self._func_table.values())
 
     def _finalize(self, iet, parameters):
-
-        self._func_table.update({k: MetaCall(super(OperatorOPS, self)._finalize(v.root, derive_parameters(v.root, True)), v.local) # noqa
-            for k, v in self._func_table.items()})
+        for k, v in self._func_table.items():
+            parameters = derive_parameters(v.root, True)
+            root = super(OperatorOPS, self)._finalize(v.root, parameters)
+            self._func_table[k] = MetaCall(root, v.local)
 
         return super()._finalize(iet, parameters)
 

--- a/devito/ops/operator.py
+++ b/devito/ops/operator.py
@@ -112,10 +112,9 @@ class OperatorOPS(Operator):
         return ''.join(str(kernel.root) for kernel in self._func_table.values())
 
     def _finalize(self, iet, parameters):
-        # Applies _finalize for each generated OPS kernel, which will generate the .h file
-        self._ops_kernels = [super(OperatorOPS, self)._finalize(
-            kernel.root, derive_parameters(kernel, True))
-            for kernel in self._func_table.values()]
+
+        self._func_table.update({k: MetaCall(super(OperatorOPS, self)._finalize(v.root, derive_parameters(v.root, True)), v.local) # noqa
+            for k, v in self._func_table.items()})
 
         return super()._finalize(iet, parameters)
 

--- a/devito/ops/utils.py
+++ b/devito/ops/utils.py
@@ -50,3 +50,5 @@ namespace['ops_dat_base'] = lambda i: '%s_base' % i
 namespace['ops_dat_d_p'] = lambda i: '%s_d_p' % i
 namespace['ops_dat_d_m'] = lambda i: '%s_d_m' % i
 namespace['ops_dat_name'] = lambda i: '%s_dat' % i
+
+namespace['ops_kernel_file'] = lambda i: 'ops_kernel_%s' % i

--- a/tests/test_ops.py
+++ b/tests/test_ops.py
@@ -86,7 +86,8 @@ class TestOPSExpression(object):
 
         operator = Operator(eval(equation))
 
-        assert str(operator._ops_kernels[0]) == expected
+        for func in operator._func_table.values():
+            assert str(func.root) == expected
 
     @pytest.mark.parametrize('equation, expected', [
         ('Eq(u,3*a - 4**a)', '{ "ut0": [[0]] }'),


### PR DESCRIPTION
OPS was using a list to store all the kernels that will go into the .h file, but Devito already has one dictionary for this.

